### PR TITLE
fix!: empty parent paths should only error if we want them to error

### DIFF
--- a/grovedb/src/element/mod.rs
+++ b/grovedb/src/element/mod.rs
@@ -44,7 +44,7 @@ pub(crate) mod helpers;
 mod insert;
 #[cfg(any(feature = "full", feature = "verify"))]
 mod query;
-#[cfg(any(feature = "full", feature = "verify"))]
+#[cfg(feature = "full")]
 pub use query::QueryOptions;
 #[cfg(any(feature = "full", feature = "verify"))]
 mod serialize;

--- a/grovedb/src/element/mod.rs
+++ b/grovedb/src/element/mod.rs
@@ -44,7 +44,7 @@ pub(crate) mod helpers;
 mod insert;
 #[cfg(any(feature = "full", feature = "verify"))]
 mod query;
-#[cfg(feature = "full")]
+#[cfg(any(feature = "full", feature = "verify"))]
 pub use query::QueryOptions;
 #[cfg(any(feature = "full", feature = "verify"))]
 mod serialize;

--- a/grovedb/src/element/mod.rs
+++ b/grovedb/src/element/mod.rs
@@ -45,6 +45,8 @@ mod insert;
 #[cfg(any(feature = "full", feature = "verify"))]
 mod query;
 #[cfg(any(feature = "full", feature = "verify"))]
+pub use query::QueryOptions;
+#[cfg(any(feature = "full", feature = "verify"))]
 mod serialize;
 #[cfg(feature = "full")]
 use core::fmt;

--- a/grovedb/src/element/query.rs
+++ b/grovedb/src/element/query.rs
@@ -74,6 +74,7 @@ pub struct QueryOptions {
     pub error_if_intermediate_path_tree_not_present: bool,
 }
 
