### PR TITLE
fix: reference insertion without batch + verify

### DIFF
--- a/grovedb/src/element/mod.rs
+++ b/grovedb/src/element/mod.rs
@@ -16,9 +16,6 @@ pub(crate) mod helpers;
 mod insert;
 #[cfg(any(feature = "full", feature = "verify"))]
 mod query;
-use grovedb_costs::{cost_return_on_error_default, CostContext, CostsExt, OperationCost};
-use grovedb_merk::{tree::value_hash, CryptoHash};
-use grovedb_version::version::GroveVersion;
 #[cfg(any(feature = "full", feature = "verify"))]
 pub use query::QueryOptions;
 #[cfg(any(feature = "full", feature = "verify"))]
@@ -37,6 +34,8 @@ use grovedb_visualize::visualize_to_vec;
 use crate::operations::proof::util::hex_to_ascii;
 #[cfg(any(feature = "full", feature = "verify"))]
 use crate::reference_path::ReferencePathType;
+#[cfg(feature = "full")]
+use crate::OperationCost;
 
 #[cfg(any(feature = "full", feature = "verify"))]
 /// Optional meta-data to be stored per element
@@ -157,12 +156,13 @@ impl Element {
         }
     }
 
+    #[cfg(feature = "full")]
     pub(crate) fn value_hash(
         &self,
-        grove_version: &GroveVersion,
-    ) -> CostContext<Result<CryptoHash, crate::Error>> {
-        let bytes = cost_return_on_error_default!(self.serialize(grove_version));
-        value_hash(&bytes).map(Result::Ok)
+        grove_version: &grovedb_version::version::GroveVersion,
+    ) -> grovedb_costs::CostResult<grovedb_merk::CryptoHash, crate::Error> {
+        let bytes = grovedb_costs::cost_return_on_error_default!(self.serialize(grove_version));
+        crate::value_hash(&bytes).map(Result::Ok)
     }
 }
 

--- a/grovedb/src/element/mod.rs
+++ b/grovedb/src/element/mod.rs
@@ -16,6 +16,9 @@ pub(crate) mod helpers;
 mod insert;
 #[cfg(any(feature = "full", feature = "verify"))]
 mod query;
+use grovedb_costs::{cost_return_on_error_default, CostContext, CostsExt, OperationCost};
+use grovedb_merk::{tree::value_hash, CryptoHash};
+use grovedb_version::version::GroveVersion;
 #[cfg(any(feature = "full", feature = "verify"))]
 pub use query::QueryOptions;
 #[cfg(any(feature = "full", feature = "verify"))]
@@ -152,6 +155,14 @@ impl Element {
             Element::SumItem(..) => "sum item",
             Element::SumTree(..) => "sum tree",
         }
+    }
+
+    pub(crate) fn value_hash(
+        &self,
+        grove_version: &GroveVersion,
+    ) -> CostContext<Result<CryptoHash, crate::Error>> {
+        let bytes = cost_return_on_error_default!(self.serialize(grove_version));
+        value_hash(&bytes).map(Result::Ok)
     }
 }
 

--- a/grovedb/src/lib.rs
+++ b/grovedb/src/lib.rs
@@ -1063,46 +1063,26 @@ impl GroveDb {
                             "expected merk to contain value at key".to_string(),
                         ))?;
 
