### PR TITLE
fix: fix sub tree prefix and go to version 2.2.1

### DIFF
--- a/costs/Cargo.toml
+++ b/costs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grovedb-costs"
-version = "2.2.0"
+version = "2.2.1"
 edition = "2021"
 license = "MIT"
 description = "Costs extension crate for GroveDB"

--- a/grovedb-epoch-based-storage-flags/Cargo.toml
+++ b/grovedb-epoch-based-storage-flags/Cargo.toml
@@ -2,13 +2,13 @@
 name = "grovedb-epoch-based-storage-flags"
 authors = ["Samuel Westrich <sam@dash.org>"]
 description = "Epoch based storage flags for GroveDB"
-version = "2.2.0"
+version = "2.2.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/dashpay/grovedb"
 
 [dependencies]
-grovedb-costs = { version = "2.2.0", path = "../costs" }
+grovedb-costs = { version = "2.2.1", path = "../costs" }
 
 hex = { version = "0.4.3" }
 integer-encoding = { version = "4.0.0" }

--- a/grovedb-version/Cargo.toml
+++ b/grovedb-version/Cargo.toml
@@ -2,7 +2,7 @@
 name = "grovedb-version"
 authors = ["Samuel Westrich <sam@dash.org>"]
 description = "Versioning library for Platform"
-version = "2.2.0"
+version = "2.2.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/dashpay/grovedb"

--- a/grovedb/Cargo.toml
+++ b/grovedb/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "grovedb"
 description = "Fully featured database using balanced hierarchical authenticated data structures"
-version = "2.2.0"
+version = "2.2.1"
 authors = ["Samuel Westrich <sam@dash.org>", "Wisdom Ogwu <wisdom@dash.org", "Evgeny Fomin <evgeny.fomin@dash.org>"]
 edition = "2021"
 license = "MIT"
@@ -11,13 +11,13 @@ readme = "../README.md"
 documentation = "https://docs.rs/grovedb"
 
 [dependencies]
-grovedb-costs = { version = "2.2.0", path = "../costs" , optional = true }
-grovedbg-types = { version = "2.2.0", path = "../grovedbg-types", optional = true }
-grovedb-merk = { version = "2.2.0", path = "../merk", optional = true, default-features = false }
-grovedb-path = { version = "2.2.0", path = "../path" }
-grovedb-storage = { version = "2.2.0", path = "../storage", optional = true }
-grovedb-version = { version = "2.2.0", path = "../grovedb-version" }
-grovedb-visualize = { version = "2.2.0", path = "../visualize", optional = true }
+grovedb-costs = { version = "2.2.1", path = "../costs" , optional = true }
+grovedbg-types = { version = "2.2.1", path = "../grovedbg-types", optional = true }
+grovedb-merk = { version = "2.2.1", path = "../merk", optional = true, default-features = false }
+grovedb-path = { version = "2.2.1", path = "../path" }
+grovedb-storage = { version = "2.2.1", path = "../storage", optional = true }
+grovedb-version = { version = "2.2.1", path = "../grovedb-version" }
+grovedb-visualize = { version = "2.2.1", path = "../visualize", optional = true }
 
 axum = { version = "=0.7.5", features = ["macros"], optional = true }
 bincode = { version = "2.0.0-rc.3" }
@@ -36,7 +36,7 @@ zip-extensions = { version = "0.8.1", optional = true }
 serde = { version = "1.0.210", features = ["derive"], optional = true }
 
 [dev-dependencies]
-grovedb-epoch-based-storage-flags = { version = "2.2.0", path = "../grovedb-epoch-based-storage-flags" }
+grovedb-epoch-based-storage-flags = { version = "2.2.1", path = "../grovedb-epoch-based-storage-flags" }
 
 criterion = "0.5.1"
 hex = "0.4.3"

--- a/grovedb/src/replication/state_sync_session.rs
+++ b/grovedb/src/replication/state_sync_session.rs
@@ -22,7 +22,7 @@ use super::{
 };
 use crate::{replication, Element, Error, GroveDb, Transaction};
 
-pub(crate) type SubtreePrefix = [u8; blake3::OUT_LEN];
+pub(crate) type SubtreePrefix = [u8; 32];
 
 /// Struct governing the state synchronization of one subtree.
 struct SubtreeStateSyncInfo<'db> {

