### PR TITLE
feat: added option to get from grovedb without using cache

### DIFF
--- a/grovedb/Cargo.toml
+++ b/grovedb/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "grovedb"
 description = "Fully featured database using balanced hierarchical authenticated data structures"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Samuel Westrich <sam@dash.org>", "Wisdom Ogwu <wisdom@dash.org", "Evgeny Fomin <evgeny.fomin@dash.org>"]
 edition = "2021"
 license = "MIT"

--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -604,7 +604,7 @@ where
             if recursions_allowed == 1 {
                 let referenced_element_value_hash_opt = cost_return_on_error!(
                     &mut cost,
-                    merk.get_value_hash(key.as_ref())
+                    merk.get_value_hash(key.as_ref(), true)
                         .map_err(|e| Error::CorruptedData(e.to_string()))
                 );
 
@@ -634,7 +634,7 @@ where
                 // change in the batch.
                 let referenced_element = cost_return_on_error!(
                     &mut cost,
-                    merk.get(key.as_ref())
+                    merk.get(key.as_ref(), true)
                         .map_err(|e| Error::CorruptedData(e.to_string()))
                 );
 

--- a/grovedb/src/element/insert.rs
+++ b/grovedb/src/element/insert.rs
@@ -269,7 +269,7 @@ mod tests {
             .expect("expected successful insertion 2");
 
         assert_eq!(
-            Element::get(&merk, b"another-key")
+            Element::get(&merk, b"another-key", true)
                 .unwrap()
                 .expect("expected successful get"),
             Element::new_item(b"value".to_vec()),

--- a/grovedb/src/estimated_costs/average_case_costs.rs
+++ b/grovedb/src/estimated_costs/average_case_costs.rs
@@ -413,7 +413,7 @@ mod test {
         // 2. Left link exists
         // 3. Right link exists
         // Based on merk's avl rotation algorithm node is key 8 satisfies this
-        let node_result = merk.get(&8_u64.to_be_bytes());
+        let node_result = merk.get(&8_u64.to_be_bytes(), true);
 
         // By tweaking the max element size, we can adapt the average case function to
         // this scenario. make_batch_seq creates values that are 60 bytes in size

--- a/grovedb/src/estimated_costs/worst_case_costs.rs
+++ b/grovedb/src/estimated_costs/worst_case_costs.rs
@@ -369,7 +369,7 @@ mod test {
         // 2. Left link exists
         // 3. Right link exists
         // Based on merk's avl rotation algorithm node is key 8 satisfies this
-        let node_result = merk.get(&8_u64.to_be_bytes());
+        let node_result = merk.get(&8_u64.to_be_bytes(), true);
 
         // By tweaking the max element size, we can adapt the worst case function to
         // this scenario. make_batch_seq creates values that are 60 bytes in size

--- a/grovedb/src/lib.rs
+++ b/grovedb/src/lib.rs
@@ -498,7 +498,7 @@ impl GroveDb {
         key: K,
     ) -> CostResult<Element, Error> {
         subtree
-            .get(key.as_ref())
+            .get(key.as_ref(), true)
             .map_err(|_| {
                 Error::InvalidPath("can't find subtree in parent during propagation".to_owned())
             })
@@ -640,7 +640,7 @@ impl GroveDb {
             let element = raw_decode(&element_value).unwrap();
             if element.is_tree() {
                 let (kv_value, element_value_hash) = merk
-                    .get_value_and_value_hash(&key)
+                    .get_value_and_value_hash(&key, true)
                     .unwrap()
                     .unwrap()
                     .unwrap();

--- a/grovedb/src/operations/get/mod.rs
+++ b/grovedb/src/operations/get/mod.rs
@@ -151,7 +151,7 @@ impl GroveDb {
                 })
         );
 
-        Element::get(&merk_to_get_from, key).add_cost(cost)
+        Element::get(&merk_to_get_from, key, true).add_cost(cost)
     }
 
     /// Get tree item without following references
@@ -177,7 +177,7 @@ impl GroveDb {
                 })
         );
 
-        Element::get(&merk_to_get_from, key).add_cost(cost)
+        Element::get(&merk_to_get_from, key, true).add_cost(cost)
     }
 
     /// Does tree element exist without following references
@@ -224,14 +224,14 @@ impl GroveDb {
                 self.open_transactional_merk_at_path(parent_iter, transaction)
             );
 
-            Element::get(&merk_to_get_from, parent_key)
+            Element::get(&merk_to_get_from, parent_key, true)
         } else {
             let merk_to_get_from: Merk<PrefixedRocksDbStorageContext> = cost_return_on_error!(
                 &mut cost,
                 self.open_non_transactional_merk_at_path(parent_iter)
             );
 
-            Element::get(&merk_to_get_from, parent_key)
+            Element::get(&merk_to_get_from, parent_key, true)
         }
         .unwrap_add_cost(&mut cost);
         match element {

--- a/grovedb/src/operations/get/query.rs
+++ b/grovedb/src/operations/get/query.rs
@@ -295,7 +295,7 @@ where {
         result_type: QueryResultType,
         transaction: TransactionArg,
     ) -> CostResult<(QueryResultElements, u16), Error> {
-        Element::get_raw_path_query(&self.db, path_query, result_type, transaction)
+        Element::get_raw_path_query(&self.db, path_query, true, result_type, transaction)
     }
 
     /// If max_results is exceeded we return an error

--- a/grovedb/src/operations/insert/mod.rs
+++ b/grovedb/src/operations/insert/mod.rs
@@ -162,7 +162,7 @@ impl GroveDb {
             let maybe_element_bytes = cost_return_on_error!(
                 &mut cost,
                 subtree_to_insert_into
-                    .get(key)
+                    .get(key, true)
                     .map_err(|e| Error::CorruptedData(e.to_string()))
             );
             if let Some(element_bytes) = maybe_element_bytes {
@@ -206,7 +206,7 @@ impl GroveDb {
 
                 let referenced_element_value_hash_opt = cost_return_on_error!(
                     &mut cost,
-                    Element::get_value_hash(&subtree_for_reference, referenced_key)
+                    Element::get_value_hash(&subtree_for_reference, referenced_key, true)
                 );
 
                 let referenced_element_value_hash = cost_return_on_error!(
@@ -297,7 +297,7 @@ impl GroveDb {
             let maybe_element_bytes = cost_return_on_error!(
                 &mut cost,
                 subtree_to_insert_into
-                    .get(key)
+                    .get(key, true)
                     .map_err(|e| Error::CorruptedData(e.to_string()))
             );
             if let Some(element_bytes) = maybe_element_bytes {
@@ -339,9 +339,10 @@ impl GroveDb {
                     self.open_non_transactional_merk_at_path(referenced_path_iter)
                 );
 
+                // when there is no transaction, we don't want to use caching
                 let referenced_element_value_hash_opt = cost_return_on_error!(
                     &mut cost,
-                    Element::get_value_hash(&subtree_for_reference, referenced_key)
+                    Element::get_value_hash(&subtree_for_reference, referenced_key, false)
                 );
 
                 let referenced_element_value_hash = cost_return_on_error!(

--- a/grovedb/src/operations/proof/generate.rs
+++ b/grovedb/src/operations/proof/generate.rs
@@ -67,9 +67,12 @@ impl GroveDb {
                         break;
                     }
 
-                    let has_item =
-                        Element::get(subtree.as_ref().expect("confirmed not error above"), key)
-                            .unwrap_add_cost(&mut cost);
+                    let has_item = Element::get(
+                        subtree.as_ref().expect("confirmed not error above"),
+                        key,
+                        true,
+                    )
+                    .unwrap_add_cost(&mut cost);
 
                     let mut next_key_query = Query::new();
                     next_key_query.insert_key(key.to_vec());

--- a/grovedb/src/tests/mod.rs
+++ b/grovedb/src/tests/mod.rs
@@ -2312,7 +2312,7 @@ fn test_get_subtree() {
             Merk::open_layered_with_root_key(subtree_storage, Some(b"key3".to_vec()), false)
                 .unwrap()
                 .expect("cannot open merk");
-        let result_element = Element::get(&subtree, b"key3").unwrap().unwrap();
+        let result_element = Element::get(&subtree, b"key3", true).unwrap().unwrap();
         assert_eq!(result_element, Element::new_item(b"ayy".to_vec()));
     }
     // Insert a new tree with transaction
@@ -2347,7 +2347,7 @@ fn test_get_subtree() {
     let subtree = Merk::open_layered_with_root_key(subtree_storage, Some(b"key4".to_vec()), false)
         .unwrap()
         .expect("cannot open merk");
-    let result_element = Element::get(&subtree, b"key4").unwrap().unwrap();
+    let result_element = Element::get(&subtree, b"key4", true).unwrap().unwrap();
     assert_eq!(result_element, Element::new_item(b"ayy".to_vec()));
 
     // Should be able to retrieve instances created before transaction
@@ -2359,7 +2359,7 @@ fn test_get_subtree() {
     let subtree = Merk::open_layered_with_root_key(subtree_storage, Some(b"key3".to_vec()), false)
         .unwrap()
         .expect("cannot open merk");
-    let result_element = Element::get(&subtree, b"key3").unwrap().unwrap();
+    let result_element = Element::get(&subtree, b"key3", true).unwrap().unwrap();
     assert_eq!(result_element, Element::new_item(b"ayy".to_vec()));
 }
 

--- a/grovedb/src/tests/sum_tree_tests.rs
+++ b/grovedb/src/tests/sum_tree_tests.rs
@@ -221,25 +221,25 @@ fn test_homogenous_node_type_in_sum_trees_and_regular_trees() {
         .unwrap()
         .expect("should open tree");
     assert!(matches!(
-        merk.get_feature_type(b"item1")
+        merk.get_feature_type(b"item1", true)
             .unwrap()
             .expect("node should exist"),
         Some(SummedMerk(30))
     ));
     assert!(matches!(
-        merk.get_feature_type(b"item2")
+        merk.get_feature_type(b"item2", true)
             .unwrap()
             .expect("node should exist"),
         Some(SummedMerk(10))
     ));
     assert!(matches!(
-        merk.get_feature_type(b"item3")
+        merk.get_feature_type(b"item3", true)
             .unwrap()
             .expect("node should exist"),
         Some(SummedMerk(0))
     ));
     assert!(matches!(
-        merk.get_feature_type(b"item4")
+        merk.get_feature_type(b"item4", true)
             .unwrap()
             .expect("node should exist"),
         Some(SummedMerk(0))
@@ -275,13 +275,13 @@ fn test_homogenous_node_type_in_sum_trees_and_regular_trees() {
         .unwrap()
         .expect("should open tree");
     assert!(matches!(
-        merk.get_feature_type(b"item1")
+        merk.get_feature_type(b"item1", true)
             .unwrap()
             .expect("node should exist"),
         Some(BasicMerk)
     ));
     assert!(matches!(
-        merk.get_feature_type(b"item2")
+        merk.get_feature_type(b"item2", true)
             .unwrap()
             .expect("node should exist"),
         Some(BasicMerk)
@@ -507,7 +507,7 @@ fn test_sum_tree_propagation() {
         .expect("should open tree");
     assert!(matches!(
         test_leaf_merk
-            .get_feature_type(b"key")
+            .get_feature_type(b"key", true)
             .unwrap()
             .expect("node should exist"),
         Some(BasicMerk)
@@ -519,7 +519,7 @@ fn test_sum_tree_propagation() {
         .expect("should open tree");
     assert!(matches!(
         parent_sum_tree
-            .get_feature_type(b"tree2")
+            .get_feature_type(b"tree2", true)
             .unwrap()
             .expect("node should exist"),
         Some(SummedMerk(15)) /* 15 because the child sum tree has one sum item of
@@ -533,21 +533,21 @@ fn test_sum_tree_propagation() {
         .expect("should open tree");
     assert!(matches!(
         child_sum_tree
-            .get_feature_type(b"item1")
+            .get_feature_type(b"item1", true)
             .unwrap()
             .expect("node should exist"),
         Some(SummedMerk(0))
     ));
     assert!(matches!(
         child_sum_tree
-            .get_feature_type(b"sumitem1")
+            .get_feature_type(b"sumitem1", true)
             .unwrap()
             .expect("node should exist"),
         Some(SummedMerk(5))
     ));
     assert!(matches!(
         child_sum_tree
-            .get_feature_type(b"sumitem2")
+            .get_feature_type(b"sumitem2", true)
             .unwrap()
             .expect("node should exist"),
         Some(SummedMerk(10))
@@ -556,7 +556,7 @@ fn test_sum_tree_propagation() {
     // TODO: should references take the sum of the referenced element??
     assert!(matches!(
         child_sum_tree
-            .get_feature_type(b"item2")
+            .get_feature_type(b"item2", true)
             .unwrap()
             .expect("node should exist"),
         Some(SummedMerk(0))
@@ -595,14 +595,14 @@ fn test_sum_tree_with_batches() {
 
     assert!(matches!(
         sum_tree
-            .get_feature_type(b"a")
+            .get_feature_type(b"a", true)
             .unwrap()
             .expect("node should exist"),
         Some(SummedMerk(0))
     ));
     assert!(matches!(
         sum_tree
-            .get_feature_type(b"b")
+            .get_feature_type(b"b", true)
             .unwrap()
             .expect("node should exist"),
         Some(SummedMerk(10))
@@ -623,7 +623,7 @@ fn test_sum_tree_with_batches() {
         .expect("should open tree");
     assert!(matches!(
         sum_tree
-            .get_feature_type(b"c")
+            .get_feature_type(b"c", true)
             .unwrap()
             .expect("node should exist"),
         Some(SummedMerk(10))

--- a/grovedb/src/tests/tree_hashes_tests.rs
+++ b/grovedb/src/tests/tree_hashes_tests.rs
@@ -28,19 +28,19 @@ fn test_node_hashes_when_inserting_item() {
         .expect("should open merk");
 
     let (elem_value, elem_value_hash) = test_leaf_merk
-        .get_value_and_value_hash(b"key1")
+        .get_value_and_value_hash(b"key1", true)
         .unwrap()
         .expect("should get value hash")
         .expect("value hash should be some");
 
     let elem_kv_hash = test_leaf_merk
-        .get_kv_hash(b"key1")
+        .get_kv_hash(b"key1", true)
         .unwrap()
         .expect("should get value hash")
         .expect("value hash should be some");
 
     let elem_node_hash = test_leaf_merk
-        .get_hash(b"key1")
+        .get_hash(b"key1", true)
         .unwrap()
         .expect("should get value hash")
         .expect("value hash should be some");
@@ -73,19 +73,19 @@ fn test_tree_hashes_when_inserting_empty_tree() {
         .expect("should open merk");
 
     let (elem_value, elem_value_hash) = test_leaf_merk
-        .get_value_and_value_hash(b"key1")
+        .get_value_and_value_hash(b"key1", true)
         .unwrap()
         .expect("should get value hash")
         .expect("value hash should be some");
 
     let elem_kv_hash = test_leaf_merk
-        .get_kv_hash(b"key1")
+        .get_kv_hash(b"key1", true)
         .unwrap()
         .expect("should get value hash")
         .expect("value hash should be some");
 
     let elem_node_hash = test_leaf_merk
-        .get_hash(b"key1")
+        .get_hash(b"key1", true)
         .unwrap()
         .expect("should get value hash")
         .expect("value hash should be some");
@@ -143,7 +143,7 @@ fn test_tree_hashes_when_inserting_empty_trees_twice_under_each_other() {
     // Let's first verify that the lowest nodes hashes are as we expect
 
     let (elem_value, elem_value_hash) = middle_merk_key1
-        .get_value_and_value_hash(b"key2")
+        .get_value_and_value_hash(b"key2", true)
         .unwrap()
         .expect("should get value hash")
         .expect("value hash should be some");
@@ -163,7 +163,7 @@ fn test_tree_hashes_when_inserting_empty_trees_twice_under_each_other() {
     assert_eq!(elem_value_hash, combined_value_hash_key2);
 
     let elem_kv_hash = middle_merk_key1
-        .get_kv_hash(b"key2")
+        .get_kv_hash(b"key2", true)
         .unwrap()
         .expect("should get kv hash")
         .expect("value hash should be some");
@@ -173,7 +173,7 @@ fn test_tree_hashes_when_inserting_empty_trees_twice_under_each_other() {
     assert_eq!(elem_kv_hash, kv_hash_key2);
 
     let elem_node_hash = middle_merk_key1
-        .get_hash(b"key2")
+        .get_hash(b"key2", true)
         .unwrap()
         .expect("should get kv hash")
         .expect("value hash should be some");
@@ -191,7 +191,7 @@ fn test_tree_hashes_when_inserting_empty_trees_twice_under_each_other() {
     assert_eq!(root_hash, node_hash_key2);
 
     let (middle_elem_value_key1, middle_elem_value_hash_key1) = under_top_merk
-        .get_value_and_value_hash(b"key1")
+        .get_value_and_value_hash(b"key1", true)
         .unwrap()
         .expect("should get value hash")
         .expect("value hash should be some");
@@ -229,7 +229,7 @@ fn test_tree_hashes_when_inserting_empty_trees_twice_under_each_other() {
     );
 
     let middle_elem_kv_hash_key1 = under_top_merk
-        .get_kv_hash(b"key1")
+        .get_kv_hash(b"key1", true)
         .unwrap()
         .expect("should get value hash")
         .expect("value hash should be some");
@@ -243,7 +243,7 @@ fn test_tree_hashes_when_inserting_empty_trees_twice_under_each_other() {
     );
 
     let middle_elem_node_hash_key1 = under_top_merk
-        .get_hash(b"key1")
+        .get_hash(b"key1", true)
         .unwrap()
         .expect("should get value hash")
         .expect("value hash should be some");

--- a/merk/Cargo.toml
+++ b/merk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "merk"
 description = "Merkle key/value store adapted for GroveDB"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Samuel Westrich <sam@dash.org>", "Wisdom Ogwu <wisdom@dash.org", "Evgeny Fomin <evgeny.fomin@dash.org>", "Matt Bell <mappum@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/merk/src/merk/mod.rs
+++ b/merk/src/merk/mod.rs
@@ -1604,13 +1604,13 @@ mod test {
         let mut merk = TempMerk::new();
 
         // no root
-        assert!(merk.get(&[1, 2, 3]).unwrap().unwrap().is_none());
+        assert!(merk.get(&[1, 2, 3], true).unwrap().unwrap().is_none());
 
         // cached
         merk.apply::<_, Vec<_>>(&[(vec![5, 5, 5], Op::Put(vec![], BasicMerk))], &[], None)
             .unwrap()
             .unwrap();
-        assert!(merk.get(&[1, 2, 3]).unwrap().unwrap().is_none());
+        assert!(merk.get(&[1, 2, 3], true).unwrap().unwrap().is_none());
 
         // uncached
         merk.apply::<_, Vec<_>>(
@@ -1624,7 +1624,7 @@ mod test {
         )
         .unwrap()
         .unwrap();
-        assert!(merk.get(&[3, 3, 3]).unwrap().unwrap().is_none());
+        assert!(merk.get(&[3, 3, 3], true).unwrap().unwrap().is_none());
     }
 
     #[test]
@@ -1788,7 +1788,7 @@ mod test {
         .expect("should insert successfully");
 
         let result = merk
-            .get(b"10".as_slice())
+            .get(b"10".as_slice(), true)
             .unwrap()
             .expect("should get successfully");
         assert_eq!(result, Some(b"a".to_vec()));
@@ -1802,7 +1802,7 @@ mod test {
         .unwrap()
         .expect("should insert successfully");
         let result = merk
-            .get(b"10".as_slice())
+            .get(b"10".as_slice(), true)
             .unwrap()
             .expect("should get successfully");
         assert_eq!(result, Some(b"b".to_vec()));
@@ -1822,7 +1822,7 @@ mod test {
         .unwrap()
         .expect("should insert successfully");
         let result = merk
-            .get(b"10".as_slice())
+            .get(b"10".as_slice(), true)
             .unwrap()
             .expect("should get successfully");
         assert_eq!(result, Some(b"c".to_vec()));

--- a/merk/src/merk/mod.rs
+++ b/merk/src/merk/mod.rs
@@ -335,7 +335,6 @@ where
     /// Note that this is essentially the same as a normal RocksDB `get`, so
     /// should be a fast operation and has almost no tree overhead.
     pub fn exists(&self, key: &[u8]) -> CostResult<bool, Error> {
-
         self.has_node_direct(key)
     }
 
@@ -343,8 +342,8 @@ where
     ///
     /// Note that this is essentially the same as a normal RocksDB `get`, so
     /// should be a fast operation and has almost no tree overhead.
-    /// Contrary to a simple exists, this traverses the tree and can be faster if the tree is
-    /// cached, but slower if it is not
+    /// Contrary to a simple exists, this traverses the tree and can be faster
+    /// if the tree is cached, but slower if it is not
     pub fn exists_by_traversing_tree(&self, key: &[u8]) -> CostResult<bool, Error> {
         self.has_node(key)
     }
@@ -371,7 +370,11 @@ where
     }
 
     /// Returns the feature type for the node at the given key.
-    pub fn get_feature_type(&self, key: &[u8], allow_cache: bool) -> CostResult<Option<TreeFeatureType>, Error> {
+    pub fn get_feature_type(
+        &self,
+        key: &[u8],
+        allow_cache: bool,
+    ) -> CostResult<Option<TreeFeatureType>, Error> {
         if allow_cache {
             self.get_node_fn(key, |node| {
                 node.feature_type().wrap_with_cost(Default::default())
@@ -395,7 +398,11 @@ where
 
     /// Gets the value hash of a node by a given key, `None` is returned in case
     /// when node not found by the key.
-    pub fn get_value_hash(&self, key: &[u8], allow_cache: bool) -> CostResult<Option<CryptoHash>, Error> {
+    pub fn get_value_hash(
+        &self,
+        key: &[u8],
+        allow_cache: bool,
+    ) -> CostResult<Option<CryptoHash>, Error> {
         if allow_cache {
             self.get_node_fn(key, |node| {
                 (*node.value_hash()).wrap_with_cost(OperationCost::default())
@@ -409,7 +416,11 @@ where
 
     /// Gets a hash of a node by a given key, `None` is returned in case
     /// when node not found by the key.
-    pub fn get_kv_hash(&self, key: &[u8], allow_cache: bool) -> CostResult<Option<CryptoHash>, Error> {
+    pub fn get_kv_hash(
+        &self,
+        key: &[u8],
+        allow_cache: bool,
+    ) -> CostResult<Option<CryptoHash>, Error> {
         if allow_cache {
             self.get_node_fn(key, |node| {
                 (*node.inner.kv.hash()).wrap_with_cost(OperationCost::default())
@@ -479,14 +490,13 @@ where
 
     /// Generic way to get a node's field
     fn get_node_direct_fn<T, F>(&self, key: &[u8], f: F) -> CostResult<Option<T>, Error>
-        where
-            F: FnOnce(&Tree) -> CostContext<T>,
+    where
+        F: FnOnce(&Tree) -> CostContext<T>,
     {
         Tree::get(&self.storage, key).flat_map_ok(|maybe_node| {
-                            let mut cost = OperationCost::default();
-                            Ok(maybe_node.map(|node| f(&node).unwrap_add_cost(&mut cost)))
-                                .wrap_with_cost(cost)
-                        })
+            let mut cost = OperationCost::default();
+            Ok(maybe_node.map(|node| f(&node).unwrap_add_cost(&mut cost))).wrap_with_cost(cost)
+        })
     }
 
     /// Generic way to get a node's field

--- a/merk/src/test_utils/crash_merk.rs
+++ b/merk/src/test_utils/crash_merk.rs
@@ -82,6 +82,9 @@ mod tests {
 
         merk.crash();
 
-        assert_eq!(merk.get(&[1, 2, 3]).unwrap().expect("failed to get"), None);
+        assert_eq!(
+            merk.get(&[1, 2, 3], true).unwrap().expect("failed to get"),
+            None
+        );
     }
 }

--- a/node-grove/Cargo.toml
+++ b/node-grove/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "node-grove"
-version = "0.9.0"
+version = "0.9.1"
 description = "GroveDB node.js bindings"
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
There was a small issue inconsistency issue in rs-drive where we were not getting the same cost value for getting a contract, and I realized this was due to caching. Since we always need that value to be deterministic even outside of transactions it made sense to offer a way to get directly without cache.


## What was done?
<!--- Describe your changes in detail -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
