### PR TITLE
fix: result set path error

### DIFF
--- a/grovedb/src/operations/proof/verify.rs
+++ b/grovedb/src/operations/proof/verify.rs
@@ -678,7 +678,6 @@ impl ProofVerifier {
             ProofTokenType::Merk | ProofTokenType::SizedMerk => {
                 let mut key_as_query = Query::new();
                 key_as_query.insert_key(last_key.to_owned());
-                current_path.push(last_key);
 
                 let verification_result = self.execute_merk_proof(
                     proof_token_type,
@@ -687,6 +686,8 @@ impl ProofVerifier {
                     key_as_query.left_to_right,
                     current_path.to_owned(),
                 )?;
+
+                current_path.push(last_key);
 
                 Ok((verification_result.0, verification_result.1, false))
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->
During proof verification, we added the last key to the current path before completing subquery path proof verification. This made the absence function not work as expected due to incorrect paths. 

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## What was done?
<!--- Describe your changes in detail -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
