### PR TITLE
feat: sync multiple subtrees

### DIFF
--- a/grovedb/src/replication.rs
+++ b/grovedb/src/replication.rs
@@ -398,8 +398,7 @@ impl GroveDb {
         if state_sync_info.current_prefixes.is_empty() {
             return Err(Error::InternalError("GroveDB is not in syncing mode"));
         }
-        if let Some(subtree_state_sync) = state_sync_info.current_prefixes.remove(&chunk_prefix)
-        {
+        if let Some(subtree_state_sync) = state_sync_info.current_prefixes.remove(&chunk_prefix) {
             if let Ok((res, mut new_subtree_state_sync)) =
                 self.apply_inner_chunk(subtree_state_sync, &chunk_id, chunk_data)
             {
@@ -426,9 +425,7 @@ impl GroveDb {
 
                     // Subtree is finished. We can save it.
                     match new_subtree_state_sync.restorer.take() {
-                        None => {
-                            Err(Error::InternalError("Unable to finalize subtree"))
-                        }
+                        None => Err(Error::InternalError("Unable to finalize subtree")),
                         Some(restorer) => {
                             if (new_subtree_state_sync.num_processed_chunks > 0)
                                 && (restorer.finalize().is_err())


### PR DESCRIPTION
## Issue being fixed or feature implemented
Until now, state syncing was made one subtree at a time sequentially. This has an room for optimization. 

## What was done?
Each time a new subtree is synced, grovedb discovers any new subtrees that can be synced and starts fetching for them in parallel.

## How Has This Been Tested?


## Breaking Changes
no

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
