### PR TITLE
feat: partial batches

### DIFF
--- a/grovedb/src/batch/just_in_time_cost_tests.rs
+++ b/grovedb/src/batch/just_in_time_cost_tests.rs
@@ -1,0 +1,259 @@
+// MIT LICENSE
+//
+// Copyright (c) 2023 Dash Core Group
+//
+// Permission is hereby granted, free of charge, to any
+// person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the
+// Software without restriction, including without
+// limitation the rights to use, copy, modify, merge,
+// publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software
+// is furnished to do so, subject to the following
+// conditions:
+//
+// The above copyright notice and this permission notice
+// shall be included in all copies or substantial portions
+// of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+// ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+// TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+// PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+// SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+// IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+//! This tests just in time costs
+//! Just in time costs modify the tree in the same batch
+
+#[cfg(feature = "full")]
+mod tests {
+    use std::{ops::Add, option::Option::None};
+
+    use costs::{
+        storage_cost::{removal::StorageRemovedBytes::NoStorageRemoval, StorageCost},
+        OperationCost,
+    };
+
+    use crate::{
+        batch::GroveDbOp,
+        reference_path::ReferencePathType::{SiblingReference, UpstreamFromElementHeightReference},
+        tests::make_empty_grovedb,
+        Element,
+    };
+
+    #[test]
+    fn test_partial_costs_with_no_new_operations_are_same_as_apply_batch() {
+        let db = make_empty_grovedb();
+        let tx = db.start_transaction();
+
+        db.insert(vec![], b"documents", Element::empty_tree(), None, None)
+            .cost_as_result()
+            .expect("expected to insert successfully");
+        db.insert(vec![], b"balances", Element::empty_tree(), None, None)
+            .cost_as_result()
+            .expect("expected to insert successfully");
+        let ops = vec![
+            GroveDbOp::insert_op(
+                vec![b"documents".to_vec()],
+                b"key2".to_vec(),
+                Element::new_item_with_flags(b"pizza".to_vec(), Some([0, 1].to_vec())),
+            ),
+            GroveDbOp::insert_op(
+                vec![b"documents".to_vec()],
+                b"key3".to_vec(),
+                Element::empty_tree(),
+            ),
+            GroveDbOp::insert_op(
+                vec![b"documents".to_vec(), b"key3".to_vec()],
+                b"key4".to_vec(),
+                Element::new_reference(UpstreamFromElementHeightReference(
+                    1,
+                    vec![b"key2".to_vec()],
+                )),
+            ),
+        ];
+
+        let full_cost = db
+            .apply_batch(ops.clone(), None, Some(&tx))
+            .cost_as_result()
+            .expect("expected to apply batch");
+
+        let apply_root_hash = db
+            .root_hash(Some(&tx))
+            .unwrap()
+            .expect("expected to get root hash");
+
+        db.get([b"documents".as_slice()], b"key2", Some(&tx))
+            .unwrap()
+            .expect("cannot get element");
+
+        db.get([b"documents".as_slice()], b"key3", Some(&tx))
+            .unwrap()
+            .expect("cannot get element");
+
+        db.get(
+            [b"documents".as_slice(), b"key3".as_slice()],
+            b"key4",
+            Some(&tx),
+        )
+        .unwrap()
+        .expect("cannot get element");
+
+        tx.rollback().expect("expected to rollback");
+
+        let cost = db
+            .apply_partial_batch(ops, None, |cost, left_over_ops| Ok(vec![]), Some(&tx))
+            .cost_as_result()
+            .expect("expected to apply batch");
+
+        let apply_partial_root_hash = db
+            .root_hash(Some(&tx))
+            .unwrap()
+            .expect("expected to get root hash");
+
+        db.get([b"documents".as_slice()], b"key2", Some(&tx))
+            .unwrap()
+            .expect("cannot get element");
+
+        db.get([b"documents".as_slice()], b"key3", Some(&tx))
+            .unwrap()
+            .expect("cannot get element");
+
+        db.get(
+            [b"documents".as_slice(), b"key3".as_slice()],
+            b"key4",
+            Some(&tx),
+        )
+        .unwrap()
+        .expect("cannot get element");
+
+        assert_eq!(full_cost, cost);
+
+        assert_eq!(apply_root_hash, apply_partial_root_hash);
+    }
+
+    #[test]
+    fn test_partial_costs_with_add_balance_operations() {
+        let db = make_empty_grovedb();
+        let tx = db.start_transaction();
+
+        db.insert(vec![], b"documents", Element::empty_tree(), None, None)
+            .cost_as_result()
+            .expect("expected to insert successfully");
+        db.insert(vec![], b"balances", Element::empty_sum_tree(), None, None)
+            .cost_as_result()
+            .expect("expected to insert successfully");
+        let ops = vec![
+            GroveDbOp::insert_op(
+                vec![b"documents".to_vec()],
+                b"key2".to_vec(),
+                Element::new_item_with_flags(b"pizza".to_vec(), Some([0, 1].to_vec())),
+            ),
+            GroveDbOp::insert_op(
+                vec![b"documents".to_vec()],
+                b"key3".to_vec(),
+                Element::empty_tree(),
+            ),
+            GroveDbOp::insert_op(
+                vec![b"documents".to_vec(), b"key3".to_vec()],
+                b"key4".to_vec(),
+                Element::new_reference(UpstreamFromElementHeightReference(
+                    1,
+                    vec![b"key2".to_vec()],
+                )),
+            ),
+        ];
+
+        let full_cost = db
+            .apply_batch(ops.clone(), None, Some(&tx))
+            .cost_as_result()
+            .expect("expected to apply batch");
+
+        let apply_root_hash = db
+            .root_hash(Some(&tx))
+            .unwrap()
+            .expect("expected to get root hash");
+
+        db.get([b"documents".as_slice()], b"key2", Some(&tx))
+            .unwrap()
+            .expect("cannot get element");
+
+        db.get([b"documents".as_slice()], b"key3", Some(&tx))
+            .unwrap()
+            .expect("cannot get element");
+
+        db.get(
+            [b"documents".as_slice(), b"key3".as_slice()],
+            b"key4",
+            Some(&tx),
+        )
+        .unwrap()
+        .expect("cannot get element");
+
+        tx.rollback().expect("expected to rollback");
+
+        let cost = db
+            .apply_partial_batch(
+                ops,
+                None,
+                |cost, left_over_ops| {
+                    assert!(left_over_ops.is_some());
+                    assert_eq!(left_over_ops.as_ref().unwrap().len(), 1);
+                    let ops_by_root_path = left_over_ops
+                        .as_ref()
+                        .unwrap()
+                        .get(&0)
+                        .expect("expected to have root path");
+                    assert_eq!(ops_by_root_path.len(), 1);
+                    let new_ops = vec![GroveDbOp::insert_op(
+                        vec![b"balances".to_vec()],
+                        b"person".to_vec(),
+                        Element::new_sum_item_with_flags(1000, Some([0, 1].to_vec())),
+                    )];
+                    Ok(new_ops)
+                },
+                Some(&tx),
+            )
+            .cost_as_result()
+            .expect("expected to apply batch");
+
+        let apply_partial_root_hash = db
+            .root_hash(Some(&tx))
+            .unwrap()
+            .expect("expected to get root hash");
+
+        db.get([b"documents".as_slice()], b"key2", Some(&tx))
+            .unwrap()
+            .expect("cannot get element");
+
+        db.get([b"documents".as_slice()], b"key3", Some(&tx))
+            .unwrap()
+            .expect("cannot get element");
+
+        db.get(
+            [b"documents".as_slice(), b"key3".as_slice()],
+            b"key4",
+            Some(&tx),
+        )
+        .unwrap()
+        .expect("cannot get element");
+
+        let balance = db
+            .get([b"balances".as_slice()], b"person", Some(&tx))
+            .unwrap()
+            .expect("cannot get element");
+
+        assert_eq!(
+            balance.as_sum_item_value().expect("expected sum item"),
+            1000
+        );
+
+        assert!(full_cost.storage_cost.added_bytes < cost.storage_cost.added_bytes);
+
+        assert_ne!(apply_root_hash, apply_partial_root_hash);
+    }
+}

