### PR TITLE
refactor: root `chunk_id` should be equal to `app_hash`

### DIFF
--- a/grovedb/src/replication.rs
+++ b/grovedb/src/replication.rs
@@ -40,7 +40,7 @@ pub struct MultiStateSyncInfo<'db> {
     // Set of processed prefixes (Path digests)
     processed_prefixes: BTreeSet<SubtreePrefix>,
     // Root app_hash
-    app_hash: Vec<u8>,
+    app_hash: [u8; 32],
     // Version of state sync protocol,
     version: u16,
 }
@@ -50,7 +50,7 @@ impl<'db> Default for MultiStateSyncInfo<'db> {
         Self {
             current_prefixes: BTreeMap::new(),
             processed_prefixes: BTreeSet::new(),
-            app_hash: vec![],
+            app_hash: [0; 32],
             version: CURRENT_STATE_SYNC_VERSION,
         }
     }
@@ -382,7 +382,7 @@ impl GroveDb {
             state_sync_info
                 .current_prefixes
                 .insert(root_prefix, root_prefix_state_sync_info);
-            state_sync_info.app_hash = app_hash.to_vec();
+            state_sync_info.app_hash = app_hash;
         } else {
             return Err(Error::InternalError("Unable to open merk for replication"));
         }

--- a/grovedb/src/replication.rs
+++ b/grovedb/src/replication.rs
@@ -127,7 +127,7 @@ pub fn util_split_global_chunk_id(
         ));
     }
 
-    if (global_chunk_id == app_hash) {
+    if global_chunk_id == app_hash {
         let array_of_zeros: [u8; 32] = [0; 32];
         let root_chunk_prefix_key: crate::SubtreePrefix = array_of_zeros;
         return Ok((root_chunk_prefix_key, vec![]));

--- a/grovedb/src/replication.rs
+++ b/grovedb/src/replication.rs
@@ -32,12 +32,6 @@ struct SubtreeStateSyncInfo<'db> {
     num_processed_chunks: usize,
 }
 
-impl<'a> SubtreeStateSyncInfo<'a> {
-    // Function to create an instance of SubtreeStateSyncInfo with default values
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
 
 // Struct governing state sync
 pub struct MultiStateSyncInfo<'db> {

--- a/grovedb/src/replication.rs
+++ b/grovedb/src/replication.rs
@@ -32,7 +32,6 @@ struct SubtreeStateSyncInfo<'db> {
     num_processed_chunks: usize,
 }
 
-
 // Struct governing state sync
 pub struct MultiStateSyncInfo<'db> {
     // Map of current processing subtrees

--- a/grovedb/src/replication.rs
+++ b/grovedb/src/replication.rs
@@ -130,7 +130,7 @@ pub fn util_split_global_chunk_id(
     if (global_chunk_id == app_hash) {
         let array_of_zeros: [u8; 32] = [0; 32];
         let root_chunk_prefix_key: crate::SubtreePrefix = array_of_zeros;
-        return Ok((root_chunk_prefix_key, vec![]))
+        return Ok((root_chunk_prefix_key, vec![]));
     }
 
     let (chunk_prefix, chunk_id) = global_chunk_id.split_at(chunk_prefix_length);
@@ -264,7 +264,8 @@ impl GroveDb {
         }
 
         let root_app_hash = self.root_hash(tx).value?;
-        let (chunk_prefix, chunk_id) = replication::util_split_global_chunk_id(global_chunk_id, &root_app_hash)?;
+        let (chunk_prefix, chunk_id) =
+            replication::util_split_global_chunk_id(global_chunk_id, &root_app_hash)?;
 
         let subtrees_metadata = self.get_subtrees_metadata(tx)?;
 
@@ -426,7 +427,8 @@ impl GroveDb {
 
         let mut next_chunk_ids = vec![];
 
-        let (chunk_prefix, chunk_id) = replication::util_split_global_chunk_id(global_chunk_id, &state_sync_info.app_hash)?;
+        let (chunk_prefix, chunk_id) =
+            replication::util_split_global_chunk_id(global_chunk_id, &state_sync_info.app_hash)?;
 
         if state_sync_info.current_prefixes.is_empty() {
             return Err(Error::InternalError("GroveDB is not in syncing mode"));

--- a/tutorials/src/bin/replication.rs
+++ b/tutorials/src/bin/replication.rs
@@ -245,15 +245,16 @@ fn sync_db_demo(
     target_tx: &Transaction,
 ) -> Result<(), grovedb::Error> {
     let app_hash = source_db.root_hash(None).value.unwrap();
-    let (chunk_ids, mut state_sync_info) = target_db.start_snapshot_syncing(state_sync_info, app_hash, target_tx, CURRENT_STATE_SYNC_VERSION)?;
+    let mut state_sync_info = target_db.start_snapshot_syncing(state_sync_info, app_hash, target_tx, CURRENT_STATE_SYNC_VERSION)?;
 
     let mut chunk_queue : VecDeque<Vec<u8>> = VecDeque::new();
 
-    chunk_queue.extend(chunk_ids);
+    // The very first chunk to fetch is always identified by the root app_hash
+    chunk_queue.push_back(app_hash.to_vec());
 
     while let Some(chunk_id) = chunk_queue.pop_front() {
         let ops = source_db.fetch_chunk(chunk_id.as_slice(), None, CURRENT_STATE_SYNC_VERSION)?;
-        let (more_chunks, new_state_sync_info) = target_db.apply_chunk(state_sync_info, (chunk_id.as_slice(), ops), target_tx, CURRENT_STATE_SYNC_VERSION)?;
+        let (more_chunks, new_state_sync_info) = target_db.apply_chunk(state_sync_info, chunk_id.as_slice(), ops, target_tx, CURRENT_STATE_SYNC_VERSION)?;
         state_sync_info = new_state_sync_info;
         chunk_queue.extend(more_chunks);
     }


### PR DESCRIPTION
## Issue being fixed or feature implemented


## What was done?
- Root chunk id is expected to be equal to `app_hash` instead of `null_hash` (This facilitates Tenderdash in state sync init phase)
- Changed API of `appy_chunk` to accept separately parameters and not in tuple (better clarity)


## How Has This Been Tested?
Updated tutorial `replication`


## Breaking Changes



## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