--- a/grovedbg-types/Cargo.toml
+++ b/grovedbg-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grovedbg-types"
-version = "2.2.0"
+version = "2.2.1"
 edition = "2021"
 description = "Common type definitions for data exchange over GroveDBG protocol"
 authors = ["Evgeny Fomin <evgeny.fomin@dash.org>"]

--- a/merk/Cargo.toml
+++ b/merk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "grovedb-merk"
 description = "Merkle key/value store adapted for GroveDB"
-version = "2.2.0"
+version = "2.2.1"
 authors = ["Samuel Westrich <sam@dash.org>", "Wisdom Ogwu <wisdom@dash.org", "Evgeny Fomin <evgeny.fomin@dash.org>", "Matt Bell <mappum@gmail.com>"]
 edition = "2021"
 license = "MIT"
@@ -11,11 +11,11 @@ readme = "README.md"
 documentation = "https://docs.rs/grovedb-merk"
 
 [dependencies]
-grovedb-costs = { version = "2.2.0" , path = "../costs" }
-grovedb-path = { version = "2.2.0", path = "../path" }
-grovedb-storage = { version = "2.2.0", path = "../storage", optional = true }
-grovedb-version = { version = "2.2.0", path = "../grovedb-version" }
-grovedb-visualize = { version = "2.2.0", path = "../visualize" }
+grovedb-costs = { version = "2.2.1" , path = "../costs" }
+grovedb-path = { version = "2.2.1", path = "../path" }
+grovedb-storage = { version = "2.2.1", path = "../storage", optional = true }
+grovedb-version = { version = "2.2.1", path = "../grovedb-version" }
+grovedb-visualize = { version = "2.2.1", path = "../visualize" }
 
 bincode = { version = "2.0.0-rc.3" }
 hex = "0.4.3"

--- a/node-grove/Cargo.toml
+++ b/node-grove/Cargo.toml
@@ -10,8 +10,8 @@ exclude = ["index.node"]
 crate-type = ["cdylib"]
 
 [dependencies]
-grovedb = { version = "2.2.0", path = "../grovedb", features = ["full", "estimated_costs"] }
-grovedb-version =  { version = "2.2.0", path = "../grovedb-version" }
+grovedb = { version = "2.2.1", path = "../grovedb", features = ["full", "estimated_costs"] }
+grovedb-version =  { version = "2.2.1", path = "../grovedb-version" }
 
 [dependencies.neon]
 version = "0.10.1"

--- a/path/Cargo.toml
+++ b/path/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grovedb-path"
-version = "2.2.0"
+version = "2.2.1"
 edition = "2021"
 license = "MIT"
 description = "Path extension crate for GroveDB"

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grovedb-storage"
-version = "2.2.0"
+version = "2.2.1"
 edition = "2021"
 license = "MIT"
 description = "Storage extension crate for GroveDB"
@@ -9,9 +9,9 @@ documentation = "https://docs.rs/grovedb-storage"
 repository = "https://github.com/dashpay/grovedb"
 
 [dependencies]
-grovedb-costs = { version = "2.2.0", path = "../costs" }
-grovedb-path = { version = "2.2.0", path = "../path" }
-grovedb-visualize = { version = "2.2.0", path = "../visualize" }
+grovedb-costs = { version = "2.2.1", path = "../costs" }
+grovedb-path = { version = "2.2.1", path = "../path" }
+grovedb-visualize = { version = "2.2.1", path = "../visualize" }
 
 blake3 = { version = "1.5.1", optional = true }
 hex = "0.4.3"

