### PR TITLE
fix: early limit reduction

### DIFF
--- a/grovedb/src/batch/key_info.rs
+++ b/grovedb/src/batch/key_info.rs
@@ -100,20 +100,7 @@ impl PartialEq<&[u8]> for KeyInfo {
 #[cfg(feature = "full")]
 impl PartialOrd<Self> for KeyInfo {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        match self.as_slice().partial_cmp(other.as_slice()) {
-            None => None,
-            Some(ord) => match ord {
-                Ordering::Less => Some(Ordering::Less),
-                Ordering::Equal => {
-                    let other_len = other.max_length();
-                    match self.max_length().partial_cmp(&other_len) {
-                        None => Some(Ordering::Equal),
-                        Some(ord) => Some(ord),
-                    }
-                }
-                Ordering::Greater => Some(Ordering::Greater),
-            },
-        }
+        Some(self.cmp(other))
     }
 }
 

--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -168,19 +168,19 @@ pub enum Op {
 
 impl PartialOrd for Op {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        match (self, other) {
-            (Op::Delete, Op::Insert { .. }) => Some(Ordering::Less),
-            (Op::Delete, Op::Replace { .. }) => Some(Ordering::Less),
-            (Op::Insert { .. }, Op::Delete) => Some(Ordering::Greater),
-            (Op::Replace { .. }, Op::Delete) => Some(Ordering::Greater),
-            _ => Some(Ordering::Equal),
-        }
+        Some(self.cmp(other))
     }
 }
 
 impl Ord for Op {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.partial_cmp(other).expect("all ops have order")
+        match (self, other) {
+            (Op::Delete, Op::Insert { .. }) => Ordering::Less,
+            (Op::Delete, Op::Replace { .. }) => Ordering::Less,
+            (Op::Insert { .. }, Op::Delete) => Ordering::Greater,
+            (Op::Replace { .. }, Op::Delete) => Ordering::Greater,
+            _ => Ordering::Equal,
+        }
     }
 }
 

--- a/grovedb/src/operations/proof/util.rs
+++ b/grovedb/src/operations/proof/util.rs
@@ -333,9 +333,17 @@ pub fn reduce_limit_and_offset_by(
     skip_limit
 }
 
-pub fn increase_limit_by(limit: &mut Option<u16>, n: u16) {
+pub fn increase_limit_and_offset_by(
+    limit: &mut Option<u16>,
+    offset: &mut Option<u16>,
+    limit_inc: u16,
+    offset_inc: u16,
+) {
+    if let Some(offset_value) = *offset {
+        *offset = Some(offset_value + offset_inc);
+    }
     if let Some(limit_value) = *limit {
-        *limit = Some(limit_value + n);
+        *limit = Some(limit_value + limit_inc);
     }
 }
 

--- a/grovedb/src/operations/proof/util.rs
+++ b/grovedb/src/operations/proof/util.rs
@@ -333,6 +333,12 @@ pub fn reduce_limit_and_offset_by(
     skip_limit
 }
 
+pub fn increase_limit_by(limit: &mut Option<u16>, n: u16) {
+    if let Some(limit_value) = *limit {
+        *limit = Some(limit_value + n);
+    }
+}
+
 /// Proved path-key-values
 pub type ProvedPathKeyValues = Vec<ProvedPathKeyValue>;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->
When doing proof generation, we sometimes reduce the limit and offset value to save space for some element we know we'd be generating a proof for in the future. 
During proof generation for that element, we are supposed to add back this saved space, we failed to do this, leading to a bug. 
This PR fixes this. 

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## What was done?
<!--- Describe your changes in detail -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