--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -74,6 +74,7 @@ use integer_encoding::VarInt;
 use itertools::Itertools;
 use key_info::{KeyInfo, KeyInfo::KnownKey};
 use merk::{
+    proofs::query::Map,
     tree::{
         kv::ValueDefinedCostType::{LayeredValueDefinedCost, SpecializedValueDefinedCost},
         value_hash, NULL_HASH,
@@ -1168,10 +1169,12 @@ where
 
 impl GroveDb {
     /// Method to propagate updated subtree root hashes up to GroveDB root
+    /// If the stop level is set in the apply options the remaining operations
+    /// are returned
     fn apply_batch_structure<C: TreeCache<F, SR>, F, SR>(
         batch_structure: BatchStructure<C, F, SR>,
         batch_apply_options: Option<BatchApplyOptions>,
-    ) -> CostResult<(), Error>
+    ) -> CostResult<Option<BTreeMap<KeyInfoPath, BTreeMap<KeyInfo, Op>>>, Error>
     where
         F: FnMut(&StorageCost, Option<ElementFlags>, &mut ElementFlags) -> Result<bool, Error>,
         SR: FnMut(
@@ -1192,6 +1195,7 @@ impl GroveDb {
         let mut current_level = last_level;
 
         let batch_apply_options = batch_apply_options.unwrap_or_default();
+        let stop_level = batch_apply_options.batch_pause_height.unwrap_or_default() as u32;
 
         // We will update up the tree
         while let Some(ops_at_level) = ops_by_level_paths.remove(&current_level) {
@@ -1347,14 +1351,23 @@ impl GroveDb {
                     }
                 }
             }
+            if current_level == stop_level {
+                if current_level > 0 {
+                    current_level -= 1;
+                }
+                // we need to pause the batch execution
+                return Ok(ops_by_level_paths.remove(&current_level)).wrap_with_cost(cost);
+            }
             if current_level > 0 {
                 current_level -= 1;
             }
         }
-        Ok(()).wrap_with_cost(cost)
+        Ok(None).wrap_with_cost(cost)
     }
 
     /// Method to propagate updated subtree root hashes up to GroveDB root
+    /// If the pause height is set in the batch apply options
+    /// Then return the list of leftover operations
     fn apply_body<'db, S: StorageContext<'db>>(
         &self,
         ops: Vec<GroveDbOp>,
@@ -1373,7 +1386,7 @@ impl GroveDb {
             Error,
         >,
         get_merk_fn: impl FnMut(&[Vec<u8>], bool) -> CostResult<Merk<S>, Error>,
-    ) -> CostResult<(), Error> {
+    ) -> CostResult<Option<BTreeMap<KeyInfoPath, BTreeMap<KeyInfo, Op>>>, Error> {
         let mut cost = OperationCost::default();
         let batch_structure = cost_return_on_error!(
             &mut cost,
@@ -1651,11 +1664,10 @@ impl GroveDb {
             );
 
             // TODO: compute batch costs
-            cost_return_on_error_no_add!(
-                &cost,
+            cost_return_on_error!(
+                &mut cost,
                 self.db
                     .commit_multi_context_batch(storage_batch, Some(tx))
-                    .unwrap_add_cost(&mut cost)
                     .map_err(|e| e.into())
             );
         } else {
@@ -1673,11 +1685,147 @@ impl GroveDb {
             );
 
             // TODO: compute batch costs
-            cost_return_on_error_no_add!(
-                &cost,
+            cost_return_on_error!(
+                &mut cost,
                 self.db
                     .commit_multi_context_batch(storage_batch, None)
-                    .unwrap_add_cost(&mut cost)
+                    .map_err(|e| e.into())
+            );
+        }
+        Ok(()).wrap_with_cost(cost)
+    }
+
+    /// Applies a partial batch of operations on GroveDB
+    /// The batch is not committed
+    /// Clients should set the Batch Apply Options batch pause height
+    /// If it is not set we default to pausing at the root tree
+    pub fn apply_partial_batch_with_element_flags_update(
+        &self,
+        ops: Vec<GroveDbOp>,
+        batch_apply_options: Option<BatchApplyOptions>,
+        update_element_flags_function: impl FnMut(
+            &StorageCost,
+            Option<ElementFlags>,
+            &mut ElementFlags,
+        ) -> Result<bool, Error>,
+        split_removal_bytes_function: impl FnMut(
+            &mut ElementFlags,
+            u32, // key removed bytes
+            u32, // value removed bytes
+        ) -> Result<
+            (StorageRemovedBytes, StorageRemovedBytes),
+            Error,
+        >,
+        transaction: TransactionArg,
+    ) -> CostResult<(), Error> {
+        let mut cost = OperationCost::default();
+
+        if ops.is_empty() {
+            return Ok(()).wrap_with_cost(cost);
+        }
+
+        let mut batch_apply_options = batch_apply_options.unwrap_or_default();
+        if batch_apply_options.batch_pause_height.is_none() {
+            // we default to pausing at the root tree, which is the most common case
+            batch_apply_options.batch_pause_height = Some(1);
+        }
+
+        // Determines whether to check batch operation consistency
+        // return false if the disable option is set to true, returns true for any other
+        // case
+        let check_batch_operation_consistency =
+            !batch_apply_options.disable_operation_consistency_check;
+
+        if check_batch_operation_consistency {
+            let consistency_result = GroveDbOp::verify_consistency_of_operations(&ops);
+            if !consistency_result.is_empty() {
+                return Err(Error::InvalidBatchOperation(
+                    "batch operations fail consistency checks",
+                ))
+                .wrap_with_cost(cost);
+            }
+        }
+
+        // `StorageBatch` allows us to collect operations on different subtrees before
+        // execution
+        let storage_batch = StorageBatch::new();
+
+        // With the only one difference (if there is a transaction) do the following:
+        // 2. If nothing left to do and we were on a non-leaf subtree or we're done with
+        //    one subtree and moved to another then add propagation operation to the
+        //    operations tree and drop Merk handle;
+        // 3. Take Merk from temp subtrees or open a new one with batched storage_cost
+        //    context;
+        // 4. Apply operation to the Merk;
+        // 5. Remove operation from the tree, repeat until there are operations to do;
+        // 6. Add root leaves save operation to the batch
+        // 7. Apply storage_cost batch
+        if let Some(tx) = transaction {
+            let left_over_operations = cost_return_on_error!(
+                &mut cost,
+                self.apply_body(
+                    ops,
+                    Some(batch_apply_options),
+                    update_element_flags_function,
+                    split_removal_bytes_function,
+                    |path, new_merk| {
+                        self.open_batch_transactional_merk_at_path(
+                            &storage_batch,
+                            path.iter().map(|x| x.as_slice()),
+                            tx,
+                            new_merk,
+                        )
+                    }
+                )
+            );
+            // if we paused at the root height, the left over operations would be to replace
+            // a lot of leaf nodes in the root tree
+
+            // let's build the write batch
+            let (mut write_batch, pending_costs) = cost_return_on_error!(
+                &mut cost,
+                self.db
+                    .build_write_batch(storage_batch)
+                    .map_err(|e| e.into())
+            );
+
+            // TODO: compute batch costs
+            cost_return_on_error!(
+                &mut cost,
+                self.db
+                    .commit_db_write_batch(write_batch, pending_costs, Some(tx))
+                    .map_err(|e| e.into())
+            );
+        } else {
+            let left_over_operations = cost_return_on_error!(
+                &mut cost,
+                self.apply_body(
+                    ops,
+                    Some(batch_apply_options),
+                    update_element_flags_function,
+                    split_removal_bytes_function,
+                    |path, new_merk| {
+                        self.open_batch_merk_at_path(&storage_batch, path, new_merk)
+                    }
+                )
+            );
+
+            // if we paused at the root height, the left over operations would be to replace
+            // a lot of leaf nodes in the root tree
+
+            // let's build the write batch
+            let (mut write_batch, pending_costs) = cost_return_on_error!(
+                &mut cost,
+                self.db
+                    .build_write_batch(storage_batch)
+                    .map_err(|e| e.into())
+            );
+
+            // TODO: compute batch costs
+            cost_return_on_error!(
+                &mut cost,
+                self.db
+                    .commit_db_write_batch(write_batch, pending_costs, None)
                     .map_err(|e| e.into())
             );
         }
@@ -1900,6 +2048,7 @@ mod tests {
                     deleting_non_empty_trees_returns_error: true,
                     disable_operation_consistency_check: true,
                     base_root_storage_is_free: true,
+                    batch_pause_height: None,
                 }),
                 None
             )
@@ -2617,6 +2766,7 @@ mod tests {
                     deleting_non_empty_trees_returns_error: true,
                     disable_operation_consistency_check: false,
                     base_root_storage_is_free: true,
+                    batch_pause_height: None,
                 }),
                 None
             )
@@ -2655,6 +2805,7 @@ mod tests {
                     validate_insertion_does_not_override: true,
                     deleting_non_empty_trees_returns_error: true,
                     base_root_storage_is_free: true,
+                    batch_pause_height: None,
                 }),
                 None
             )
