### PR TITLE
feat: PathQuery depth

### DIFF
--- a/grovedb/build.rs
+++ b/grovedb/build.rs
@@ -13,7 +13,10 @@ fn main() {
     let grovedbg_zip_path = out_dir.join("grovedbg.zip");
 
     if !grovedbg_zip_path.exists() {
-        let response = reqwest::blocking::get(format!("https://github.com/dashpay/grovedbg/releases/download/{GROVEDBG_VERSION}/grovedbg-{GROVEDBG_VERSION}.zip"))
+        let response = reqwest::blocking::get(format!(
+                "https://github.com/dashpay/grovedbg/releases/download/{GROVEDBG_VERSION}/\
+grovedbg-{GROVEDBG_VERSION}.zip"
+            ))
         .expect("can't download GroveDBG artifact");
 
         let mut grovedbg_zip = File::create(&grovedbg_zip_path).unwrap();

--- a/grovedb/build.rs
+++ b/grovedb/build.rs
@@ -14,9 +14,9 @@ fn main() {
 
     if !grovedbg_zip_path.exists() {
         let response = reqwest::blocking::get(format!(
-                "https://github.com/dashpay/grovedbg/releases/download/{GROVEDBG_VERSION}/\
+            "https://github.com/dashpay/grovedbg/releases/download/{GROVEDBG_VERSION}/\
 grovedbg-{GROVEDBG_VERSION}.zip"
-            ))
+        ))
         .expect("can't download GroveDBG artifact");
 
         let mut grovedbg_zip = File::create(&grovedbg_zip_path).unwrap();

--- a/grovedb/src/query/mod.rs
+++ b/grovedb/src/query/mod.rs
@@ -134,6 +134,12 @@ impl PathQuery {
         Self { path, query }
     }
 
+    /// The max depth od the query, this is the maximum layers we could get back
+    /// from grovedb
+    pub fn max_depth(&self) -> u32 {
+        self.query.query.max_depth()
+    }
+
     /// Gets the path of all terminal keys
     pub fn terminal_keys(
         &self,
@@ -1633,6 +1639,8 @@ mod tests {
                 offset: None,
             },
         };
+
+        assert_eq!(path_query.max_depth(), 4);
 
         {
             let path = vec![];

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -86,7 +86,7 @@ impl SubqueryBranch {
             return None;
         }
         let subquery_path_depth = self.subquery_path.as_ref().map_or(Some(0), |path| {
-            if path.len() > 255 {
+            if path.len() > u16::MAX as usize {
                 None
             } else {
                 Some(path.len() as u16)

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -86,10 +86,11 @@ impl SubqueryBranch {
             return None;
         }
         let subquery_path_depth = self.subquery_path.as_ref().map_or(Some(0), |path| {
-            if path.len() > u16::MAX as usize {
+            let path_len = path.len();
+            if path_len > u16::MAX as usize {
                 None
             } else {
-                Some(path.len() as u16)
+                Some(path_len as u16)
             }
         })?;
         let subquery_depth = self.subquery.as_ref().map_or(Some(0), |query| {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
PathQuery depth is a small feature that gives the max depth of the PathQuery. This can be used to estimate the complexity of the PathQuery


## What was done?
The PathQuery depth taxes the max of default pathquery subbranches and conditional pathquery subbranches.


## How Has This Been Tested?
Added a test to check if it worked.


## Breaking Changes
None


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated relevant unit/integration/functional/e2e tests
- [X] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
