### PR TITLE
fix!: limit will now decrease when subquery has no elements

### DIFF
--- a/grovedb/src/query/mod.rs
+++ b/grovedb/src/query/mod.rs
@@ -534,6 +534,7 @@ mod tests {
             .query_raw(
                 &merged_path_query,
                 true,
+                true,
                 QueryResultType::QueryPathKeyElementTrioResultType,
                 None,
             )
@@ -825,6 +826,7 @@ mod tests {
         let (result_set_merged, _) = temp_db
             .query_raw(
                 &merged_path_query,
+                true,
                 true,
                 QueryResultType::QueryPathKeyElementTrioResultType,
                 None,

--- a/grovedb/src/reference_path.rs
+++ b/grovedb/src/reference_path.rs
@@ -387,7 +387,7 @@ mod tests {
         let path_query =
             PathQuery::new_unsized(vec![TEST_LEAF.to_vec(), b"innertree4".to_vec()], query);
         let result = db
-            .query_item_value(&path_query, true, None)
+            .query_item_value(&path_query, true, true, None)
             .unwrap()
             .expect("should query items");
         assert_eq!(result.0.len(), 5);

--- a/grovedb/src/tests/mod.rs
+++ b/grovedb/src/tests/mod.rs
@@ -541,7 +541,7 @@ fn test_element_with_flags() {
         SizedQuery::new(query, None, None),
     );
     let (flagged_ref_no_follow, _) = db
-        .query_raw(&path_query, true, QueryKeyElementPairResultType, None)
+        .query_raw(&path_query, true, true, QueryKeyElementPairResultType, None)
         .unwrap()
         .expect("should get successfully");
 
@@ -2621,6 +2621,7 @@ fn test_get_full_query() {
     assert_eq!(
         db.query_many_raw(
             &[&path_query1, &path_query2],
+            true,
             true,
             QueryKeyElementPairResultType,
             None

--- a/grovedb/src/tests/query_tests.rs
+++ b/grovedb/src/tests/query_tests.rs
@@ -365,7 +365,7 @@ fn test_get_range_query_with_non_unique_subquery() {
     let path_query = PathQuery::new_unsized(path, query.clone());
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, None)
+        .query_item_value(&path_query, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -402,7 +402,7 @@ fn test_get_range_query_with_unique_subquery() {
     let path_query = PathQuery::new_unsized(path, query.clone());
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, None)
+        .query_item_value(&path_query, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -437,7 +437,7 @@ fn test_get_range_query_with_unique_subquery_on_references() {
     let path_query = PathQuery::new_unsized(path, query.clone());
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, None)
+        .query_item_value(&path_query, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -481,7 +481,7 @@ fn test_get_range_query_with_unique_subquery_with_non_unique_null_values() {
     let path_query = PathQuery::new_unsized(path, query.clone());
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, None)
+        .query_item_value(&path_query, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -524,7 +524,7 @@ fn test_get_range_query_with_unique_subquery_ignore_non_unique_null_values() {
     let path_query = PathQuery::new_unsized(path, query.clone());
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, None)
+        .query_item_value(&path_query, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -562,7 +562,7 @@ fn test_get_range_inclusive_query_with_non_unique_subquery() {
     let path_query = PathQuery::new_unsized(path, query.clone());
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, None)
+        .query_item_value(&path_query, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -602,7 +602,7 @@ fn test_get_range_inclusive_query_with_non_unique_subquery_on_references() {
     let path_query = PathQuery::new_unsized(path, query.clone());
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, None)
+        .query_item_value(&path_query, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -642,7 +642,7 @@ fn test_get_range_inclusive_query_with_unique_subquery() {
     let path_query = PathQuery::new_unsized(path, query.clone());
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, None)
+        .query_item_value(&path_query, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -680,7 +680,7 @@ fn test_get_range_from_query_with_non_unique_subquery() {
     let path_query = PathQuery::new_unsized(path, query.clone());
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, None)
+        .query_item_value(&path_query, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -717,7 +717,7 @@ fn test_get_range_from_query_with_unique_subquery() {
     let path_query = PathQuery::new_unsized(path, query.clone());
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, None)
+        .query_item_value(&path_query, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -755,7 +755,7 @@ fn test_get_range_to_query_with_non_unique_subquery() {
     let path_query = PathQuery::new_unsized(path, query.clone());
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, None)
+        .query_item_value(&path_query, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -792,7 +792,7 @@ fn test_get_range_to_query_with_unique_subquery() {
     let path_query = PathQuery::new_unsized(path, query.clone());
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, None)
+        .query_item_value(&path_query, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -830,7 +830,7 @@ fn test_get_range_to_inclusive_query_with_non_unique_subquery() {
     let path_query = PathQuery::new_unsized(path, query.clone());
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, None)
+        .query_item_value(&path_query, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -870,7 +870,7 @@ fn test_get_range_to_inclusive_query_with_non_unique_subquery_and_key_out_of_bou
     let path_query = PathQuery::new_unsized(path, query.clone());
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, None)
+        .query_item_value(&path_query, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -907,7 +907,7 @@ fn test_get_range_to_inclusive_query_with_unique_subquery() {
     let path_query = PathQuery::new_unsized(path, query.clone());
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, None)
+        .query_item_value(&path_query, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -945,7 +945,7 @@ fn test_get_range_after_query_with_non_unique_subquery() {
     let path_query = PathQuery::new_unsized(path, query.clone());
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, None)
+        .query_item_value(&path_query, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -985,7 +985,7 @@ fn test_get_range_after_to_query_with_non_unique_subquery() {
     let path_query = PathQuery::new_unsized(path, query.clone());
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, None)
+        .query_item_value(&path_query, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -1027,7 +1027,7 @@ fn test_get_range_after_to_inclusive_query_with_non_unique_subquery() {
     let path_query = PathQuery::new_unsized(path, query.clone());
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, None)
+        .query_item_value(&path_query, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -1069,7 +1069,7 @@ fn test_get_range_after_to_inclusive_query_with_non_unique_subquery_and_key_out_
     let path_query = PathQuery::new_unsized(path, query.clone());
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, None)
+        .query_item_value(&path_query, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -1117,7 +1117,7 @@ fn test_get_range_inclusive_query_with_double_non_unique_subquery() {
     let path_query = PathQuery::new_unsized(path, query.clone());
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, None)
+        .query_item_value(&path_query, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -1156,7 +1156,7 @@ fn test_get_range_query_with_limit_and_offset() {
     let path_query = PathQuery::new(path.clone(), SizedQuery::new(query.clone(), None, None));
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, None)
+        .query_item_value(&path_query, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -1187,7 +1187,7 @@ fn test_get_range_query_with_limit_and_offset() {
     let path_query = PathQuery::new(path.clone(), SizedQuery::new(query.clone(), None, None));
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, None)
+        .query_item_value(&path_query, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -1218,7 +1218,7 @@ fn test_get_range_query_with_limit_and_offset() {
     let path_query = PathQuery::new(path.clone(), SizedQuery::new(query.clone(), Some(55), None));
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, None)
+        .query_item_value(&path_query, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -1249,7 +1249,7 @@ fn test_get_range_query_with_limit_and_offset() {
     );
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, None)
+        .query_item_value(&path_query, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -1287,7 +1287,7 @@ fn test_get_range_query_with_limit_and_offset() {
     );
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, None)
+        .query_item_value(&path_query, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -1322,7 +1322,7 @@ fn test_get_range_query_with_limit_and_offset() {
     );
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, None)
+        .query_item_value(&path_query, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -1343,7 +1343,7 @@ fn test_get_range_query_with_limit_and_offset() {
     );
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, None)
+        .query_item_value(&path_query, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -1366,7 +1366,7 @@ fn test_get_range_query_with_limit_and_offset() {
     let path_query = PathQuery::new(path, SizedQuery::new(query.clone(), Some(5), Some(2)));
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, None)
+        .query_item_value(&path_query, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -1609,7 +1609,7 @@ fn test_mixed_level_proofs() {
 
     let path_query = PathQuery::new_unsized(path.clone(), query.clone());
     let (elements, _) = db
-        .query_item_value(&path_query, true, None)
+        .query_item_value(&path_query, true, true, None)
         .unwrap()
         .expect("successful get_path_query");
 
@@ -1625,7 +1625,7 @@ fn test_mixed_level_proofs() {
     // Test mixed element proofs with limit and offset
     let path_query = PathQuery::new_unsized(path.clone(), query.clone());
     let (elements, _) = db
-        .query_item_value(&path_query, true, None)
+        .query_item_value(&path_query, true, true, None)
         .unwrap()
         .expect("successful get_path_query");
 
@@ -1642,7 +1642,7 @@ fn test_mixed_level_proofs() {
 
     let path_query = PathQuery::new(path.clone(), SizedQuery::new(query.clone(), Some(1), None));
     let (elements, _) = db
-        .query_item_value(&path_query, true, None)
+        .query_item_value(&path_query, true, true, None)
         .unwrap()
         .expect("successful get_path_query");
 
@@ -1660,7 +1660,7 @@ fn test_mixed_level_proofs() {
         SizedQuery::new(query.clone(), Some(3), Some(0)),
     );
     let (elements, _) = db
-        .query_item_value(&path_query, true, None)
+        .query_item_value(&path_query, true, true, None)
         .unwrap()
         .expect("successful get_path_query");
 
@@ -1678,7 +1678,7 @@ fn test_mixed_level_proofs() {
         SizedQuery::new(query.clone(), Some(4), Some(0)),
     );
     let (elements, _) = db
-        .query_item_value(&path_query, true, None)
+        .query_item_value(&path_query, true, true, None)
         .unwrap()
         .expect("successful get_path_query");
 
@@ -1693,7 +1693,7 @@ fn test_mixed_level_proofs() {
 
     let path_query = PathQuery::new(path, SizedQuery::new(query.clone(), Some(10), Some(4)));
     let (elements, _) = db
-        .query_item_value(&path_query, true, None)
+        .query_item_value(&path_query, true, true, None)
         .unwrap()
         .expect("successful get_path_query");
 
@@ -1789,6 +1789,7 @@ fn test_mixed_level_proofs_with_tree() {
         .query_raw(
             &path_query,
             true,
+            true,
             QueryResultType::QueryPathKeyElementTrioResultType,
             None,
         )
@@ -1810,6 +1811,7 @@ fn test_mixed_level_proofs_with_tree() {
     let (elements, _) = db
         .query_raw(
             &path_query,
+            true,
             true,
             QueryResultType::QueryPathKeyElementTrioResultType,
             None,

--- a/node-grove/src/lib.rs
+++ b/node-grove/src/lib.rs
@@ -663,6 +663,7 @@ impl GroveDbWrapper {
                 .query_item_value(
                     &path_query,
                     allows_cache,
+                    true,
                     using_transaction.then_some(transaction).flatten(),
                 )
                 .unwrap(); // Todo: Costs;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
When Querying Grovedb using subqueries and with a limit the limit would only decrease if the subquery actually had an item. However in most cases the limit is there to protect against very expensive queries.

The queries would be expensive because we could go through many many trees where the sub elements have no matches, hence the limit would not decrease and hence we would continue on the increasingly expensive query.

## What was done?
Created an option to allow to decrease the limit by one per iteration if subqueries have no items on them.

## How Has This Been Tested?
Updated tests and debugged to make sure it was working


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated relevant unit/integration/functional/e2e tests
- [X] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