@@ -2687,6 +2838,7 @@ mod tests {
                     deleting_non_empty_trees_returns_error: true,
                     disable_operation_consistency_check: false,
                     base_root_storage_is_free: true,
+                    batch_pause_height: None,
                 }),
                 None
             )

--- a/grovedb/src/batch/options.rs
+++ b/grovedb/src/batch/options.rs
@@ -50,6 +50,9 @@ pub struct BatchApplyOptions {
     pub disable_operation_consistency_check: bool,
     /// Base root storage is free
     pub base_root_storage_is_free: bool,
+    /// At what height do we want to pause applying batch operations
+    /// Most of the time this should be not set
+    pub batch_pause_height: Option<u8>,
 }
 
 #[cfg(feature = "full")]
@@ -62,6 +65,7 @@ impl Default for BatchApplyOptions {
             deleting_non_empty_trees_returns_error: true,
             disable_operation_consistency_check: false,
             base_root_storage_is_free: true,
+            batch_pause_height: None,
         }
     }
 }

--- a/storage/src/rocksdb_storage.rs
+++ b/storage/src/rocksdb_storage.rs
@@ -33,7 +33,7 @@ pub mod test_utils;
 #[cfg(test)]
 mod tests;
 
-pub use rocksdb::Error;
+pub use rocksdb::{Error, WriteBatchWithTransaction};
 pub use storage_context::{
     PrefixedRocksDbBatch, PrefixedRocksDbBatchStorageContext,
     PrefixedRocksDbBatchTransactionContext, PrefixedRocksDbRawIterator,

--- a/storage/src/rocksdb_storage/storage.rs
+++ b/storage/src/rocksdb_storage/storage.rs
@@ -31,8 +31,9 @@
 use std::{ops::AddAssign, path::Path};
 
 use costs::{
-    cost_return_on_error_no_add, storage_cost::removal::StorageRemovedBytes::BasicStorageRemoval,
-    CostContext, CostResult, CostsExt, OperationCost,
+    cost_return_on_error, cost_return_on_error_no_add,
+    storage_cost::removal::StorageRemovedBytes::BasicStorageRemoval, CostContext, CostResult,
+    CostsExt, OperationCost,
 };
 use error::Error;
 use integer_encoding::VarInt;
@@ -153,85 +154,14 @@ impl RocksDbStorage {
                 .wrap_with_cost(OperationCost::with_hash_node_calls(blocks_count as u16))
         }
     }
