### PR TITLE
fix: query item range inclusive

### DIFF
--- a/merk/src/proofs/query/query_item/mod.rs
+++ b/merk/src/proofs/query/query_item/mod.rs
@@ -295,11 +295,13 @@ impl QueryItem {
                     iter.seek(end).flat_map(|_| iter.prev())
                 }
             }
-            QueryItem::RangeInclusive(range_inclusive) => iter.seek(if left_to_right {
-                range_inclusive.start()
-            } else {
-                range_inclusive.end()
-            }),
+            QueryItem::RangeInclusive(range_inclusive) => {
+                if left_to_right {
+                    iter.seek(range_inclusive.start())
+                } else {
+                    iter.seek_for_prev(range_inclusive.end())
+                }
+            }
             QueryItem::RangeFull(..) => {
                 if left_to_right {
                     iter.seek_to_first()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
This is a critical fix for query item range inclusive.

If they were being queried in descending order they would add an extra value that was out of bounds.


## What was done?
<!--- Describe your changes in detail -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated relevant unit/integration/functional/e2e tests
- [X] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
