### PR TITLE
fix path

### DIFF
--- a/tutorials/Cargo.toml
+++ b/tutorials/Cargo.toml
@@ -8,7 +8,7 @@ default-run = "tutorials"
 
 [dependencies]
 grovedb = { git = "https://github.com/dashpay/grovedb.git" }
-path = { path = "../path" }
+grovedb-path = { path = "../path" }
 rand = "0.8.5"
 
 [workspace]


### PR DESCRIPTION
## Issue being fixed or feature implemented
Tutorials building was broken due to incorrect grovedb-path create name.

## What was done?
Renamed to correct grovedb-path crate name in tutorials.


## How Has This Been Tested?
Building and running tutorials

## Breaking Changes
no


## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
