### PR TITLE
fix-tutorials-build

### DIFF
--- a/tutorials/Cargo.toml
+++ b/tutorials/Cargo.toml
@@ -8,11 +8,9 @@ default-run = "tutorials"
 
 [dependencies]
 grovedb = { git = "https://github.com/dashpay/grovedb.git" }
-path = { path = "../path" }
+grovedb-path = { path = "../path" }
 rand = "0.8.5"
 
 [workspace]
 
-exclude = [
-    "tutorials",
-]
+exclude = ["tutorials"]


### PR DESCRIPTION
Fixed error : 
```
$ cargo run --bin query-complex                                                                         
    Updating git repository `https://github.com/dashpay/grovedb.git`                                                   
    Updating crates.io index                               
error: no matching package named `path` found                                                                          
```