### PR TITLE
feat: added a convenience method that will return an existing item du…

### DIFF
--- a/grovedb-version/src/version/grovedb_versions.rs
+++ b/grovedb-version/src/version/grovedb_versions.rs
@@ -135,6 +135,7 @@ pub struct GroveDBOperationsInsertVersions {
     pub add_element_on_transaction: FeatureVersion,
     pub add_element_without_transaction: FeatureVersion,
     pub insert_if_not_exists: FeatureVersion,
+    pub insert_if_not_exists_return_existing_element: FeatureVersion,
     pub insert_if_changed_value: FeatureVersion,
 }
 

--- a/grovedb-version/src/version/v1.rs
+++ b/grovedb-version/src/version/v1.rs
@@ -94,6 +94,7 @@ pub const GROVE_V1: GroveVersion = GroveVersion {
                 add_element_on_transaction: 0,
                 add_element_without_transaction: 0,
                 insert_if_not_exists: 0,
+                insert_if_not_exists_return_existing_element: 0,
                 insert_if_changed_value: 0,
             },
             delete: GroveDBOperationsDeleteVersions {

--- a/grovedb/src/operations/insert/mod.rs
+++ b/grovedb/src/operations/insert/mod.rs
@@ -488,7 +488,8 @@ impl GroveDb {
     /// Insert if not exists
     /// Insert if not exists
     ///
-    /// Inserts an element at the specified path and key if it does not already exist.
+    /// Inserts an element at the specified path and key if it does not already
+    /// exist.
     ///
     /// # Arguments
     ///
@@ -500,7 +501,8 @@ impl GroveDb {
     ///
     /// # Returns
     ///
-    /// Returns a `CostResult<bool, Error>` indicating whether the element was inserted (`true`) or already existed (`false`).
+    /// Returns a `CostResult<bool, Error>` indicating whether the element was
+    /// inserted (`true`) or already existed (`false`).
     pub fn insert_if_not_exists<'b, B, P>(
         &self,
         path: P,
@@ -553,7 +555,9 @@ impl GroveDb {
     ///
     /// # Returns
     ///
-    /// Returns a `CostResult<Option<Element>, Error>`, where `Ok(Some(element))` is the existing element if it was found, or `Ok(None)` if the new element was inserted.
+    /// Returns a `CostResult<Option<Element>, Error>`, where
+    /// `Ok(Some(element))` is the existing element if it was found, or
+    /// `Ok(None)` if the new element was inserted.
     pub fn insert_if_not_exists_return_existing_element<'b, B, P>(
         &self,
         path: P,
@@ -573,7 +577,6 @@ impl GroveDb {
                 .operations
                 .insert
                 .insert_if_not_exists_return_existing_element
-        );
         );
 
         let mut cost = OperationCost::default();
@@ -856,6 +859,122 @@ mod tests {
             )
             .unwrap();
         assert!(matches!(result, Err(Error::InvalidParentLayerPath(_))));
+    }
+
+    #[test]
+    fn test_insert_if_not_exists_return_existing_element() {
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+
+        let element_key = b"key1";
+        let new_element = Element::new_item(b"new_value".to_vec());
+
+        // Insert a new element and check if it returns None
+        let result = db
+            .insert_if_not_exists_return_existing_element(
+                [TEST_LEAF].as_ref(),
+                element_key,
+                new_element.clone(),
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("Expected insertion of new element");
+
+        assert_eq!(result, None);
+
+        // Try inserting the same element again and expect it to return the existing
+        // element
+        let result = db
+            .insert_if_not_exists_return_existing_element(
+                [TEST_LEAF].as_ref(),
+                element_key,
+                Element::new_item(b"another_value".to_vec()),
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("Expected to return existing element");
+
+        assert_eq!(result, Some(new_element.clone()));
+
+        // Check if the existing element is still the original one and not replaced
+        let fetched_element = db
+            .get([TEST_LEAF].as_ref(), element_key, None, grove_version)
+            .unwrap()
+            .expect("Expected to retrieve the existing element");
+
+        assert_eq!(fetched_element, new_element);
+    }
+
+    #[test]
+    fn test_insert_if_not_exists_return_existing_element_with_transaction() {
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+
+        let element_key = b"key2";
+        let new_element = Element::new_item(b"transaction_value".to_vec());
+        let transaction = db.start_transaction();
+
+        // Insert a new element within a transaction and check if it returns None
+        let result = db
+            .insert_if_not_exists_return_existing_element(
+                [TEST_LEAF].as_ref(),
+                element_key,
+                new_element.clone(),
+                Some(&transaction),
+                grove_version,
+            )
+            .unwrap()
+            .expect("Expected insertion of new element in transaction");
+
+        assert_eq!(result, None);
+
+        // Try inserting the same element again within the transaction
+        // and expect it to return the existing element
+        let result = db
+            .insert_if_not_exists_return_existing_element(
+                [TEST_LEAF].as_ref(),
+                element_key,
+                Element::new_item(b"another_transaction_value".to_vec()),
+                Some(&transaction),
+                grove_version,
+            )
+            .unwrap()
+            .expect("Expected to return existing element in transaction");
+
+        assert_eq!(result, Some(new_element.clone()));
+
+        // Commit the transaction
+        db.commit_transaction(transaction).unwrap().unwrap();
+
+        // Check if the element is still the original one and not replaced
+        let fetched_element = db
+            .get([TEST_LEAF].as_ref(), element_key, None, grove_version)
+            .unwrap()
+            .expect("Expected to retrieve the existing element after transaction commit");
+
+        assert_eq!(fetched_element, new_element);
+    }
+
+    #[test]
+    fn test_insert_if_not_exists_return_existing_element_invalid_path() {
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+
+        // Try inserting to an invalid path and expect an error
+        let result = db.insert_if_not_exists_return_existing_element(
+            [b"invalid_path"].as_ref(),
+            b"key",
+            Element::new_item(b"value".to_vec()),
+            None,
+            grove_version,
+        );
+
+        assert!(matches!(
+            result.unwrap(),
+            Err(Error::InvalidParentLayerPath(_))
+        ));
     }
 
     #[test]

--- a/grovedb/src/operations/insert/mod.rs
+++ b/grovedb/src/operations/insert/mod.rs
@@ -543,7 +543,7 @@ impl GroveDb {
                 .grovedb_versions
                 .operations
                 .insert
-                .insert_if_not_exists
+                .insert_if_not_exists_return_existing_element
         );
 
         let mut cost = OperationCost::default();

--- a/grovedb/src/operations/insert/mod.rs
+++ b/grovedb/src/operations/insert/mod.rs
@@ -525,6 +525,21 @@ impl GroveDb {
 
     /// Insert if not exists
     /// If the item does exist return it
+    ///
+    /// Inserts an element at the given `path` and `key` if it does not exist.
+    /// If the element already exists, returns the existing element.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - The path where the element should be inserted.
+    /// * `key` - The key under which the element should be inserted.
+    /// * `element` - The element to insert.
+    /// * `transaction` - The transaction argument, if any.
+    /// * `grove_version` - The GroveDB version.
+    ///
+    /// # Returns
+    ///
+    /// Returns a `CostResult<Option<Element>, Error>`, where `Ok(Some(element))` is the existing element if it was found, or `Ok(None)` if the new element was inserted.
     pub fn insert_if_not_exists_return_existing_element<'b, B, P>(
         &self,
         path: P,

--- a/grovedb/src/operations/insert/mod.rs
+++ b/grovedb/src/operations/insert/mod.rs
@@ -486,7 +486,21 @@ impl GroveDb {
     }
 
     /// Insert if not exists
-    /// The bool return is whether we were able to insert
+    /// Insert if not exists
+    ///
+    /// Inserts an element at the specified path and key if it does not already exist.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - The path where the element should be inserted.
+    /// * `key` - The key under which the element should be inserted.
+    /// * `element` - The element to insert.
+    /// * `transaction` - The transaction argument, if any.
+    /// * `grove_version` - The GroveDB version.
+    ///
+    /// # Returns
+    ///
+    /// Returns a `CostResult<bool, Error>` indicating whether the element was inserted (`true`) or already existed (`false`).
     pub fn insert_if_not_exists<'b, B, P>(
         &self,
         path: P,

--- a/grovedb/src/operations/insert/mod.rs
+++ b/grovedb/src/operations/insert/mod.rs
@@ -553,12 +553,13 @@ impl GroveDb {
         P: Into<SubtreePath<'b, B>>,
     {
         check_grovedb_v0_with_cost!(
-            "insert_if_not_exists",
+            "insert_if_not_exists_return_existing_element",
             grove_version
                 .grovedb_versions
                 .operations
                 .insert
                 .insert_if_not_exists_return_existing_element
+        );
         );
 
         let mut cost = OperationCost::default();


### PR DESCRIPTION
…ring a check for insertion

<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
This change implements a new function insert_if_not_exists_return_existing_element in GroveDB. The function allows for the insertion of an element if it does not already exist at the specified path and key. If the element already exists, the function returns the existing element instead of performing an insertion. This is useful for scenarios where we want to avoid overwriting existing data but still need to confirm its presence.

## What was done?
•	Added a new function insert_if_not_exists_return_existing_element to GroveDB.
	•	This function checks if an element already exists at the given path and key.
	•	If the element exists, it returns the existing element.
	•	If the element does not exist, it inserts the new element and returns None.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
This change does not introduce any breaking changes.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method to insert elements into the database only if they do not already exist, returning the existing element if found.
	- Added a new field to support this functionality in the versioning structure.

- **Bug Fixes**
	- Updated method signatures for clarity on return types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->