+#[cfg(feature = "full")]
 impl Default for QueryOptions {
     fn default() -> Self {
         QueryOptions {

--- a/grovedb/src/element/query.rs
+++ b/grovedb/src/element/query.rs
@@ -622,7 +622,8 @@ impl Element {
                         })
                         .unwrap_add_cost(&mut cost)
                     }
-                    Err(Error::PathKeyNotFound(_)) => Ok(()),
+                    Err(Error::PathKeyNotFound(_))
+                    | Err(Error::PathParentLayerNotFound(_)) => Ok(()),
                     Err(e) => Err(e),
                 }
             } else {

--- a/grovedb/src/element/query.rs
+++ b/grovedb/src/element/query.rs
@@ -59,7 +59,7 @@ use crate::{
 #[cfg(any(feature = "full", feature = "verify"))]
 use crate::{Element, SizedQuery};
 
-#[cfg(feature = "full")]
+#[cfg(any(feature = "full", feature = "verify"))]
 #[derive(Copy, Clone, Debug)]
 pub struct QueryOptions {
     pub allow_get_raw: bool,
@@ -74,7 +74,7 @@ pub struct QueryOptions {
     pub error_if_intermediate_path_tree_not_present: bool,
 }
 
-#[cfg(feature = "full")]
+#[cfg(any(feature = "full", feature = "verify"))]
 impl Default for QueryOptions {
     fn default() -> Self {
         QueryOptions {

--- a/grovedb/src/query/mod.rs
+++ b/grovedb/src/query/mod.rs
@@ -536,6 +536,7 @@ mod tests {
                 &merged_path_query,
                 true,
                 true,
+                true,
                 QueryResultType::QueryPathKeyElementTrioResultType,
                 None,
             )
@@ -827,6 +828,7 @@ mod tests {
         let (result_set_merged, _) = temp_db
             .query_raw(
                 &merged_path_query,
+                true,
                 true,
                 true,
                 QueryResultType::QueryPathKeyElementTrioResultType,

--- a/grovedb/src/reference_path.rs
+++ b/grovedb/src/reference_path.rs
@@ -387,7 +387,7 @@ mod tests {
         let path_query =
             PathQuery::new_unsized(vec![TEST_LEAF.to_vec(), b"innertree4".to_vec()], query);
         let result = db
-            .query_item_value(&path_query, true, true, None)
+            .query_item_value(&path_query, true, true, true, None)
             .unwrap()
             .expect("should query items");
         assert_eq!(result.0.len(), 5);

--- a/grovedb/src/tests/mod.rs
+++ b/grovedb/src/tests/mod.rs
@@ -541,7 +541,14 @@ fn test_element_with_flags() {
         SizedQuery::new(query, None, None),
     );
     let (flagged_ref_no_follow, _) = db
-        .query_raw(&path_query, true, true, QueryKeyElementPairResultType, None)
+        .query_raw(
+            &path_query,
+            true,
+            true,
+            true,
+            QueryKeyElementPairResultType,
+            None,
+        )
         .unwrap()
         .expect("should get successfully");
 
@@ -2621,6 +2628,7 @@ fn test_get_full_query() {
     assert_eq!(
         db.query_many_raw(
             &[&path_query1, &path_query2],
+            true,
             true,
             true,
             QueryKeyElementPairResultType,

--- a/grovedb/src/tests/query_tests.rs
+++ b/grovedb/src/tests/query_tests.rs
@@ -365,7 +365,7 @@ fn test_get_range_query_with_non_unique_subquery() {
     let path_query = PathQuery::new_unsized(path, query.clone());
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, true, None)
+        .query_item_value(&path_query, true, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -402,7 +402,7 @@ fn test_get_range_query_with_unique_subquery() {
     let path_query = PathQuery::new_unsized(path, query.clone());
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, true, None)
+        .query_item_value(&path_query, true, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -437,7 +437,7 @@ fn test_get_range_query_with_unique_subquery_on_references() {
     let path_query = PathQuery::new_unsized(path, query.clone());
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, true, None)
+        .query_item_value(&path_query, true, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -481,7 +481,7 @@ fn test_get_range_query_with_unique_subquery_with_non_unique_null_values() {
     let path_query = PathQuery::new_unsized(path, query.clone());
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, true, None)
+        .query_item_value(&path_query, true, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -524,7 +524,7 @@ fn test_get_range_query_with_unique_subquery_ignore_non_unique_null_values() {
     let path_query = PathQuery::new_unsized(path, query.clone());
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, true, None)
+        .query_item_value(&path_query, true, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -562,7 +562,7 @@ fn test_get_range_inclusive_query_with_non_unique_subquery() {
     let path_query = PathQuery::new_unsized(path, query.clone());
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, true, None)
+        .query_item_value(&path_query, true, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -602,7 +602,7 @@ fn test_get_range_inclusive_query_with_non_unique_subquery_on_references() {
     let path_query = PathQuery::new_unsized(path, query.clone());
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, true, None)
+        .query_item_value(&path_query, true, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -642,7 +642,7 @@ fn test_get_range_inclusive_query_with_unique_subquery() {
     let path_query = PathQuery::new_unsized(path, query.clone());
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, true, None)
+        .query_item_value(&path_query, true, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -680,7 +680,7 @@ fn test_get_range_from_query_with_non_unique_subquery() {
     let path_query = PathQuery::new_unsized(path, query.clone());
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, true, None)
+        .query_item_value(&path_query, true, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -717,7 +717,7 @@ fn test_get_range_from_query_with_unique_subquery() {
     let path_query = PathQuery::new_unsized(path, query.clone());
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, true, None)
+        .query_item_value(&path_query, true, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -755,7 +755,7 @@ fn test_get_range_to_query_with_non_unique_subquery() {
     let path_query = PathQuery::new_unsized(path, query.clone());
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, true, None)
+        .query_item_value(&path_query, true, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -792,7 +792,7 @@ fn test_get_range_to_query_with_unique_subquery() {
     let path_query = PathQuery::new_unsized(path, query.clone());
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, true, None)
+        .query_item_value(&path_query, true, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -830,7 +830,7 @@ fn test_get_range_to_inclusive_query_with_non_unique_subquery() {
     let path_query = PathQuery::new_unsized(path, query.clone());
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, true, None)
+        .query_item_value(&path_query, true, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -870,7 +870,7 @@ fn test_get_range_to_inclusive_query_with_non_unique_subquery_and_key_out_of_bou
     let path_query = PathQuery::new_unsized(path, query.clone());
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, true, None)
+        .query_item_value(&path_query, true, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -907,7 +907,7 @@ fn test_get_range_to_inclusive_query_with_unique_subquery() {
     let path_query = PathQuery::new_unsized(path, query.clone());
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, true, None)
+        .query_item_value(&path_query, true, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -945,7 +945,7 @@ fn test_get_range_after_query_with_non_unique_subquery() {
     let path_query = PathQuery::new_unsized(path, query.clone());
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, true, None)
+        .query_item_value(&path_query, true, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -985,7 +985,7 @@ fn test_get_range_after_to_query_with_non_unique_subquery() {
     let path_query = PathQuery::new_unsized(path, query.clone());
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, true, None)
+        .query_item_value(&path_query, true, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -1027,7 +1027,7 @@ fn test_get_range_after_to_inclusive_query_with_non_unique_subquery() {
     let path_query = PathQuery::new_unsized(path, query.clone());
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, true, None)
+        .query_item_value(&path_query, true, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -1069,7 +1069,7 @@ fn test_get_range_after_to_inclusive_query_with_non_unique_subquery_and_key_out_
     let path_query = PathQuery::new_unsized(path, query.clone());
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, true, None)
+        .query_item_value(&path_query, true, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -1117,7 +1117,7 @@ fn test_get_range_inclusive_query_with_double_non_unique_subquery() {
     let path_query = PathQuery::new_unsized(path, query.clone());
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, true, None)
+        .query_item_value(&path_query, true, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -1156,7 +1156,7 @@ fn test_get_range_query_with_limit_and_offset() {
     let path_query = PathQuery::new(path.clone(), SizedQuery::new(query.clone(), None, None));
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, true, None)
+        .query_item_value(&path_query, true, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -1187,7 +1187,7 @@ fn test_get_range_query_with_limit_and_offset() {
     let path_query = PathQuery::new(path.clone(), SizedQuery::new(query.clone(), None, None));
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, true, None)
+        .query_item_value(&path_query, true, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -1218,7 +1218,7 @@ fn test_get_range_query_with_limit_and_offset() {
     let path_query = PathQuery::new(path.clone(), SizedQuery::new(query.clone(), Some(55), None));
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, true, None)
+        .query_item_value(&path_query, true, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -1249,7 +1249,7 @@ fn test_get_range_query_with_limit_and_offset() {
     );
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, true, None)
+        .query_item_value(&path_query, true, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -1287,7 +1287,7 @@ fn test_get_range_query_with_limit_and_offset() {
     );
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, true, None)
+        .query_item_value(&path_query, true, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -1322,7 +1322,7 @@ fn test_get_range_query_with_limit_and_offset() {
     );
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, true, None)
+        .query_item_value(&path_query, true, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -1343,7 +1343,7 @@ fn test_get_range_query_with_limit_and_offset() {
     );
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, true, None)
+        .query_item_value(&path_query, true, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -1366,7 +1366,7 @@ fn test_get_range_query_with_limit_and_offset() {
     let path_query = PathQuery::new(path, SizedQuery::new(query.clone(), Some(5), Some(2)));
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, true, None)
+        .query_item_value(&path_query, true, true, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 
@@ -1609,7 +1609,7 @@ fn test_mixed_level_proofs() {
 
     let path_query = PathQuery::new_unsized(path.clone(), query.clone());
     let (elements, _) = db
-        .query_item_value(&path_query, true, true, None)
+        .query_item_value(&path_query, true, true, true, None)
         .unwrap()
         .expect("successful get_path_query");
 
@@ -1625,7 +1625,7 @@ fn test_mixed_level_proofs() {
     // Test mixed element proofs with limit and offset
     let path_query = PathQuery::new_unsized(path.clone(), query.clone());
     let (elements, _) = db
-        .query_item_value(&path_query, true, true, None)
+        .query_item_value(&path_query, true, true, true, None)
         .unwrap()
         .expect("successful get_path_query");
 
@@ -1642,7 +1642,7 @@ fn test_mixed_level_proofs() {
 
     let path_query = PathQuery::new(path.clone(), SizedQuery::new(query.clone(), Some(1), None));
     let (elements, _) = db
-        .query_item_value(&path_query, true, true, None)
+        .query_item_value(&path_query, true, true, true, None)
         .unwrap()
         .expect("successful get_path_query");
 
@@ -1660,7 +1660,7 @@ fn test_mixed_level_proofs() {
         SizedQuery::new(query.clone(), Some(3), Some(0)),
     );
     let (elements, _) = db
-        .query_item_value(&path_query, true, true, None)
+        .query_item_value(&path_query, true, true, true, None)
         .unwrap()
         .expect("successful get_path_query");
 
@@ -1678,7 +1678,7 @@ fn test_mixed_level_proofs() {
         SizedQuery::new(query.clone(), Some(4), Some(0)),
     );
     let (elements, _) = db
-        .query_item_value(&path_query, true, true, None)
+        .query_item_value(&path_query, true, true, true, None)
         .unwrap()
         .expect("successful get_path_query");
 
@@ -1693,7 +1693,7 @@ fn test_mixed_level_proofs() {
 
     let path_query = PathQuery::new(path, SizedQuery::new(query.clone(), Some(10), Some(4)));
     let (elements, _) = db
-        .query_item_value(&path_query, true, true, None)
+        .query_item_value(&path_query, true, true, true, None)
         .unwrap()
         .expect("successful get_path_query");
 
@@ -1790,6 +1790,7 @@ fn test_mixed_level_proofs_with_tree() {
             &path_query,
             true,
             true,
+            true,
             QueryResultType::QueryPathKeyElementTrioResultType,
             None,
         )
@@ -1811,6 +1812,7 @@ fn test_mixed_level_proofs_with_tree() {
     let (elements, _) = db
         .query_raw(
             &path_query,
+            true,
             true,
             true,
             QueryResultType::QueryPathKeyElementTrioResultType,

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -183,7 +183,8 @@ impl Query {
                 for key in conditional_keys.into_iter() {
                     if current_len > max_results {
                         return Err(Error::RequestAmountExceeded(format!(
-                            "terminal keys limit exceeded for conditional subqueries, set max is {max_results}, current length is {current_len}",
+                            "terminal keys limit exceeded for conditional subqueries, set max is \
+                             {max_results}, current length is {current_len}",
                         )));
                     }
                     already_added_keys.insert(key.clone());
@@ -203,7 +204,9 @@ impl Query {
                         } else {
                             if current_len == max_results {
                                 return Err(Error::RequestAmountExceeded(format!(
-                                    "terminal keys limit exceeded when subquery path but no subquery, set max is {max_results}, current length is {current_len}",
+                                    "terminal keys limit exceeded when subquery path but no \
+                                     subquery, set max is {max_results}, current length is \
+                                     {current_len}",
                                 )));
                             }
                             // a subquery path but no subquery
@@ -249,7 +252,8 @@ impl Query {
                 }
                 if current_len > max_results {
                     return Err(Error::RequestAmountExceeded(format!(
-                        "terminal keys limit exceeded for items, set max is {max_results}, current len is {current_len}",
+                        "terminal keys limit exceeded for items, set max is {max_results}, \
+                         current len is {current_len}",
                     )));
                 }
                 let mut path = current_path.clone();
@@ -268,7 +272,8 @@ impl Query {
                     } else {
                         if current_len == max_results {
                             return Err(Error::RequestAmountExceeded(format!(
-                                "terminal keys limit exceeded when subquery path but no subquery, set max is {max_results}, current len is {current_len}",
+                                "terminal keys limit exceeded when subquery path but no subquery, \
+                                 set max is {max_results}, current len is {current_len}",
                             )));
                         }
                         // a subquery path but no subquery
@@ -299,7 +304,8 @@ impl Query {
                 } else {
                     if current_len == max_results {
                         return Err(Error::RequestAmountExceeded(format!(
-                            "terminal keys limit exceeded without subquery or subquery path, set max is {max_results}, current len is {current_len}",
+                            "terminal keys limit exceeded without subquery or subquery path, set \
+                             max is {max_results}, current len is {current_len}",
                         )));
                     }
                     result.push((path, key));

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -183,7 +183,7 @@ impl Query {
                 for key in conditional_keys.into_iter() {
                     if current_len > max_results {
                         return Err(Error::RequestAmountExceeded(format!(
-                            "terminal keys limit exceeded, set max is {max_results}",
+                            "terminal keys limit exceeded for conditional subqueries, set max is {max_results}, current length is {current_len}",
                         )));
                     }
                     already_added_keys.insert(key.clone());
@@ -203,7 +203,7 @@ impl Query {
                         } else {
                             if current_len == max_results {
                                 return Err(Error::RequestAmountExceeded(format!(
-                                    "terminal keys limit exceeded, set max is {max_results}",
+                                    "terminal keys limit exceeded when subquery path but no subquery, set max is {max_results}, current length is {current_len}",
                                 )));
                             }
                             // a subquery path but no subquery
@@ -249,7 +249,7 @@ impl Query {
                 }
                 if current_len > max_results {
                     return Err(Error::RequestAmountExceeded(format!(
-                        "terminal keys limit exceeded, set max is {max_results}",
+                        "terminal keys limit exceeded for items, set max is {max_results}, current len is {current_len}",
                     )));
                 }
                 let mut path = current_path.clone();
@@ -268,7 +268,7 @@ impl Query {
                     } else {
                         if current_len == max_results {
                             return Err(Error::RequestAmountExceeded(format!(
-                                "terminal keys limit exceeded, set max is {max_results}",
+                                "terminal keys limit exceeded when subquery path but no subquery, set max is {max_results}, current len is {current_len}",
                             )));
                         }
                         // a subquery path but no subquery
@@ -299,7 +299,7 @@ impl Query {
                 } else {
                     if current_len == max_results {
                         return Err(Error::RequestAmountExceeded(format!(
-                            "terminal keys limit exceeded, set max is {max_results}",
+                            "terminal keys limit exceeded without subquery or subquery path, set max is {max_results}, current len is {current_len}",
                         )));
                     }
                     result.push((path, key));

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -197,8 +197,7 @@ impl Query {
                             // push the subquery path to the path
                             path.extend(subquery_path.iter().cloned());
                             // recurse onto the lower level
-                            let added_here =
-                                subquery.terminal_keys(path, max_results, result)?;
+                            let added_here = subquery.terminal_keys(path, max_results, result)?;
                             added += added_here;
                             current_len += added_here;
                         } else {
@@ -265,8 +264,7 @@ impl Query {
                         // push the subquery path to the path
                         path.extend(subquery_path.iter().cloned());
                         // recurse onto the lower level
-                        let added_here =
-                            subquery.terminal_keys(path, max_results, result)?;
+                        let added_here = subquery.terminal_keys(path, max_results, result)?;
                         added += added_here;
                         current_len += added_here;
                     } else {
@@ -297,8 +295,7 @@ impl Query {
                     // push the key to the path
                     path.push(key);
                     // recurse onto the lower level
-                    let added_here =
-                        subquery.terminal_keys(path, max_results, result)?;
+                    let added_here = subquery.terminal_keys(path, max_results, result)?;
                     added += added_here;
                     current_len += added_here;
                 } else {

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -198,7 +198,7 @@ impl Query {
                             path.extend(subquery_path.iter().cloned());
                             // recurse onto the lower level
                             let added_here =
-                                subquery.terminal_keys(path, max_results - current_len, result)?;
+                                subquery.terminal_keys(path, max_results, result)?;
                             added += added_here;
                             current_len += added_here;
                         } else {
@@ -266,7 +266,7 @@ impl Query {
                         path.extend(subquery_path.iter().cloned());
                         // recurse onto the lower level
                         let added_here =
-                            subquery.terminal_keys(path, max_results - current_len, result)?;
+                            subquery.terminal_keys(path, max_results, result)?;
                         added += added_here;
                         current_len += added_here;
                     } else {
@@ -298,7 +298,7 @@ impl Query {
                     path.push(key);
                     // recurse onto the lower level
                     let added_here =
-                        subquery.terminal_keys(path, max_results - current_len, result)?;
+                        subquery.terminal_keys(path, max_results, result)?;
                     added += added_here;
                     current_len += added_here;
                 } else {

--- a/node-grove/src/lib.rs
+++ b/node-grove/src/lib.rs
@@ -664,6 +664,7 @@ impl GroveDbWrapper {
                     &path_query,
                     allows_cache,
                     true,
+                    true,
                     using_transaction.then_some(transaction).flatten(),
                 )
                 .unwrap(); // Todo: Costs;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
If a tree on an intermediate path on a subquery path was not present we would receive an error. Now instead we have a field to allow this situation or not. If the option is set to false (don't error), then we simply don't error, any query for any item in that path will simply give back a None value.

Also we fixed an issue with terminal paths.


## What was done?
<!--- Describe your changes in detail -->


## How Has This Been Tested?
Added a test to verify this works as intended.

## Breaking Changes
Breaking in the sense that method calls have changed.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated relevant unit/integration/functional/e2e tests
- [X] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