-                    // Absolute path to the referenced merk and the key in that merk:
-                    let (referenced_path, referenced_key) = {
+                    let referenced_value_hash = {
                         let mut full_path = path_from_reference_path_type(
                             reference_path.clone(),
                             &path.to_vec(),
                             Some(&key),
                         )?;
-                        let key = full_path.pop().ok_or_else(|| {
-                            Error::MissingReference(
-                                "can't resolve reference path to absolute path".to_owned(),
+                        let item = self
+                            .follow_reference(
+                                (full_path.as_slice()).into(),
+                                true,
+                                None,
+                                grove_version,
                             )
-                        })?;
-                        (full_path, key)
+                            .unwrap()?;
+                        value_hash(&item.serialize(grove_version)?).unwrap()
                     };
-
-                    // Open another subtree, one that is referenced:
-                    let referenced_merk = self
-                        .open_non_transactional_merk_at_path(
-                            (referenced_path.as_slice()).into(),
-                            None,
-                            grove_version,
-                        )
-                        .unwrap()?;
-
-                    // Get value hash of the referenced item
-                    let (_, referenced_value_hash) = referenced_merk
-                        .get_value_and_value_hash(
-                            &referenced_key,
-                            true,
-                            None::<&fn(&[u8], &GroveVersion) -> Option<ValueDefinedCostType>>,
-                            grove_version,
-                        )
-                        .unwrap()
-                        .map_err(MerkError)?
-                        .ok_or(Error::CorruptedData(
-                            "expected merk to contain value at key".to_string(),
-                        ))?;
 
                     // Take the current item (reference) hash and combine it with referenced value's
                     // hash
+
                     let self_actual_value_hash = value_hash(&kv_value).unwrap();
                     let combined_value_hash =
                         combine_hash(&self_actual_value_hash, &referenced_value_hash).unwrap();
@@ -1223,44 +1203,22 @@ impl GroveDb {
                             "expected merk to contain value at key".to_string(),
                         ))?;
 
-                    // Absolute path to the referenced merk and the key in that merk:
-                    let (referenced_path, referenced_key) = {
+                    let referenced_value_hash = {
                         let mut full_path = path_from_reference_path_type(
                             reference_path.clone(),
                             &path.to_vec(),
                             Some(&key),
                         )?;
-                        let key = full_path.pop().ok_or_else(|| {
-                            Error::MissingReference(
-                                "can't resolve reference path to absolute path".to_owned(),
+                        let item = self
+                            .follow_reference(
+                                (full_path.as_slice()).into(),
+                                true,
+                                Some(transaction),
+                                grove_version,
                             )
-                        })?;
-                        (full_path, key)
+                            .unwrap()?;
+                        value_hash(&item.serialize(grove_version)?).unwrap()
                     };
-
-                    // Open another subtree, one that is referenced:
-                    let referenced_merk = self
-                        .open_transactional_merk_at_path(
-                            (referenced_path.as_slice()).into(),
-                            transaction,
-                            None,
-                            grove_version,
-                        )
-                        .unwrap()?;
-
-                    // Get value hash of the referenced item
-                    let (_, referenced_value_hash) = referenced_merk
-                        .get_value_and_value_hash(
-                            &referenced_key,
-                            true,
-                            None::<&fn(&[u8], &GroveVersion) -> Option<ValueDefinedCostType>>,
-                            grove_version,
-                        )
-                        .unwrap()
-                        .map_err(MerkError)?
-                        .ok_or(Error::CorruptedData(
-                            "expected merk to contain value at key".to_string(),
-                        ))?;
 
                     // Take the current item (reference) hash and combine it with referenced value's
                     // hash

--- a/grovedb/src/lib.rs
+++ b/grovedb/src/lib.rs
@@ -1077,7 +1077,7 @@ impl GroveDb {
                                 grove_version,
                             )
                             .unwrap()?;
-                        value_hash(&item.serialize(grove_version)?).unwrap()
+                        item.value_hash(grove_version).unwrap()?
                     };
 
                     // Take the current item (reference) hash and combine it with referenced value's
@@ -1217,7 +1217,7 @@ impl GroveDb {
                                 grove_version,
                             )
                             .unwrap()?;
-                        value_hash(&item.serialize(grove_version)?).unwrap()
+                        item.value_hash(grove_version).unwrap()?
                     };
 
                     // Take the current item (reference) hash and combine it with referenced value's

--- a/grovedb/src/tests/mod.rs
+++ b/grovedb/src/tests/mod.rs
@@ -1190,7 +1190,12 @@ mod tests {
             )
             .unwrap();
 
-        assert!(matches!(result, Err(Error::MissingReference(_))));
+        dbg!(&result);
+
+        assert!(matches!(
+            result,
+            Err(Error::CorruptedReferencePathKeyNotFound(_))
+        ));
     }
 
     #[test]
@@ -1229,24 +1234,15 @@ mod tests {
         }
 
         // Add one more reference
-        db.insert(
-            [TEST_LEAF].as_ref(),
-            &keygen(MAX_REFERENCE_HOPS + 1),
-            Element::new_reference(ReferencePathType::AbsolutePathReference(vec![
-                TEST_LEAF.to_vec(),
-                keygen(MAX_REFERENCE_HOPS),
-            ])),
-            None,
-            None,
-            grove_version,
-        )
-        .unwrap()
-        .expect("expected insert");
-
         let result = db
-            .get(
+            .insert(
                 [TEST_LEAF].as_ref(),
                 &keygen(MAX_REFERENCE_HOPS + 1),
+                Element::new_reference(ReferencePathType::AbsolutePathReference(vec![
+                    TEST_LEAF.to_vec(),
+                    keygen(MAX_REFERENCE_HOPS),
+                ])),
+                None,
                 None,
                 grove_version,
             )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR addresses an issue with references insertion outside of a batch, also fixes verify function to align it all with batches and proof system


## What was done?
<!--- Describe your changes in detail -->

Combined hash of references now uses value hash of the last item of references chain instead of the value hash of the direct item, which in turn could be a reference


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

add tests for longer reference chains both for batch insertions and regular ones


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
