### PR TITLE
Feat: chunk ids as vec bytes

### DIFF
--- a/grovedb/src/replication.rs
+++ b/grovedb/src/replication.rs
@@ -246,7 +246,7 @@ impl GroveDb {
                                         "Unable to create to load chunk".to_string(),
                                     )),
                                 }
-                            },
+                            }
                             Err(_) => Err(Error::CorruptedData(
                                 "Unable to create Chunk producer".to_string(),
                             )),
@@ -271,7 +271,7 @@ impl GroveDb {
                                         "Unable to create to load chunk".to_string(),
                                     )),
                                 }
-                            },
+                            }
                             Err(_) => Err(Error::CorruptedData(
                                 "Unable to create Chunk producer".to_string(),
                             )),

--- a/grovedb/src/replication.rs
+++ b/grovedb/src/replication.rs
@@ -89,7 +89,7 @@ pub fn util_path_to_string(path: &[Vec<u8>]) -> Vec<String> {
 // Splits the given global chunk id into [SUBTREE_PREFIX:CHUNK_ID]
 pub fn util_split_global_chunk_id(
     global_chunk_id: &[u8],
-) -> Result<(crate::SubtreePrefix, String), Error> {
+) -> Result<(crate::SubtreePrefix, Vec<u8>), Error> {
     let chunk_prefix_length: usize = 32;
     if global_chunk_id.len() < chunk_prefix_length {
         return Err(Error::CorruptedData(
@@ -101,13 +101,7 @@ pub fn util_split_global_chunk_id(
     let mut array = [0u8; 32];
     array.copy_from_slice(chunk_prefix);
     let chunk_prefix_key: crate::SubtreePrefix = array;
-    let str_chunk_id = String::from_utf8(chunk_id.to_vec());
-    match str_chunk_id {
-        Ok(s) => Ok((chunk_prefix_key, s)),
-        Err(_) => Err(Error::CorruptedData(
-            "unable to convert chunk id to string".to_string(),
-        )),
-    }
+    Ok((chunk_prefix_key, chunk_id.to_vec()))
 }
 
 #[cfg(feature = "full")]
@@ -244,19 +238,14 @@ impl GroveDb {
 
                         let chunk_producer_res = ChunkProducer::new(&merk);
                         match chunk_producer_res {
-                            Ok(mut chunk_producer) => match std::str::from_utf8(chunk_id) {
-                                Ok(chunk_id_str) => {
-                                    let chunk_res = chunk_producer.chunk(chunk_id_str);
-                                    match chunk_res {
-                                        Ok((chunk, _)) => Ok(chunk),
-                                        Err(_) => Err(Error::CorruptedData(
-                                            "Unable to create to load chunk".to_string(),
-                                        )),
-                                    }
+                            Ok(mut chunk_producer) => {
+                                let chunk_res = chunk_producer.chunk(chunk_id);
+                                match chunk_res {
+                                    Ok((chunk, _)) => Ok(chunk),
+                                    Err(_) => Err(Error::CorruptedData(
+                                        "Unable to create to load chunk".to_string(),
+                                    )),
                                 }
-                                Err(_) => Err(Error::CorruptedData(
-                                    "Unable to process chunk id".to_string(),
-                                )),
                             },
                             Err(_) => Err(Error::CorruptedData(
                                 "Unable to create Chunk producer".to_string(),
@@ -274,19 +263,14 @@ impl GroveDb {
 
                         let chunk_producer_res = ChunkProducer::new(&merk);
                         match chunk_producer_res {
-                            Ok(mut chunk_producer) => match std::str::from_utf8(chunk_id) {
-                                Ok(chunk_id_str) => {
-                                    let chunk_res = chunk_producer.chunk(chunk_id_str);
-                                    match chunk_res {
-                                        Ok((chunk, _)) => Ok(chunk),
-                                        Err(_) => Err(Error::CorruptedData(
-                                            "Unable to create to load chunk".to_string(),
-                                        )),
-                                    }
+                            Ok(mut chunk_producer) => {
+                                let chunk_res = chunk_producer.chunk(chunk_id);
+                                match chunk_res {
+                                    Ok((chunk, _)) => Ok(chunk),
+                                    Err(_) => Err(Error::CorruptedData(
+                                        "Unable to create to load chunk".to_string(),
+                                    )),
                                 }
-                                Err(_) => Err(Error::CorruptedData(
-                                    "Unable to process chunk id".to_string(),
-                                )),
                             },
                             Err(_) => Err(Error::CorruptedData(
                                 "Unable to create Chunk producer".to_string(),
@@ -380,12 +364,12 @@ impl GroveDb {
                 }
                 state_sync_info.pending_chunks.remove(global_chunk_id);
                 if !chunk_data.is_empty() {
-                    match restorer.process_chunk(chunk_id.to_string(), chunk_data) {
+                    match restorer.process_chunk(&chunk_id, chunk_data) {
                         Ok(next_chunk_ids) => {
                             state_sync_info.num_processed_chunks += 1;
                             for next_chunk_id in next_chunk_ids {
                                 let mut next_global_chunk_id = chunk_prefix.to_vec();
-                                next_global_chunk_id.extend(next_chunk_id.as_bytes().to_vec());
+                                next_global_chunk_id.extend(next_chunk_id.to_vec());
                                 state_sync_info
                                     .pending_chunks
                                     .insert(next_global_chunk_id.clone());

--- a/merk/src/merk/chunks.rs
+++ b/merk/src/merk/chunks.rs
@@ -41,7 +41,6 @@ use crate::{
                 chunk_height, chunk_index_from_traversal_instruction,
                 chunk_index_from_traversal_instruction_with_recovery, generate_traversal_instruction,
                 number_of_chunks,
-                string_as_traversal_instruction,
             },
         },
         Node, Op,

--- a/merk/src/merk/chunks.rs
+++ b/merk/src/merk/chunks.rs
@@ -39,9 +39,9 @@ use crate::{
             error::ChunkError,
             util::{
                 chunk_height, chunk_index_from_traversal_instruction,
-                chunk_index_from_traversal_instruction_with_recovery, generate_traversal_instruction,
-                generate_traversal_instruction_as_vec_bytes, vec_bytes_as_traversal_instruction,
-                number_of_chunks,
+                chunk_index_from_traversal_instruction_with_recovery,
+                generate_traversal_instruction, generate_traversal_instruction_as_vec_bytes,
+                number_of_chunks, vec_bytes_as_traversal_instruction,
             },
         },
         Node, Op,
@@ -383,7 +383,9 @@ where
             self.chunk_with_index(self.index)
                 .and_then(|(chunk, chunk_index)| {
                     chunk_index
-                        .map(|index| generate_traversal_instruction_as_vec_bytes(self.height, index))
+                        .map(|index| {
+                            generate_traversal_instruction_as_vec_bytes(self.height, index)
+                        })
                         .transpose()
                         .map(|v| (chunk, v))
                 }),

--- a/merk/src/merk/chunks.rs
+++ b/merk/src/merk/chunks.rs
@@ -187,11 +187,11 @@ where
     /// chunks or hit some optional limit
     pub fn multi_chunk_with_limit(
         &mut self,
-        chunk_id: &str,
+        chunk_id: &[u8],
         limit: Option<usize>,
     ) -> Result<MultiChunk, Error> {
         // we want to convert the chunk id to the index
-        let chunk_index = string_as_traversal_instruction(chunk_id).and_then(|instruction| {
+        let chunk_index = vec_bytes_as_traversal_instruction(chunk_id).and_then(|instruction| {
             chunk_index_from_traversal_instruction(instruction.as_slice(), self.height)
         })?;
         self.multi_chunk_with_limit_and_index(chunk_index, limit)
@@ -434,6 +434,7 @@ mod test {
         tree::RefWalker,
         PanicSource,
     };
+    use crate::proofs::chunk::util::traversal_instruction_as_vec_bytes;
 
     #[derive(Default)]
     struct NodeCounts {
@@ -1028,7 +1029,7 @@ mod test {
 
         // ensure that the remaining limit, next index and values given are correct
         // if limit is smaller than first chunk, we should get an error
-        let chunk_result = chunk_producer.multi_chunk_with_limit("", Some(5));
+        let chunk_result = chunk_producer.multi_chunk_with_limit(vec![].as_slice(), Some(5));
         assert!(matches!(
             chunk_result,
             Err(Error::ChunkingError(ChunkError::LimitTooSmall(..)))
@@ -1053,7 +1054,7 @@ mod test {
             .expect("should generate chunk");
         assert_eq!(
             chunk_result.next_index,
-            Some(traversal_instruction_as_string(
+            Some(traversal_instruction_as_vec_bytes(
                 &generate_traversal_instruction(4, 4).unwrap()
             ))
         );

--- a/merk/src/merk/mod.rs
+++ b/merk/src/merk/mod.rs
@@ -63,7 +63,7 @@ use crate::{
     proofs::{
         chunk::{
             chunk::{LEFT, RIGHT},
-            util::traversal_instruction_as_string,
+            util::traversal_instruction_as_vec_bytes,
         },
         query::query_item::QueryItem,
         Query,
@@ -75,7 +75,6 @@ use crate::{
     Link,
     MerkType::{BaseMerk, LayeredMerk, StandaloneMerk},
 };
-use crate::proofs::chunk::util::traversal_instruction_as_vec_bytes;
 
 /// Key update types
 pub struct KeyUpdates {

--- a/merk/src/merk/mod.rs
+++ b/merk/src/merk/mod.rs
@@ -75,6 +75,7 @@ use crate::{
     Link,
     MerkType::{BaseMerk, LayeredMerk, StandaloneMerk},
 };
+use crate::proofs::chunk::util::traversal_instruction_as_vec_bytes;
 
 /// Key update types
 pub struct KeyUpdates {
@@ -556,11 +557,11 @@ where
     pub fn verify(
         &self,
         skip_sum_checks: bool,
-    ) -> (BTreeMap<String, CryptoHash>, BTreeMap<String, Vec<u8>>) {
+    ) -> (BTreeMap<Vec<u8>, CryptoHash>, BTreeMap<Vec<u8>, Vec<u8>>) {
         let tree = self.tree.take();
 
-        let mut bad_link_map: BTreeMap<String, CryptoHash> = BTreeMap::new();
-        let mut parent_keys: BTreeMap<String, Vec<u8>> = BTreeMap::new();
+        let mut bad_link_map: BTreeMap<Vec<u8>, CryptoHash> = BTreeMap::new();
+        let mut parent_keys: BTreeMap<Vec<u8>, Vec<u8>> = BTreeMap::new();
         let mut root_traversal_instruction = vec![];
 
         // TODO: remove clone
@@ -581,8 +582,8 @@ where
         &self,
         tree: &TreeNode,
         traversal_instruction: &mut Vec<bool>,
-        bad_link_map: &mut BTreeMap<String, CryptoHash>,
-        parent_keys: &mut BTreeMap<String, Vec<u8>>,
+        bad_link_map: &mut BTreeMap<Vec<u8>, CryptoHash>,
+        parent_keys: &mut BTreeMap<Vec<u8>, Vec<u8>>,
         skip_sum_checks: bool,
     ) {
         if let Some(link) = tree.link(LEFT) {
@@ -617,8 +618,8 @@ where
         link: &Link,
         parent_key: &[u8],
         traversal_instruction: &mut Vec<bool>,
-        bad_link_map: &mut BTreeMap<String, CryptoHash>,
-        parent_keys: &mut BTreeMap<String, Vec<u8>>,
+        bad_link_map: &mut BTreeMap<Vec<u8>, CryptoHash>,
+        parent_keys: &mut BTreeMap<Vec<u8>, Vec<u8>>,
         skip_sum_checks: bool,
     ) {
         let (hash, key, sum) = match link {
@@ -639,7 +640,7 @@ where
             _ => todo!(),
         };
 
-        let instruction_id = traversal_instruction_as_string(traversal_instruction);
+        let instruction_id = traversal_instruction_as_vec_bytes(traversal_instruction);
         let node = TreeNode::get(
             &self.storage,
             key,
@@ -648,29 +649,29 @@ where
         .unwrap();
 
         if node.is_err() {
-            bad_link_map.insert(instruction_id.clone(), hash);
-            parent_keys.insert(instruction_id, parent_key.to_vec());
+            bad_link_map.insert(instruction_id.to_vec(), hash);
+            parent_keys.insert(instruction_id.to_vec(), parent_key.to_vec());
             return;
         }
 
         let node = node.unwrap();
         if node.is_none() {
-            bad_link_map.insert(instruction_id.clone(), hash);
-            parent_keys.insert(instruction_id, parent_key.to_vec());
+            bad_link_map.insert(instruction_id.to_vec(), hash);
+            parent_keys.insert(instruction_id.to_vec(), parent_key.to_vec());
             return;
         }
 
         let node = node.unwrap();
         if node.hash().unwrap() != hash {
-            bad_link_map.insert(instruction_id.clone(), hash);
-            parent_keys.insert(instruction_id, parent_key.to_vec());
+            bad_link_map.insert(instruction_id.to_vec(), hash);
+            parent_keys.insert(instruction_id.to_vec(), parent_key.to_vec());
             return;
         }
 
         // Need to skip this when restoring a sum tree
         if !skip_sum_checks && node.sum().unwrap() != sum {
-            bad_link_map.insert(instruction_id.clone(), hash);
-            parent_keys.insert(instruction_id, parent_key.to_vec());
+            bad_link_map.insert(instruction_id.to_vec(), hash);
+            parent_keys.insert(instruction_id.to_vec(), parent_key.to_vec());
             return;
         }
 

--- a/merk/src/merk/restore.rs
+++ b/merk/src/merk/restore.rs
@@ -41,7 +41,7 @@ use crate::{
             chunk::{LEFT, RIGHT},
             chunk_op::ChunkOp,
             error::{ChunkError, ChunkError::InternalError},
-            util::{string_as_traversal_instruction, traversal_instruction_as_string, vec_bytes_as_traversal_instruction, traversal_instruction_as_vec_bytes},
+            util::{vec_bytes_as_traversal_instruction, traversal_instruction_as_vec_bytes},
         },
         tree::{execute, Child, Tree as ProofTree},
         Node, Op,

--- a/merk/src/proofs/chunk/util.rs
+++ b/merk/src/proofs/chunk/util.rs
@@ -171,7 +171,10 @@ fn exit_node_count(height: usize) -> usize {
 }
 
 /// Generate instruction for traversing to a given chunk index in a binary tree
-pub fn generate_traversal_instruction(height: usize, chunk_index: usize) -> Result<Vec<bool>, Error> {
+pub fn generate_traversal_instruction(
+    height: usize,
+    chunk_index: usize,
+) -> Result<Vec<bool>, Error> {
     let mut instructions = vec![];
 
     let total_chunk_count = number_of_chunks(height);
@@ -226,8 +229,8 @@ pub fn generate_traversal_instruction(height: usize, chunk_index: usize) -> Resu
     Ok(instructions)
 }
 
-/// Determine the chunk index given the traversal instruction and the max height of
-/// the tree
+/// Determine the chunk index given the traversal instruction and the max height
+/// of the tree
 pub fn chunk_index_from_traversal_instruction(
     traversal_instruction: &[bool],
     height: usize,
@@ -309,8 +312,8 @@ pub fn chunk_index_from_traversal_instruction(
     Ok(current_chunk_index)
 }
 
-/// Determine the chunk index given the traversal instruction and the max height of
-/// the tree. This can recover from traversal instructions not pointing to a
+/// Determine the chunk index given the traversal instruction and the max height
+/// of the tree. This can recover from traversal instructions not pointing to a
 /// chunk boundary, in such a case, it backtracks until it hits a chunk
 /// boundary.
 pub fn chunk_index_from_traversal_instruction_with_recovery(
@@ -349,7 +352,9 @@ pub fn traversal_instruction_as_vec_bytes(instruction: &[bool]) -> Vec<u8> {
 
 /// Converts a vec bytes that represents a traversal instruction
 /// to a vec of bool, true = left and false = right
-pub fn vec_bytes_as_traversal_instruction(instruction_vec_bytes: &[u8]) -> Result<Vec<bool>, Error> {
+pub fn vec_bytes_as_traversal_instruction(
+    instruction_vec_bytes: &[u8],
+) -> Result<Vec<bool>, Error> {
     instruction_vec_bytes
         .iter()
         .map(|byte| match byte {
@@ -579,8 +584,14 @@ mod test {
 
     #[test]
     fn test_instruction_string_to_traversal_instruction() {
-        assert_eq!(vec_bytes_as_traversal_instruction(&vec![1u8]).unwrap(), vec![LEFT]);
-        assert_eq!(vec_bytes_as_traversal_instruction(&vec![0u8]).unwrap(), vec![RIGHT]);
+        assert_eq!(
+            vec_bytes_as_traversal_instruction(&vec![1u8]).unwrap(),
+            vec![LEFT]
+        );
+        assert_eq!(
+            vec_bytes_as_traversal_instruction(&vec![0u8]).unwrap(),
+            vec![RIGHT]
+        );
         assert_eq!(
             vec_bytes_as_traversal_instruction(&vec![0u8, 0u8, 1u8]).unwrap(),
             vec![RIGHT, RIGHT, LEFT]

--- a/merk/src/proofs/chunk/util.rs
+++ b/merk/src/proofs/chunk/util.rs
@@ -327,16 +327,6 @@ pub fn chunk_index_from_traversal_instruction_with_recovery(
     chunk_index_result
 }
 
-/// Generate instruction for traversing to a given chunk in a binary tree,
-/// returns string representation
-pub fn generate_traversal_instruction_as_string(
-    height: usize,
-    chunk_id: usize,
-) -> Result<String, Error> {
-    let instruction = generate_traversal_instruction(height, chunk_id)?;
-    Ok(traversal_instruction_as_string(&instruction))
-}
-
 /// Generate instruction for traversing to a given chunk index in a binary tree,
 /// returns vec bytes representation
 pub fn generate_traversal_instruction_as_vec_bytes(
@@ -345,16 +335,6 @@ pub fn generate_traversal_instruction_as_vec_bytes(
 ) -> Result<Vec<u8>, Error> {
     let instruction = generate_traversal_instruction(height, chunk_index)?;
     Ok(traversal_instruction_as_vec_bytes(&instruction))
-}
-
-/// Convert traversal instruction to byte string
-/// 1 represents left (true)
-/// 0 represents right (false)
-pub fn traversal_instruction_as_string(instruction: &[bool]) -> String {
-    instruction
-        .iter()
-        .map(|v| if *v { "1" } else { "0" })
-        .collect()
 }
 
 /// Convert traversal instruction to bytes vec
@@ -382,12 +362,10 @@ pub fn vec_bytes_as_traversal_instruction(instruction_vec_bytes: &[u8]) -> Resul
         .collect()
 }
 
-/*
 pub fn write_to_vec<W: Write>(dest: &mut W, value: &[u8]) -> Result<(), Error> {
     dest.write_all(value)
         .map_err(|_e| InternalError("failed to write to vector"))
 }
-*/
 
 #[cfg(test)]
 mod test {
@@ -590,12 +568,12 @@ mod test {
 
     #[test]
     fn test_traversal_instruction_as_string() {
-        assert_eq!(traversal_instruction_as_string(&vec![]), "");
-        assert_eq!(traversal_instruction_as_string(&vec![LEFT]), "1");
-        assert_eq!(traversal_instruction_as_string(&vec![RIGHT]), "0");
+        assert_eq!(traversal_instruction_as_vec_bytes(&vec![]), vec![]);
+        assert_eq!(traversal_instruction_as_vec_bytes(&vec![LEFT]), vec![1u8]);
+        assert_eq!(traversal_instruction_as_vec_bytes(&vec![RIGHT]), vec![0u8]);
         assert_eq!(
-            traversal_instruction_as_string(&vec![RIGHT, LEFT, LEFT, RIGHT]),
-            "0110"
+            traversal_instruction_as_vec_bytes(&vec![RIGHT, LEFT, LEFT, RIGHT]),
+            vec![0u8, 1u8, 1u8, 0u8]
         );
     }
 

--- a/merk/src/proofs/chunk/util.rs
+++ b/merk/src/proofs/chunk/util.rs
@@ -170,14 +170,14 @@ fn exit_node_count(height: usize) -> usize {
     2_usize.pow(height as u32)
 }
 
-/// Generate instruction for traversing to a given chunk in a binary tree
-pub fn generate_traversal_instruction(height: usize, chunk_id: usize) -> Result<Vec<bool>, Error> {
+/// Generate instruction for traversing to a given chunk index in a binary tree
+pub fn generate_traversal_instruction(height: usize, chunk_index: usize) -> Result<Vec<bool>, Error> {
     let mut instructions = vec![];
 
     let total_chunk_count = number_of_chunks(height);
 
     // out of bounds
-    if chunk_id < 1 || chunk_id > total_chunk_count {
+    if chunk_index < 1 || chunk_index > total_chunk_count {
         return Err(Error::ChunkingError(ChunkError::OutOfBounds(
             "chunk id out of bounds",
         )));
@@ -202,7 +202,7 @@ pub fn generate_traversal_instruction(height: usize, chunk_id: usize) -> Result<
             // checks if we last decision we made got us to the desired chunk id
             let advance_result = chunk_range.advance_range_start().unwrap();
             chunk_range = advance_result.0;
-            if advance_result.1 == chunk_id {
+            if advance_result.1 == chunk_index {
                 return Ok(instructions);
             }
         } else {
@@ -211,7 +211,7 @@ pub fn generate_traversal_instruction(height: usize, chunk_id: usize) -> Result<
             // we first check which half the desired chunk is
             // then follow that path
             let chunk_id_half = chunk_range
-                .which_half(chunk_id)
+                .which_half(chunk_index)
                 .expect("chunk id must exist in range");
             instructions.push(chunk_id_half);
             chunk_range = chunk_range
@@ -226,9 +226,9 @@ pub fn generate_traversal_instruction(height: usize, chunk_id: usize) -> Result<
     Ok(instructions)
 }
 
-/// Determine the chunk id given the traversal instruction and the max height of
+/// Determine the chunk index given the traversal instruction and the max height of
 /// the tree
-pub fn chunk_id_from_traversal_instruction(
+pub fn chunk_index_from_traversal_instruction(
     traversal_instruction: &[bool],
     height: usize,
 ) -> Result<usize, Error> {
@@ -238,7 +238,7 @@ pub fn chunk_id_from_traversal_instruction(
     }
 
     let mut chunk_count = number_of_chunks(height);
-    let mut current_chunk_id = 1;
+    let mut current_chunk_index = 1;
 
     let mut layer_heights = chunk_height_per_layer(height);
     let last_layer_height = layer_heights.pop().expect("confirmed not empty");
@@ -301,30 +301,30 @@ pub fn chunk_id_from_traversal_instruction(
 
         chunk_count /= exit_node_count(layer_height);
 
-        current_chunk_id = current_chunk_id + offset_multiplier * chunk_count + 1;
+        current_chunk_index = current_chunk_index + offset_multiplier * chunk_count + 1;
 
         start_index = end_index;
     }
 
-    Ok(current_chunk_id)
+    Ok(current_chunk_index)
 }
 
-/// Determine the chunk id given the traversal instruction and the max height of
+/// Determine the chunk index given the traversal instruction and the max height of
 /// the tree. This can recover from traversal instructions not pointing to a
 /// chunk boundary, in such a case, it backtracks until it hits a chunk
 /// boundary.
-pub fn chunk_id_from_traversal_instruction_with_recovery(
+pub fn chunk_index_from_traversal_instruction_with_recovery(
     traversal_instruction: &[bool],
     height: usize,
 ) -> Result<usize, Error> {
-    let chunk_id_result = chunk_id_from_traversal_instruction(traversal_instruction, height);
-    if chunk_id_result.is_err() {
-        return chunk_id_from_traversal_instruction_with_recovery(
+    let chunk_index_result = chunk_index_from_traversal_instruction(traversal_instruction, height);
+    if chunk_index_result.is_err() {
+        return chunk_index_from_traversal_instruction_with_recovery(
             &traversal_instruction[0..traversal_instruction.len() - 1],
             height,
         );
     }
-    chunk_id_result
+    chunk_index_result
 }
 
 /// Generate instruction for traversing to a given chunk in a binary tree,
@@ -337,6 +337,16 @@ pub fn generate_traversal_instruction_as_string(
     Ok(traversal_instruction_as_string(&instruction))
 }
 
+/// Generate instruction for traversing to a given chunk index in a binary tree,
+/// returns vec bytes representation
+pub fn generate_traversal_instruction_as_vec_bytes(
+    height: usize,
+    chunk_index: usize,
+) -> Result<Vec<u8>, Error> {
+    let instruction = generate_traversal_instruction(height, chunk_index)?;
+    Ok(traversal_instruction_as_vec_bytes(&instruction))
+}
+
 /// Convert traversal instruction to byte string
 /// 1 represents left (true)
 /// 0 represents right (false)
@@ -344,6 +354,16 @@ pub fn traversal_instruction_as_string(instruction: &[bool]) -> String {
     instruction
         .iter()
         .map(|v| if *v { "1" } else { "0" })
+        .collect()
+}
+
+/// Convert traversal instruction to bytes vec
+/// 1 represents left (true)
+/// 0 represents right (false)
+pub fn traversal_instruction_as_vec_bytes(instruction: &[bool]) -> Vec<u8> {
+    instruction
+        .iter()
+        .map(|v| if *v { 1u8 } else { 0u8 })
         .collect()
 }
 
@@ -362,10 +382,27 @@ pub fn string_as_traversal_instruction(instruction_string: &str) -> Result<Vec<b
         .collect()
 }
 
+/// Converts a vec bytes that represents a traversal instruction
+/// to a vec of bool, true = left and false = right
+pub fn vec_bytes_as_traversal_instruction(instruction_vec_bytes: &[u8]) -> Result<Vec<bool>, Error> {
+    instruction_vec_bytes
+        .iter()
+        .map(|byte| match byte {
+            1u8 => Ok(LEFT),
+            0u8 => Ok(RIGHT),
+            _ => Err(Error::ChunkingError(ChunkError::BadTraversalInstruction(
+                "failed to parse instruction vec bytes",
+            ))),
+        })
+        .collect()
+}
+
+/*
 pub fn write_to_vec<W: Write>(dest: &mut W, value: &[u8]) -> Result<(), Error> {
     dest.write_all(value)
         .map_err(|_e| InternalError("failed to write to vector"))
 }
+*/
 
 #[cfg(test)]
 mod test {
@@ -597,69 +634,69 @@ mod test {
         // tree of height 4
         let traversal_instruction = generate_traversal_instruction(4, 1).unwrap();
         assert_eq!(
-            chunk_id_from_traversal_instruction(traversal_instruction.as_slice(), 4).unwrap(),
+            chunk_index_from_traversal_instruction(traversal_instruction.as_slice(), 4).unwrap(),
             1
         );
         let traversal_instruction = generate_traversal_instruction(4, 2).unwrap();
         assert_eq!(
-            chunk_id_from_traversal_instruction(traversal_instruction.as_slice(), 4).unwrap(),
+            chunk_index_from_traversal_instruction(traversal_instruction.as_slice(), 4).unwrap(),
             2
         );
         let traversal_instruction = generate_traversal_instruction(4, 3).unwrap();
         assert_eq!(
-            chunk_id_from_traversal_instruction(traversal_instruction.as_slice(), 4).unwrap(),
+            chunk_index_from_traversal_instruction(traversal_instruction.as_slice(), 4).unwrap(),
             3
         );
         let traversal_instruction = generate_traversal_instruction(4, 4).unwrap();
         assert_eq!(
-            chunk_id_from_traversal_instruction(traversal_instruction.as_slice(), 4).unwrap(),
+            chunk_index_from_traversal_instruction(traversal_instruction.as_slice(), 4).unwrap(),
             4
         );
 
         // tree of height 6
         let traversal_instruction = generate_traversal_instruction(6, 1).unwrap();
         assert_eq!(
-            chunk_id_from_traversal_instruction(traversal_instruction.as_slice(), 6).unwrap(),
+            chunk_index_from_traversal_instruction(traversal_instruction.as_slice(), 6).unwrap(),
             1
         );
         let traversal_instruction = generate_traversal_instruction(6, 2).unwrap();
         assert_eq!(
-            chunk_id_from_traversal_instruction(traversal_instruction.as_slice(), 6).unwrap(),
+            chunk_index_from_traversal_instruction(traversal_instruction.as_slice(), 6).unwrap(),
             2
         );
         let traversal_instruction = generate_traversal_instruction(6, 3).unwrap();
         assert_eq!(
-            chunk_id_from_traversal_instruction(traversal_instruction.as_slice(), 6).unwrap(),
+            chunk_index_from_traversal_instruction(traversal_instruction.as_slice(), 6).unwrap(),
             3
         );
         let traversal_instruction = generate_traversal_instruction(6, 4).unwrap();
         assert_eq!(
-            chunk_id_from_traversal_instruction(traversal_instruction.as_slice(), 6).unwrap(),
+            chunk_index_from_traversal_instruction(traversal_instruction.as_slice(), 6).unwrap(),
             4
         );
         let traversal_instruction = generate_traversal_instruction(6, 5).unwrap();
         assert_eq!(
-            chunk_id_from_traversal_instruction(traversal_instruction.as_slice(), 6).unwrap(),
+            chunk_index_from_traversal_instruction(traversal_instruction.as_slice(), 6).unwrap(),
             5
         );
         let traversal_instruction = generate_traversal_instruction(6, 6).unwrap();
         assert_eq!(
-            chunk_id_from_traversal_instruction(traversal_instruction.as_slice(), 6).unwrap(),
+            chunk_index_from_traversal_instruction(traversal_instruction.as_slice(), 6).unwrap(),
             6
         );
         let traversal_instruction = generate_traversal_instruction(6, 7).unwrap();
         assert_eq!(
-            chunk_id_from_traversal_instruction(traversal_instruction.as_slice(), 6).unwrap(),
+            chunk_index_from_traversal_instruction(traversal_instruction.as_slice(), 6).unwrap(),
             7
         );
         let traversal_instruction = generate_traversal_instruction(6, 8).unwrap();
         assert_eq!(
-            chunk_id_from_traversal_instruction(traversal_instruction.as_slice(), 6).unwrap(),
+            chunk_index_from_traversal_instruction(traversal_instruction.as_slice(), 6).unwrap(),
             8
         );
         let traversal_instruction = generate_traversal_instruction(6, 9).unwrap();
         assert_eq!(
-            chunk_id_from_traversal_instruction(traversal_instruction.as_slice(), 6).unwrap(),
+            chunk_index_from_traversal_instruction(traversal_instruction.as_slice(), 6).unwrap(),
             9
         );
     }
@@ -674,26 +711,26 @@ mod test {
         // function with recovery we expect this to backtrack to the last chunk
         // boundary e.g. [left] should backtrack to []
         //      [left, left, right, left] should backtrack to [left, left, right]
-        assert!(chunk_id_from_traversal_instruction(&[LEFT], 5).is_err());
+        assert!(chunk_index_from_traversal_instruction(&[LEFT], 5).is_err());
         assert_eq!(
-            chunk_id_from_traversal_instruction_with_recovery(&[LEFT], 5).unwrap(),
+            chunk_index_from_traversal_instruction_with_recovery(&[LEFT], 5).unwrap(),
             1
         );
         assert_eq!(
-            chunk_id_from_traversal_instruction_with_recovery(&[LEFT, LEFT], 5).unwrap(),
+            chunk_index_from_traversal_instruction_with_recovery(&[LEFT, LEFT], 5).unwrap(),
             1
         );
         assert_eq!(
-            chunk_id_from_traversal_instruction_with_recovery(&[LEFT, LEFT, RIGHT], 5).unwrap(),
+            chunk_index_from_traversal_instruction_with_recovery(&[LEFT, LEFT, RIGHT], 5).unwrap(),
             3
         );
         assert_eq!(
-            chunk_id_from_traversal_instruction_with_recovery(&[LEFT, LEFT, RIGHT, LEFT], 5)
+            chunk_index_from_traversal_instruction_with_recovery(&[LEFT, LEFT, RIGHT, LEFT], 5)
                 .unwrap(),
             3
         );
         assert_eq!(
-            chunk_id_from_traversal_instruction_with_recovery(&[LEFT; 50], 5).unwrap(),
+            chunk_index_from_traversal_instruction_with_recovery(&[LEFT; 50], 5).unwrap(),
             2
         );
     }

--- a/merk/src/proofs/chunk/util.rs
+++ b/merk/src/proofs/chunk/util.rs
@@ -367,21 +367,6 @@ pub fn traversal_instruction_as_vec_bytes(instruction: &[bool]) -> Vec<u8> {
         .collect()
 }
 
-/// Converts a string that represents a traversal instruction
-/// to a vec of bool, true = left and false = right
-pub fn string_as_traversal_instruction(instruction_string: &str) -> Result<Vec<bool>, Error> {
-    instruction_string
-        .chars()
-        .map(|char| match char {
-            '1' => Ok(LEFT),
-            '0' => Ok(RIGHT),
-            _ => Err(Error::ChunkingError(ChunkError::BadTraversalInstruction(
-                "failed to parse instruction string",
-            ))),
-        })
-        .collect()
-}
-
 /// Converts a vec bytes that represents a traversal instruction
 /// to a vec of bool, true = left and false = right
 pub fn vec_bytes_as_traversal_instruction(instruction_vec_bytes: &[u8]) -> Result<Vec<bool>, Error> {
@@ -616,15 +601,15 @@ mod test {
 
     #[test]
     fn test_instruction_string_to_traversal_instruction() {
-        assert_eq!(string_as_traversal_instruction("1").unwrap(), vec![LEFT]);
-        assert_eq!(string_as_traversal_instruction("0").unwrap(), vec![RIGHT]);
+        assert_eq!(vec_bytes_as_traversal_instruction(&vec![1u8]).unwrap(), vec![LEFT]);
+        assert_eq!(vec_bytes_as_traversal_instruction(&vec![0u8]).unwrap(), vec![RIGHT]);
         assert_eq!(
-            string_as_traversal_instruction("001").unwrap(),
+            vec_bytes_as_traversal_instruction(&vec![0u8, 0u8, 1u8]).unwrap(),
             vec![RIGHT, RIGHT, LEFT]
         );
-        assert!(string_as_traversal_instruction("002").is_err());
+        assert!(vec_bytes_as_traversal_instruction(&vec![0u8, 0u8, 2u8]).is_err());
         assert_eq!(
-            string_as_traversal_instruction("").unwrap(),
+            vec_bytes_as_traversal_instruction(&vec![]).unwrap(),
             Vec::<bool>::new()
         );
     }

--- a/tutorials/src/bin/proofs.rs
+++ b/tutorials/src/bin/proofs.rs
@@ -28,7 +28,7 @@ fn main() {
     let path_query = PathQuery::new_unsized(path, query.clone());
     // Execute the query and collect the result items in "elements".
     let (_elements, _) = db
-        .query_item_value(&path_query, true, None)
+        .query_item_value(&path_query, true, false, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 

--- a/tutorials/src/bin/query-complex.rs
+++ b/tutorials/src/bin/query-complex.rs
@@ -66,7 +66,7 @@ fn main() {
 
     // Execute the path query and collect the result items in "elements".
     let (elements, _) = db
-        .query_item_value(&path_query, true, None)
+        .query_item_value(&path_query, true, false, true, None)
         .unwrap()
         .expect("expected successful get_path_query");
 

--- a/tutorials/src/bin/query-simple.rs
+++ b/tutorials/src/bin/query-simple.rs
@@ -36,7 +36,7 @@ fn main() {
 
     // Execute the query and collect the result items in "elements".
     let (elements, _) = db
-        .query_item_value(&path_query, true, None)
+        .query_item_value(&path_query, true, false, true,None)
         .unwrap()
         .expect("expected successful get_path_query");
 

--- a/tutorials/src/bin/replication.rs
+++ b/tutorials/src/bin/replication.rs
@@ -203,7 +203,7 @@ fn query_db(db: &GroveDb, path: &[&[u8]], key: Vec<u8>) {
    let path_query = PathQuery::new_unsized(path_vec, query.clone());
 
     let (elements, _) = db
-        .query_item_value(&path_query, true, None)
+        .query_item_value(&path_query, true, false,true, None)
         .unwrap()
         .expect("expected successful get_path_query");
     for e in elements.into_iter() {


### PR DESCRIPTION
## Issue being fixed or feature implemented
Merk chunking code was using internally string to identify chunks by their traversal instructions: "1" for left and "0" for right.

## What was done?
This PR changes this to `Vec<u8>`. 
In a future PR, we can compact traversal instructions into `bitvec`.

## How Has This Been Tested?
All chunk unit tests were updated.

## Breaking Changes


## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
