### PR TITLE
fix: limit zero proof bug

### DIFF
--- a/grovedb/src/tests/query_tests.rs
+++ b/grovedb/src/tests/query_tests.rs
@@ -36,7 +36,9 @@ use crate::{
     batch::GroveDbOp,
     query_result_type::QueryResultType,
     reference_path::ReferencePathType,
-    tests::{common::compare_result_sets, make_test_grovedb, TempGroveDb, TEST_LEAF},
+    tests::{
+        common::compare_result_sets, make_deep_tree, make_test_grovedb, TempGroveDb, TEST_LEAF,
+    },
     Element, GroveDb, PathQuery, SizedQuery,
 };
 
@@ -1901,4 +1903,20 @@ fn test_mixed_level_proofs_with_subquery_paths() {
     let (hash, result_set) = GroveDb::verify_query(&proof, &path_query).unwrap();
     assert_eq!(hash, db.root_hash(None).unwrap().unwrap());
     assert_eq!(result_set.len(), 8);
+}
+
+#[test]
+fn tests_proof_with_limit_zero() {
+    let db = make_deep_tree();
+    let mut query = Query::new();
+    query.insert_all();
+    let path_query = PathQuery::new(
+        vec![TEST_LEAF.to_vec()],
+        SizedQuery::new(query, Some(0), Some(0)),
+    );
+
+    let proof = db.prove_query(&path_query).unwrap().unwrap();
+    let (hash, result_set) = GroveDb::verify_query(&proof, &path_query).unwrap();
+    assert_eq!(hash, db.root_hash(None).unwrap().unwrap());
+    assert_eq!(result_set.len(), 0);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Prior to this pr, generating proofs with a limit of zero failed during verification. 
This was because proof construction didn't generate a root hash proof for the subtree at the given path when the limit is zero.


## What was done?
<!--- Describe your changes in detail -->
Generate root hash proof for subtree at the given path when the limit is 0.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