--- a/storage/src/rocksdb_storage/storage.rs
+++ b/storage/src/rocksdb_storage/storage.rs
@@ -51,12 +51,13 @@ use super::{
 use crate::{
     error,
     error::Error::{CostError, RocksDBError},
-    storage::{AbstractBatchOperation, SubtreePrefix},
+    storage::AbstractBatchOperation,
     worst_case_costs::WorstKeyLength,
     Storage, StorageBatch,
 };
 
 const BLAKE_BLOCK_LEN: usize = 64;
+pub type SubtreePrefix = [u8; 32];
 
 fn blake_block_count(len: usize) -> usize {
     if len == 0 {

--- a/storage/src/rocksdb_storage/storage.rs
+++ b/storage/src/rocksdb_storage/storage.rs
@@ -55,10 +55,9 @@ use crate::{
     worst_case_costs::WorstKeyLength,
     Storage, StorageBatch,
 };
+use crate::storage::SubtreePrefix;
 
 const BLAKE_BLOCK_LEN: usize = 64;
-
-pub type SubtreePrefix = [u8; blake3::OUT_LEN];
 
 fn blake_block_count(len: usize) -> usize {
     if len == 0 {

--- a/storage/src/rocksdb_storage/storage.rs
+++ b/storage/src/rocksdb_storage/storage.rs
@@ -51,11 +51,10 @@ use super::{
 use crate::{
     error,
     error::Error::{CostError, RocksDBError},
-    storage::AbstractBatchOperation,
+    storage::{AbstractBatchOperation, SubtreePrefix},
     worst_case_costs::WorstKeyLength,
     Storage, StorageBatch,
 };
-use crate::storage::SubtreePrefix;
 
 const BLAKE_BLOCK_LEN: usize = 64;
 

--- a/storage/src/rocksdb_storage/storage_context/batch.rs
+++ b/storage/src/rocksdb_storage/storage_context/batch.rs
@@ -7,9 +7,8 @@ use integer_encoding::VarInt;
 use rocksdb::{ColumnFamily, WriteBatchWithTransaction};
 
 use super::make_prefixed_key;
-use crate::{Batch, StorageBatch};
-
 pub use crate::rocksdb_storage::storage::SubtreePrefix;
+use crate::{Batch, StorageBatch};
 
 /// Wrapper to RocksDB batch.
 /// All calls go to RocksDB batch, but wrapper handles prefixes and column

--- a/storage/src/rocksdb_storage/storage_context/batch.rs
+++ b/storage/src/rocksdb_storage/storage_context/batch.rs
@@ -7,7 +7,9 @@ use integer_encoding::VarInt;
 use rocksdb::{ColumnFamily, WriteBatchWithTransaction};
 
 use super::make_prefixed_key;
-use crate::{rocksdb_storage::storage::SubtreePrefix, Batch, StorageBatch};
+use crate::{Batch, StorageBatch};
+
+pub use crate::rocksdb_storage::storage::SubtreePrefix;
 
 /// Wrapper to RocksDB batch.
 /// All calls go to RocksDB batch, but wrapper handles prefixes and column

--- a/storage/src/rocksdb_storage/storage_context/batch.rs
+++ b/storage/src/rocksdb_storage/storage_context/batch.rs
@@ -7,8 +7,7 @@ use integer_encoding::VarInt;
 use rocksdb::{ColumnFamily, WriteBatchWithTransaction};
 
 use super::make_prefixed_key;
-pub use crate::rocksdb_storage::storage::SubtreePrefix;
-use crate::{Batch, StorageBatch};
+use crate::{rocksdb_storage::storage::SubtreePrefix, Batch, StorageBatch};
 
 /// Wrapper to RocksDB batch.
 /// All calls go to RocksDB batch, but wrapper handles prefixes and column

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -42,8 +42,7 @@ use grovedb_path::SubtreePath;
 use grovedb_visualize::visualize_to_vec;
 
 use crate::{worst_case_costs::WorstKeyLength, Error};
-
-pub type SubtreePrefix = [u8; blake3::OUT_LEN];
+pub type SubtreePrefix = [u8; 32];
 
 /// Top-level storage_cost abstraction.
 /// Should be able to hold storage_cost connection and to start transaction when

--- a/visualize/Cargo.toml
+++ b/visualize/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grovedb-visualize"
-version = "2.2.0"
+version = "2.2.1"
 edition = "2021"
 license = "MIT"
 description = "Debug prints extension crate for GroveDB"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->


## What was done?
<!--- Describe your changes in detail -->


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Version Updates**
	- Incremented version from 2.2.0 to 2.2.1 across multiple packages including grovedb, grovedb-costs, grovedb-version, grovedbg-types, merk, node-grove, path, storage, and visualize
	- Updated dependencies to match the new version number

- **Type Changes**
	- Modified `SubtreePrefix` type definition to use a fixed 32-byte array in storage module

<!-- end of auto-generated comment: release notes by coderabbit.ai -->