### PR TITLE
feat: add debug to QueryResultElement struct

### DIFF
--- a/grovedb/src/query_result_type.rs
+++ b/grovedb/src/query_result_type.rs
@@ -49,6 +49,7 @@ pub enum QueryResultType {
 }
 
 /// Query result elements
+#[derive(Debug)]
 pub struct QueryResultElements {
     /// Elements
     pub elements: Vec<QueryResultElement>,
@@ -180,6 +181,7 @@ impl Default for QueryResultElements {
 }
 
 /// Query result element
+#[derive(Debug)]
 pub enum QueryResultElement {
     /// Element result item
     ElementResultItem(Element),


### PR DESCRIPTION
Requested feature to print element returned from a query for the Grovedb tutorial.