### PR TITLE
fix: non deterministic cost

### DIFF
--- a/grovedb/src/operations/proof/generate.rs
+++ b/grovedb/src/operations/proof/generate.rs
@@ -92,6 +92,10 @@ impl GroveDb {
     /// Generate a verbose proof for a given path query
     /// allows for subset verification
     pub fn prove_verbose(&self, query: &PathQuery) -> CostResult<Vec<u8>, Error> {
+        // TODO: we need to solve the localized limit and offset problem.
+        //      when using a path query that has a limit and offset value,
+        //      to get the expected behaviour, you need to know exactly
+        //      how the proving internals work and how your state looks.
         self.prove_internal(query, true)
     }
 
@@ -102,22 +106,6 @@ impl GroveDb {
         let mut proof_result: Vec<u8> = vec![];
         let mut limit: Option<u16> = query.query.limit;
         let mut offset: Option<u16> = query.query.offset;
-
-        // TODO: add again?
-        // We prevent the generation of verbose proofs for path queries that have a
-        // limit or offset.
-        // This is because once they are set, the subset nature
-        // of the path query now depends not only on the path query definition,
-        // but also on the current state of the db.
-        // Meaning a path query that could have been a valid subset could potentially
-        // not be due to the current state.
-        // Hence verification errors due to non subset issues will not be deterministic.
-        // if (limit.is_some() || offset.is_some()) && is_verbose {
-        //     return Err(Error::InvalidInput(
-        //         "cannot generate verbose proof for path-query with a limit or offset
-        // value",     ))
-        //     .wrap_with_cost(cost);
-        // }
 
         let path_slices = query.path.iter().map(|x| x.as_slice()).collect::<Vec<_>>();
 

--- a/grovedb/src/tests/query_tests.rs
+++ b/grovedb/src/tests/query_tests.rs
@@ -2230,36 +2230,6 @@ fn test_subset_proof_verification() {
             Some(Element::new_item(b"value1".to_vec()))
         )
     );
-
-    // TODO: enable again?
-    // should not allow verbose proof generation if limit is set
-    // let path_query_with_limit = {
-    //     let mut cloned_path_query = path_query.clone();
-    //     cloned_path_query.query.limit = Some(10);
-    //     cloned_path_query
-    // };
-    // let verbose_proof_result =
-    // db.prove_verbose(&path_query_with_limit).unwrap(); assert!(matches!(
-    //     verbose_proof_result,
-    //     Err(Error::InvalidInput(
-    //         "cannot generate verbose proof for path-query with a limit or
-    // offset value"     ))
-    // ));
-
-    // TODO: enable again?
-    // should not allow verbose proof generation if offset is set
-    // let path_query_with_offset = {
-    //     let mut cloned_path_query = path_query;
-    //     cloned_path_query.query.offset = Some(10);
-    //     cloned_path_query
-    // };
-    // let verbose_proof_result =
-    // db.prove_verbose(&path_query_with_offset).unwrap(); assert!(matches!(
-    //     verbose_proof_result,
-    //     Err(Error::InvalidInput(
-    //         "cannot generate verbose proof for path-query with a limit or
-    // offset value"     ))
-    // ));
 }
 
 #[test]

--- a/storage/src/rocksdb_storage/storage_context/raw_iterator.rs
+++ b/storage/src/rocksdb_storage/storage_context/raw_iterator.rs
@@ -113,11 +113,21 @@ impl<'a> RawIterator for PrefixedRocksDbRawIterator<DBRawIteratorWithThreadMode<
                     cost.storage_loaded_bytes += k.len() as u32;
                     Some(k.split_at(self.prefix.len()).1)
                 } else {
+                    // we can think of the underlying storage layer as stacked blocks
+                    // and a block is a collection of key value pairs with the
+                    // same prefix.
+                    // if we are at the last key in a block and we try to
+                    // check for the next key, we should not add the next block's first key
+                    // len() as that will make cost depend on the ordering of blocks.
+                    // instead we should add a fixed sized cost for such boundary checks
                     cost.storage_loaded_bytes += MAX_PREFIXED_KEY_LENGTH;
                     None
                 }
             }
             None => {
+                // if we are at the last key in the last block we should also add
+                // a fixed sized cost rather than nothing, as a change in block ordering
+                // could move the last block to some other position.
                 cost.storage_loaded_bytes += MAX_PREFIXED_KEY_LENGTH;
                 None
             }
@@ -136,11 +146,21 @@ impl<'a> RawIterator for PrefixedRocksDbRawIterator<DBRawIteratorWithThreadMode<
                     cost.storage_loaded_bytes += k.len() as u32;
                     true
                 } else {
+                    // we can think of the underlying storage layer as stacked blocks
+                    // and a block is a collection of key value pairs with the
+                    // same prefix.
+                    // if we are at the last key in a block and we try to
+                    // check for the next key, we should not add the next block's first key
+                    // len() as that will make cost depend on the ordering of blocks.
+                    // instead we should add a fixed sized cost for such boundary checks
                     cost.storage_loaded_bytes += MAX_PREFIXED_KEY_LENGTH;
                     false
                 }
             })
             .unwrap_or_else(|| {
+                // if we are at the last key in the last block we should also add
+                // a fixed sized cost rather than nothing, as a change in block ordering
+                // could move the last block to some other position.
                 cost.storage_loaded_bytes += MAX_PREFIXED_KEY_LENGTH;
                 false
             })