-}
 
-impl<'db> Storage<'db> for RocksDbStorage {
-    type BatchStorageContext = PrefixedRocksDbBatchStorageContext<'db>;
-    type BatchTransactionalStorageContext = PrefixedRocksDbBatchTransactionContext<'db>;
-    type StorageContext = PrefixedRocksDbStorageContext<'db>;
-    type Transaction = Tx<'db>;
-    type TransactionalStorageContext = PrefixedRocksDbTransactionContext<'db>;
-
-    fn start_transaction(&'db self) -> Self::Transaction {
-        self.db.transaction()
-    }
-
-    fn commit_transaction(&self, transaction: Self::Transaction) -> CostResult<(), Error> {
-        // All transaction costs were provided on method calls
-        transaction
-            .commit()
-            .map_err(RocksDBError)
-            .wrap_with_cost(Default::default())
-    }
-
-    fn rollback_transaction(&self, transaction: &Self::Transaction) -> Result<(), Error> {
-        transaction.rollback().map_err(RocksDBError)
-    }
-
-    fn flush(&self) -> Result<(), Error> {
-        self.db.flush().map_err(RocksDBError)
-    }
-
-    fn get_storage_context<'p, P>(&'db self, path: P) -> CostContext<Self::StorageContext>
-    where
-        P: IntoIterator<Item = &'p [u8]>,
-    {
-        Self::build_prefix(path).map(|prefix| PrefixedRocksDbStorageContext::new(&self.db, prefix))
-    }
-
-    fn get_transactional_storage_context<'p, P>(
-        &'db self,
-        path: P,
-        transaction: &'db Self::Transaction,
-    ) -> CostContext<Self::TransactionalStorageContext>
-    where
-        P: IntoIterator<Item = &'p [u8]>,
-    {
-        Self::build_prefix(path)
-            .map(|prefix| PrefixedRocksDbTransactionContext::new(&self.db, transaction, prefix))
-    }
-
-    fn get_batch_storage_context<'p, P>(
-        &'db self,
-        path: P,
-        batch: &'db StorageBatch,
-    ) -> CostContext<Self::BatchStorageContext>
-    where
-        P: IntoIterator<Item = &'p [u8]>,
-    {
-        Self::build_prefix(path)
-            .map(|prefix| PrefixedRocksDbBatchStorageContext::new(&self.db, prefix, batch))
-    }
-
-    fn get_batch_transactional_storage_context<'p, P>(
-        &'db self,
-        path: P,
-        batch: &'db StorageBatch,
-        transaction: &'db Self::Transaction,
-    ) -> CostContext<Self::BatchTransactionalStorageContext>
-    where
-        P: IntoIterator<Item = &'p [u8]>,
-    {
-        Self::build_prefix(path).map(|prefix| {
-            PrefixedRocksDbBatchTransactionContext::new(&self.db, transaction, prefix, batch)
-        })
-    }
-
-    fn commit_multi_context_batch(
+    /// Returns the write batch, with costs and pending costs
+    /// Pending costs are costs that should only be applied after successful
+    /// write of the write batch.
+    pub fn build_write_batch(
         &self,
         batch: StorageBatch,
-        transaction: Option<&'db Self::Transaction>,
-    ) -> CostResult<(), Error> {
+    ) -> CostResult<(WriteBatchWithTransaction<true>, OperationCost), Error> {
         let mut db_batch = WriteBatchWithTransaction::<true>::default();
 
         let mut cost = OperationCost::default();
@@ -440,15 +370,114 @@ impl<'db> Storage<'db> for RocksDbStorage {
                 }
             }
         }
