### PR TITLE
fix: hide storage api

### DIFF
--- a/grovedb/src/lib.rs
+++ b/grovedb/src/lib.rs
@@ -96,7 +96,7 @@ pub use query::{PathQuery, SizedQuery};
 #[cfg(feature = "full")]
 pub use replication::{BufferedRestorer, Restorer, SiblingsChunkProducer, SubtreeChunkProducer};
 #[cfg(feature = "full")]
-pub use storage::rocksdb_storage::RocksDbStorage;
+use storage::rocksdb_storage::RocksDbStorage;
 #[cfg(feature = "full")]
 use storage::{
     rocksdb_storage::{
@@ -106,7 +106,7 @@ use storage::{
     StorageBatch,
 };
 #[cfg(feature = "full")]
-pub use storage::{Storage, StorageContext};
+use storage::{Storage, StorageContext};
 
 #[cfg(any(feature = "full", feature = "verify"))]
 pub use crate::error::Error;

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -38,8 +38,5 @@ pub mod worst_case_costs;
 
 pub use crate::{
     error::Error,
-    storage::{
-        AbstractBatchOperation, Batch, ChildrenSizes, RawIterator, Storage, StorageBatch,
-        StorageContext,
-    },
+    storage::{Batch, ChildrenSizes, RawIterator, Storage, StorageBatch, StorageContext},
 };

--- a/storage/src/rocksdb_storage/storage_context.rs
+++ b/storage/src/rocksdb_storage/storage_context.rs
@@ -42,8 +42,11 @@ pub use context_no_tx::PrefixedRocksDbStorageContext;
 pub use context_tx::PrefixedRocksDbTransactionContext;
 pub use raw_iterator::PrefixedRocksDbRawIterator;
 
+use super::storage::SubtreePrefix;
+
 /// Make prefixed key
-pub fn make_prefixed_key<K: AsRef<[u8]>>(mut prefix: Vec<u8>, key: K) -> Vec<u8> {
-    prefix.extend_from_slice(key.as_ref());
-    prefix
+pub fn make_prefixed_key<K: AsRef<[u8]>>(prefix: &SubtreePrefix, key: K) -> Vec<u8> {
+    let mut prefix_vec = prefix.to_vec();
+    prefix_vec.extend_from_slice(key.as_ref());
+    prefix_vec
 }

--- a/storage/src/rocksdb_storage/storage_context/raw_iterator.rs
+++ b/storage/src/rocksdb_storage/storage_context/raw_iterator.rs
@@ -33,7 +33,7 @@ use rocksdb::DBRawIteratorWithThreadMode;
 
 use super::make_prefixed_key;
 use crate::{
-    rocksdb_storage::storage::{Db, Tx},
+    rocksdb_storage::storage::{Db, SubtreePrefix, Tx},
     RawIterator,
 };
 
@@ -42,7 +42,7 @@ const MAX_PREFIXED_KEY_LENGTH: u32 = 256 + 32;
 
 /// Raw iterator over prefixed storage_cost.
 pub struct PrefixedRocksDbRawIterator<I> {
-    pub(super) prefix: Vec<u8>,
+    pub(super) prefix: SubtreePrefix,
     pub(super) raw_iterator: I,
 }
 
@@ -66,14 +66,13 @@ impl<'a> RawIterator for PrefixedRocksDbRawIterator<DBRawIteratorWithThreadMode<
     }
 
     fn seek<K: AsRef<[u8]>>(&mut self, key: K) -> CostContext<()> {
-        self.raw_iterator
-            .seek(make_prefixed_key(self.prefix.to_vec(), key));
+        self.raw_iterator.seek(make_prefixed_key(&self.prefix, key));
         ().wrap_with_cost(OperationCost::with_seek_count(1))
     }
 
     fn seek_for_prev<K: AsRef<[u8]>>(&mut self, key: K) -> CostContext<()> {
         self.raw_iterator
-            .seek_for_prev(make_prefixed_key(self.prefix.to_vec(), key));
+            .seek_for_prev(make_prefixed_key(&self.prefix, key));
         ().wrap_with_cost(OperationCost::with_seek_count(1))
     }
 
@@ -188,14 +187,13 @@ impl<'a> RawIterator for PrefixedRocksDbRawIterator<DBRawIteratorWithThreadMode<
     }
 
     fn seek<K: AsRef<[u8]>>(&mut self, key: K) -> CostContext<()> {
-        self.raw_iterator
-            .seek(make_prefixed_key(self.prefix.to_vec(), key));
+        self.raw_iterator.seek(make_prefixed_key(&self.prefix, key));
         ().wrap_with_cost(OperationCost::with_seek_count(1))
     }
 
     fn seek_for_prev<K: AsRef<[u8]>>(&mut self, key: K) -> CostContext<()> {
         self.raw_iterator
-            .seek_for_prev(make_prefixed_key(self.prefix.to_vec(), key));
+            .seek_for_prev(make_prefixed_key(&self.prefix, key));
         ().wrap_with_cost(OperationCost::with_seek_count(1))
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Before we agree on GroveDB's public API there are things that are obviously must not be a part of it.

## What was done?
<!--- Describe your changes in detail -->

1. Storage details are gone from public exports; also this PR addresses other visibility issues found during debugging
2. `build_prefix` now returns more specific type as we agreed on 


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

With GroveDB and Drive's test suites

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
