### PR TITLE
fix: merging epoch removed bytes should use old owner id instead of merged one

### DIFF
--- a/grovedb-epoch-based-storage-flags/src/lib.rs
+++ b/grovedb-epoch-based-storage-flags/src/lib.rs
@@ -244,7 +244,8 @@ impl StorageFlags {
                     "can not remove bytes when there is no epoch".to_string(),
                 ));
             }
-            let identifier = owner_id.copied().unwrap_or_default();
+            // we must use our owner id, because we would be removing bytes from it
+            let identifier = self.owner_id().copied().unwrap_or_default();
             let sectioned_bytes = sectioned_bytes_by_identifier.get(&identifier).ok_or(
                 StorageFlagsError::MergingStorageFlagsFromDifferentOwners(
                     "can not remove bytes when there is no epoch".to_string(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
There was an issue in documents purchase state transition that showed this error in GroveDB.


## What was done?
Used old ownerId in removed bytes instead of merged one.


## How Has This Been Tested?
Verified fix works


## Breaking Changes
Should never have worked, hence no issue.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated relevant unit/integration/functional/e2e tests
- [X] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
