### PR TITLE
feat: State sync APIs should use encoded Ops

### DIFF
--- a/grovedb/src/replication.rs
+++ b/grovedb/src/replication.rs
@@ -115,11 +115,9 @@ pub fn util_split_global_chunk_id(
 pub fn util_encode_vec_ops(chunk: Vec<Op>) -> Result<Vec<u8>, Error> {
     let mut res = vec![];
     for op in chunk {
-        if op.encode_into(&mut res).is_err() {
-            return Err(Error::CorruptedData("unable to encode chunk".to_string()));
-        }
+        op.encode_into(&mut res)
+            .map_err(|e| Error::CorruptedData(format!("unable to encode chunk: {}", e)))?;
     }
-
     Ok(res)
 }
 

--- a/grovedb/src/replication.rs
+++ b/grovedb/src/replication.rs
@@ -130,7 +130,10 @@ pub fn util_decode_vec_ops(chunk: Vec<u8>) -> Result<Vec<Op>, Error> {
         match op {
             Ok(op) => res.push(op),
             Err(e) => {
-                return Err(Error::CorruptedData(format!("unable to decode chunk: {}", e)));
+                return Err(Error::CorruptedData(format!(
+                    "unable to decode chunk: {}",
+                    e
+                )));
             }
         }
     }

--- a/grovedb/src/replication.rs
+++ b/grovedb/src/replication.rs
@@ -124,13 +124,13 @@ pub fn util_encode_vec_ops(chunk: Vec<Op>) -> Result<Vec<u8>, Error> {
 }
 
 pub fn util_decode_vec_ops(chunk: Vec<u8>) -> Result<Vec<Op>, Error> {
-    let mut decoder = Decoder::new(&chunk);
+    let decoder = Decoder::new(&chunk);
     let mut res = vec![];
     for op in decoder {
         match op {
             Ok(op) => res.push(op),
             Err(e) => {
-                return Err(Error::CorruptedData("unable to decode chunk".to_string()));
+                return Err(Error::CorruptedData(format!("unable to decode chunk: {}", e)));
             }
         }
     }

--- a/merk/src/proofs/encoding.rs
+++ b/merk/src/proofs/encoding.rs
@@ -467,6 +467,7 @@ mod test {
         tree::HASH_LENGTH,
         TreeFeatureType::{BasicMerkNode, SummedMerkNode},
     };
+    use crate::proofs::Decoder;
 
     #[test]
     fn encode_push_hash() {
@@ -992,6 +993,24 @@ mod test {
         let bytes = [0x11];
         let op = Op::decode(&bytes[..]).expect("decode failed");
         assert_eq!(op, Op::Child);
+    }
+
+    #[test]
+    fn decode_multiple_child() {
+        let bytes = [0x11, 0x11, 0x11, 0x10];
+        let mut decoder = Decoder {
+            bytes: &bytes,
+            offset: 0,
+        };
+
+        let mut vecop = vec![];
+        for op in decoder {
+            match op {
+                Ok(op) => vecop.push(op),
+                Err(e) => eprintln!("Error decoding: {:?}", e),
+            }
+        }
+        assert_eq!(vecop, vec![Op::Child, Op::Child, Op::Child, Op::Parent]);
     }
 
     #[test]

--- a/merk/src/proofs/encoding.rs
+++ b/merk/src/proofs/encoding.rs
@@ -464,10 +464,10 @@ impl<'a> Iterator for Decoder<'a> {
 mod test {
     use super::super::{Node, Op};
     use crate::{
+        proofs::Decoder,
         tree::HASH_LENGTH,
         TreeFeatureType::{BasicMerkNode, SummedMerkNode},
     };
-    use crate::proofs::Decoder;
 
     #[test]
     fn encode_push_hash() {


### PR DESCRIPTION
## Issue being fixed or feature implemented
Platform ABCI isn't aware of Ops structure. Therefore, grovedb state sync related APIs should always use encoded into bytes ops.

## What was done?
Wrote utility functions `util_encode_vec_ops` and `util_decode_vec_ops` and adjusted `fetch_chunk` and `apply_chunk`.


## How Has This Been Tested?


## Breaking Changes


## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