+        Ok((db_batch, pending_costs)).wrap_with_cost(cost)
+    }
 
+    /// Commits a write batch
+    pub fn commit_db_write_batch(
+        &self,
+        db_batch: WriteBatchWithTransaction<true>,
+        pending_costs: OperationCost,
+        transaction: Option<&<RocksDbStorage as Storage>::Transaction>,
+    ) -> CostResult<(), Error> {
         let result = match transaction {
             None => self.db.write(db_batch),
             Some(transaction) => transaction.rebuild_from_writebatch(&db_batch),
         };
 
-        cost.add_assign(pending_costs);
+        if result.is_ok() {
+            result.map_err(RocksDBError).wrap_with_cost(pending_costs)
+        } else {
+            result
+                .map_err(RocksDBError)
+                .wrap_with_cost(OperationCost::default())
+        }
+    }
+}
 
-        result.map_err(RocksDBError).wrap_with_cost(cost)
+impl<'db> Storage<'db> for RocksDbStorage {
+    type BatchStorageContext = PrefixedRocksDbBatchStorageContext<'db>;
+    type BatchTransactionalStorageContext = PrefixedRocksDbBatchTransactionContext<'db>;
+    type StorageContext = PrefixedRocksDbStorageContext<'db>;
+    type Transaction = Tx<'db>;
+    type TransactionalStorageContext = PrefixedRocksDbTransactionContext<'db>;
+
+    fn start_transaction(&'db self) -> Self::Transaction {
+        self.db.transaction()
+    }
+
+    fn commit_transaction(&self, transaction: Self::Transaction) -> CostResult<(), Error> {
+        // All transaction costs were provided on method calls
+        transaction
+            .commit()
+            .map_err(RocksDBError)
+            .wrap_with_cost(Default::default())
+    }
+
+    fn rollback_transaction(&self, transaction: &Self::Transaction) -> Result<(), Error> {
+        transaction.rollback().map_err(RocksDBError)
+    }
+
+    fn flush(&self) -> Result<(), Error> {
+        self.db.flush().map_err(RocksDBError)
+    }
+
+    fn get_storage_context<'p, P>(&'db self, path: P) -> CostContext<Self::StorageContext>
+    where
+        P: IntoIterator<Item = &'p [u8]>,
+    {
+        Self::build_prefix(path).map(|prefix| PrefixedRocksDbStorageContext::new(&self.db, prefix))
+    }
+
+    fn get_transactional_storage_context<'p, P>(
+        &'db self,
+        path: P,
+        transaction: &'db Self::Transaction,
+    ) -> CostContext<Self::TransactionalStorageContext>
+    where
+        P: IntoIterator<Item = &'p [u8]>,
+    {
+        Self::build_prefix(path)
+            .map(|prefix| PrefixedRocksDbTransactionContext::new(&self.db, transaction, prefix))
+    }
+
+    fn get_batch_storage_context<'p, P>(
+        &'db self,
+        path: P,
+        batch: &'db StorageBatch,
+    ) -> CostContext<Self::BatchStorageContext>
+    where
+        P: IntoIterator<Item = &'p [u8]>,
+    {
+        Self::build_prefix(path)
+            .map(|prefix| PrefixedRocksDbBatchStorageContext::new(&self.db, prefix, batch))
+    }
+
+    fn get_batch_transactional_storage_context<'p, P>(
+        &'db self,
+        path: P,
+        batch: &'db StorageBatch,
+        transaction: &'db Self::Transaction,
+    ) -> CostContext<Self::BatchTransactionalStorageContext>
+    where
+        P: IntoIterator<Item = &'p [u8]>,
+    {
+        Self::build_prefix(path).map(|prefix| {
+            PrefixedRocksDbBatchTransactionContext::new(&self.db, transaction, prefix, batch)
+        })
+    }
+
+    fn commit_multi_context_batch(
+        &self,
+        batch: StorageBatch,
+        transaction: Option<&'db Self::Transaction>,
+    ) -> CostResult<(), Error> {
+        let mut cost = OperationCost::default();
+        let (db_batch, pending_costs) =
+            cost_return_on_error!(&mut cost, self.build_write_batch(batch));
+
+        self.commit_db_write_batch(db_batch, pending_costs, transaction)
+            .add_cost(cost)
     }
 
     fn get_storage_context_cost<L: WorstKeyLength>(path: &[L]) -> OperationCost {

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -35,9 +35,10 @@ use std::{
 };
 
 use costs::{
-    storage_cost::key_value_cost::KeyValueStorageCost, ChildrenSizesWithIsSumTree, CostContext,
-    CostResult, OperationCost,
+    cost_return_on_error_no_add, storage_cost::key_value_cost::KeyValueStorageCost,
+    ChildrenSizesWithIsSumTree, CostContext, CostResult, OperationCost,
 };
+use rocksdb::WriteBatchWithTransaction;
 use visualize::visualize_to_vec;
 
 use crate::{worst_case_costs::WorstKeyLength, Error};
@@ -120,7 +121,10 @@ pub trait Storage<'db> {
     fn get_storage_context_cost<L: WorstKeyLength>(path: &[L]) -> OperationCost;
 }
 
+use costs::storage_cost::removal::StorageRemovedBytes::BasicStorageRemoval;
 pub use costs::ChildrenSizes;
+
+use crate::Error::RocksDBError;
 
 /// Storage context.
 /// Provides operations expected from a database abstracting details such as


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
In RS-Drive atomicity of state transitions is paramount. A state transition is a collection of multiple operations that often will cause one or more identity balances to change. The amount that the identity balance must change by is driven by costs of changes in the batch. Ideally we should be able to alter the batch by adding operations based on calculated information coming from the batch itself.

For example in one batch have the document insertion, but also the reduction of credits of the identity due to the document insertion.

## What was done?
To be able to perform this feature, we need to get back costs from an insertion, then perform just in time updates to the batch, this is what is coded up in this PR.

## How Has This Been Tested?
Added some unit tests

## Breaking Changes
No breaking changes

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated relevant unit/integration/functional/e2e tests
- [X] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