@@ -215,11 +235,21 @@ impl<'a> RawIterator for PrefixedRocksDbRawIterator<DBRawIteratorWithThreadMode<
                     cost.storage_loaded_bytes += k.len() as u32;
                     Some(k.split_at(self.prefix.len()).1)
                 } else {
+                    // we can think of the underlying storage layer as stacked blocks
+                    // and a block is a collection of key value pairs with the
+                    // same prefix.
+                    // if we are at the last key in a block and we try to
+                    // check for the next key, we should not add the next block's first key
+                    // len() as that will make cost depend on the ordering of blocks.
+                    // instead we should add a fixed sized cost for such boundary checks
                     cost.storage_loaded_bytes += MAX_PREFIXED_KEY_LENGTH;
                     None
                 }
             }
             None => {
+                // if we are at the last key in the last block we should also add
+                // a fixed sized cost rather than nothing, as a change in block ordering
+                // could move the last block to some other position.
                 cost.storage_loaded_bytes += MAX_PREFIXED_KEY_LENGTH;
                 None
             }
@@ -238,11 +268,21 @@ impl<'a> RawIterator for PrefixedRocksDbRawIterator<DBRawIteratorWithThreadMode<
                     cost.storage_loaded_bytes += k.len() as u32;
                     true
                 } else {
+                    // we can think of the underlying storage layer as stacked blocks
+                    // and a block is a collection of key value pairs with the
+                    // same prefix.
+                    // if we are at the last key in a block and we try to
+                    // check for the next key, we should not add the next block's first key
+                    // len() as that will make cost depend on the ordering of blocks.
+                    // instead we should add a fixed sized cost for such boundary checks
                     cost.storage_loaded_bytes += MAX_PREFIXED_KEY_LENGTH;
                     false
                 }
             })
             .unwrap_or_else(|| {
+                // if we are at the last key in the last block we should also add
+                // a fixed sized cost rather than nothing, as a change in block ordering
+                // could move the last block to some other position.
                 cost.storage_loaded_bytes += MAX_PREFIXED_KEY_LENGTH;
                 false
             })

--- a/storage/src/rocksdb_storage/storage_context/raw_iterator.rs
+++ b/storage/src/rocksdb_storage/storage_context/raw_iterator.rs
@@ -116,7 +116,7 @@ impl<'a> RawIterator for PrefixedRocksDbRawIterator<DBRawIteratorWithThreadMode<
                     cost.storage_loaded_bytes += MAX_PREFIXED_KEY_LENGTH;
                     None
                 }
-            },
+            }
             None => {
                 cost.storage_loaded_bytes += MAX_PREFIXED_KEY_LENGTH;
                 None
@@ -218,7 +218,7 @@ impl<'a> RawIterator for PrefixedRocksDbRawIterator<DBRawIteratorWithThreadMode<
                     cost.storage_loaded_bytes += MAX_PREFIXED_KEY_LENGTH;
                     None
                 }
-            },
+            }
             None => {
                 cost.storage_loaded_bytes += MAX_PREFIXED_KEY_LENGTH;
                 None

--- a/storage/src/rocksdb_storage/storage_context/raw_iterator.rs
+++ b/storage/src/rocksdb_storage/storage_context/raw_iterator.rs
@@ -105,10 +105,11 @@ impl<'a> RawIterator for PrefixedRocksDbRawIterator<DBRawIteratorWithThreadMode<
         let value = self.raw_iterator.key().and_then(|k| {
             // Even if we truncate prefix, loaded cost should be maximum for the whole
             // function
-            cost.storage_loaded_bytes += k.len() as u32;
             if k.starts_with(&self.prefix) {
+                cost.storage_loaded_bytes += k.len() as u32;
                 Some(k.split_at(self.prefix.len()).1)
             } else {
+                cost.storage_loaded_bytes += 256 + 32;
                 None
             }
         });
@@ -122,8 +123,13 @@ impl<'a> RawIterator for PrefixedRocksDbRawIterator<DBRawIteratorWithThreadMode<
         self.raw_iterator
             .key()
             .map(|k| {
-                cost.storage_loaded_bytes += k.len() as u32;
-                k.starts_with(&self.prefix)
+                if k.starts_with(&self.prefix) {
+                    cost.storage_loaded_bytes += k.len() as u32;
+                    true
+                } else {
+                    cost.storage_loaded_bytes += 256 + 32;
+                    false
+                }
             })
             .unwrap_or(false)
             .wrap_with_cost(cost)
@@ -192,10 +198,11 @@ impl<'a> RawIterator for PrefixedRocksDbRawIterator<DBRawIteratorWithThreadMode<
         let value = self.raw_iterator.key().and_then(|k| {
             // Even if we truncate prefix, loaded cost should be maximum for the whole
             // function
-            cost.storage_loaded_bytes += k.len() as u32;
             if k.starts_with(&self.prefix) {
+                cost.storage_loaded_bytes += k.len() as u32;
                 Some(k.split_at(self.prefix.len()).1)
             } else {
+                cost.storage_loaded_bytes += 256 + 32;
                 None
             }
         });
@@ -209,8 +216,13 @@ impl<'a> RawIterator for PrefixedRocksDbRawIterator<DBRawIteratorWithThreadMode<
         self.raw_iterator
             .key()
             .map(|k| {
-                cost.storage_loaded_bytes += k.len() as u32;
-                k.starts_with(&self.prefix)
+                if k.starts_with(&self.prefix) {
+                    cost.storage_loaded_bytes += k.len() as u32;
+                    true
+                } else {
+                    cost.storage_loaded_bytes += 256 + 32;
+                    false
+                }
             })
             .unwrap_or(false)
             .wrap_with_cost(cost)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Cost values depended on the ordering of key values in the rocksdb storage layer, leading to different state roots when prefix computation changes. 


## What was done?
<!--- Describe your changes in detail -->
Unified the costs, regardless of the ordering in the underlying storage layer. 
- if the next key is from another merk, rather than add the cost of the key we add the max key length
- if the next key is none, add the max key length rather than nothing. 


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->



## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated relevant unit/integration/functional/e2e tests
- [X] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
