### PR TITLE
refactor: correct constructors for `SubtreeStateSyncInfo` and `MultiStateSyncInfo`

### DIFF
--- a/grovedb/src/replication.rs
+++ b/grovedb/src/replication.rs
@@ -34,7 +34,7 @@ struct SubtreeStateSyncInfo<'db> {
 
 impl<'a> SubtreeStateSyncInfo<'a> {
     // Function to create an instance of SubtreeStateSyncInfo with default values
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self::default()
     }
 }

--- a/grovedb/src/replication.rs
+++ b/grovedb/src/replication.rs
@@ -43,6 +43,12 @@ impl SubtreeStateSyncInfo<'_> {
     }
 }
 
+impl Default for SubtreeStateSyncInfo<'_> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 // Struct governing state sync
 pub struct MultiStateSyncInfo<'db> {
     // Map of current processing subtrees

--- a/grovedb/src/replication.rs
+++ b/grovedb/src/replication.rs
@@ -21,6 +21,7 @@ pub(crate) type SubtreePrefix = [u8; blake3::OUT_LEN];
 
 pub const CURRENT_STATE_SYNC_VERSION: u16 = 1;
 
+#[derive(Default)]
 struct SubtreeStateSyncInfo<'db> {
     // Current Chunk restorer
     restorer: Option<Restorer<PrefixedRocksDbImmediateStorageContext<'db>>>,
@@ -31,21 +32,10 @@ struct SubtreeStateSyncInfo<'db> {
     num_processed_chunks: usize,
 }
 
-impl SubtreeStateSyncInfo<'_> {
+impl<'a> SubtreeStateSyncInfo<'a> {
     // Function to create an instance of SubtreeStateSyncInfo with default values
     fn new() -> Self {
-        let pending_chunks = BTreeSet::new();
-        Self {
-            restorer: None,
-            pending_chunks,
-            num_processed_chunks: 0,
-        }
-    }
-}
-
-impl Default for SubtreeStateSyncInfo<'_> {
-    fn default() -> Self {
-        Self::new()
+        Self::default()
     }
 }
 
@@ -60,22 +50,13 @@ pub struct MultiStateSyncInfo<'db> {
     version: u16,
 }
 
-impl MultiStateSyncInfo<'_> {
-    // Function to create an instance of MultiStateSyncInfo with default values
-    pub fn new() -> Self {
-        let processed_prefixes = BTreeSet::new();
-        let current_prefixes = BTreeMap::default();
+impl<'db> Default for MultiStateSyncInfo<'db> {
+    fn default() -> Self {
         Self {
-            current_prefixes,
-            processed_prefixes,
+            current_prefixes: BTreeMap::new(),
+            processed_prefixes: BTreeSet::new(),
             version: CURRENT_STATE_SYNC_VERSION,
         }
-    }
-}
-
-impl Default for MultiStateSyncInfo<'_> {
-    fn default() -> Self {
-        Self::new()
     }
 }
 
@@ -401,7 +382,7 @@ impl GroveDb {
             replication::util_path_to_string(&[])
         );
 
-        let mut root_prefix_state_sync_info = SubtreeStateSyncInfo::new();
+        let mut root_prefix_state_sync_info = SubtreeStateSyncInfo::default();
         let root_prefix = [0u8; 32];
         if let Ok(merk) = self.open_merk_for_replication(SubtreePath::empty(), tx) {
             let restorer = Restorer::new(merk, app_hash, None);
@@ -606,7 +587,7 @@ impl GroveDb {
                     replication::util_path_to_string(&prefix_metadata.0)
                 );
 
-                let mut subtree_state_sync_info = SubtreeStateSyncInfo::new();
+                let mut subtree_state_sync_info = SubtreeStateSyncInfo::default();
                 if let Ok(merk) = self.open_merk_for_replication(path.into(), tx) {
                     let restorer =
                         Restorer::new(merk, *s_elem_value_hash, Some(*s_actual_value_hash));

--- a/grovedb/src/replication.rs
+++ b/grovedb/src/replication.rs
@@ -67,6 +67,12 @@ impl MultiStateSyncInfo<'_> {
     }
 }
 
+impl Default for MultiStateSyncInfo<'_> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 // Struct containing information about current subtrees found in GroveDB
 pub struct SubtreesMetadata {
     // Map of Prefix (Path digest) -> (Actual path, Parent Subtree actual_value_hash, Parent

--- a/tutorials/src/bin/replication.rs
+++ b/tutorials/src/bin/replication.rs
@@ -101,7 +101,7 @@ fn main() {
     println!("{:?}", subtrees_metadata_source);
 
     println!("\n######### db_checkpoint_0 -> db_destination state sync");
-    let state_info = db_destination.create_multi_state_sync_info();
+    let state_info = MultiStateSyncInfo::new();
     let tx = db_destination.start_transaction();
     sync_db_demo(&db_checkpoint_0, &db_destination, state_info, &tx).unwrap();
     db_destination.commit_transaction(tx).unwrap().expect("expected to commit transaction");

--- a/tutorials/src/bin/replication.rs
+++ b/tutorials/src/bin/replication.rs
@@ -101,7 +101,7 @@ fn main() {
     println!("{:?}", subtrees_metadata_source);
 
     println!("\n######### db_checkpoint_0 -> db_destination state sync");
-    let state_info = MultiStateSyncInfo::new();
+    let state_info = MultiStateSyncInfo::default();
     let tx = db_destination.start_transaction();
     sync_db_demo(&db_checkpoint_0, &db_destination, state_info, &tx).unwrap();
     db_destination.commit_transaction(tx).unwrap().expect("expected to commit transaction");


### PR DESCRIPTION
## Issue being fixed or feature implemented
Constructors for `SubtreeStateSyncInfo` and `MultiStateSyncInfo` were depended on a ref of grovedb.

## What was done?
Simplified this by using default new() approach

## How Has This Been Tested?


## Breaking Changes


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
