### PR TITLE
feat: added version in state sync

### DIFF
--- a/grovedb/src/replication.rs
+++ b/grovedb/src/replication.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     fmt,
-    str::Utf8Error,
 };
 
 use grovedb_merk::{
@@ -278,7 +277,7 @@ impl GroveDb {
                     }
                     Some(t) => {
                         let merk = self
-                            .open_transactional_merk_at_path(path.into(), &t, None)
+                            .open_transactional_merk_at_path(path.into(), t, None)
                             .value?;
 
                         if merk.is_empty_tree().unwrap() {


### PR DESCRIPTION
## Issue being fixed or feature implemented
State sync wasn't versioned. This needs to be addressed as state sync protocol will probably be upgraded in the future.

## What was done?
Added `version` field in all state sync APIs.
Now, only `CURRENT_STATE_SYNC_VERSION` (=1) is supported. Any other version will be rejected.

## How Has This Been Tested?


## Breaking Changes


## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
