### PR TITLE
fix: change Element's methods visibility

### DIFF
--- a/grovedb/src/element/delete.rs
+++ b/grovedb/src/element/delete.rs
@@ -20,52 +20,11 @@ use crate::{Element, Error};
 impl Element {
     #[cfg(feature = "minimal")]
     /// Delete an element from Merk under a key
-    pub fn delete<'db, K: AsRef<[u8]>, S: StorageContext<'db>>(
-        merk: &mut Merk<S>,
-        key: K,
-        merk_options: Option<MerkOptions>,
-        is_layered: bool,
-        in_tree_type: TreeType,
-        grove_version: &GroveVersion,
-    ) -> CostResult<(), Error> {
-        check_grovedb_v0_with_cost!("delete", grove_version.grovedb_versions.element.delete);
-        let op = match (in_tree_type, is_layered) {
-            (TreeType::NormalTree, true) => Op::DeleteLayered,
-            (TreeType::NormalTree, false) => Op::Delete,
-            (TreeType::SumTree, true)
-            | (TreeType::BigSumTree, true)
-            | (TreeType::CountTree, true)
-            | (TreeType::CountSumTree, true) => Op::DeleteLayeredMaybeSpecialized,
-            (TreeType::SumTree, false)
-            | (TreeType::BigSumTree, false)
-            | (TreeType::CountTree, false)
-            | (TreeType::CountSumTree, false) => Op::DeleteMaybeSpecialized,
-        };
-        let batch = [(key, op)];
-        // todo not sure we get it again, we need to see if this is necessary
-        let tree_type = merk.tree_type;
-        merk.apply_with_specialized_costs::<_, Vec<u8>>(
-            &batch,
-            &[],
-            merk_options,
-            &|key, value| {
-                Self::specialized_costs_for_key_value(
-                    key,
-                    value,
-                    tree_type.inner_node_type(),
-                    grove_version,
-                )
-                .map_err(|e| MerkError::ClientCorruptionError(e.to_string()))
-            },
-            Some(&Element::value_defined_cost_for_serialized_value),
-            grove_version,
-        )
-        .map_err(|e| Error::CorruptedData(e.to_string()))
-    }
-
-    #[cfg(feature = "minimal")]
-    /// Delete an element from Merk under a key
-    pub fn delete_with_sectioned_removal_bytes<'db, K: AsRef<[u8]>, S: StorageContext<'db>>(
+    pub(crate) fn delete_with_sectioned_removal_bytes<
+        'db,
+        K: AsRef<[u8]>,
+        S: StorageContext<'db>,
+    >(
         merk: &mut Merk<S>,
         key: K,
         merk_options: Option<MerkOptions>,
@@ -127,7 +86,7 @@ impl Element {
 
     #[cfg(feature = "minimal")]
     /// Delete an element from Merk under a key to batch operations
-    pub fn delete_into_batch_operations<K: AsRef<[u8]>>(
+    pub(crate) fn delete_into_batch_operations<K: AsRef<[u8]>>(
         key: K,
         is_layered: bool,
         in_tree_type: TreeType,

--- a/grovedb/src/element/exists.rs
+++ b/grovedb/src/element/exists.rs
@@ -11,7 +11,7 @@ use crate::{Element, Error};
 impl Element {
     /// Helper function that returns whether an element at the key for the
     /// element already exists.
-    pub fn element_at_key_already_exists<'db, K: AsRef<[u8]>, S: StorageContext<'db>>(
+    pub(crate) fn element_at_key_already_exists<'db, K: AsRef<[u8]>, S: StorageContext<'db>>(
         &self,
         merk: &mut Merk<S>,
         key: K,

--- a/grovedb/src/element/get.rs
+++ b/grovedb/src/element/get.rs
@@ -30,7 +30,7 @@ impl Element {
     #[cfg(feature = "minimal")]
     /// Get an element from Merk under a key; path should be resolved and proper
     /// Merk should be loaded by this moment
-    pub fn get<'db, K: AsRef<[u8]>, S: StorageContext<'db>>(
+    pub(crate) fn get<'db, K: AsRef<[u8]>, S: StorageContext<'db>>(
         merk: &Merk<S>,
         key: K,
         allow_cache: bool,
@@ -61,7 +61,7 @@ impl Element {
     #[cfg(feature = "minimal")]
     /// Get an element from Merk under a key; path should be resolved and proper
     /// Merk should be loaded by this moment
-    pub fn get_optional<'db, K: AsRef<[u8]>, S: StorageContext<'db>>(
+    pub(crate) fn get_optional<'db, K: AsRef<[u8]>, S: StorageContext<'db>>(
         merk: &Merk<S>,
         key: K,
         allow_cache: bool,
@@ -101,7 +101,7 @@ impl Element {
     /// Get an element directly from storage under a key
     /// Merk does not need to be loaded
     /// Errors if element doesn't exist
-    pub fn get_from_storage<'db, K: AsRef<[u8]>, S: StorageContext<'db>>(
+    pub(crate) fn get_from_storage<'db, K: AsRef<[u8]>, S: StorageContext<'db>>(
         storage: &S,
         key: K,
         grove_version: &GroveVersion,
@@ -124,7 +124,7 @@ impl Element {
     #[cfg(feature = "minimal")]
     /// Get an element directly from storage under a key
     /// Merk does not need to be loaded
-    pub fn get_optional_from_storage<'db, K: AsRef<[u8]>, S: StorageContext<'db>>(
+    pub(crate) fn get_optional_from_storage<'db, K: AsRef<[u8]>, S: StorageContext<'db>>(
         storage: &S,
         key: K,
         grove_version: &GroveVersion,
@@ -315,42 +315,7 @@ impl Element {
     #[cfg(feature = "minimal")]
     /// Get an element from Merk under a key; path should be resolved and proper
     /// Merk should be loaded by this moment
-    pub fn get_with_absolute_refs<'db, K: AsRef<[u8]>, S: StorageContext<'db>>(
-        merk: &Merk<S>,
-        path: &[&[u8]],
-        key: K,
-        allow_cache: bool,
-        grove_version: &GroveVersion,
-    ) -> CostResult<Element, Error> {
-        use crate::error::GroveDbErrorExt;
-
-        check_grovedb_v0_with_cost!(
-            "get_with_absolute_refs",
-            grove_version
-                .grovedb_versions
-                .element
-                .get_with_absolute_refs
-        );
-        let mut cost = OperationCost::default();
-
-        let element = cost_return_on_error!(
-            &mut cost,
-            Self::get(merk, key.as_ref(), allow_cache, grove_version)
-                .add_context(format!("path is {}", path_as_slices_hex_to_ascii(path)))
-        );
-
-        let absolute_element = cost_return_on_error_no_add!(
-            cost,
-            element.convert_if_reference_to_absolute_reference(path, Some(key.as_ref()))
-        );
-
-        Ok(absolute_element).wrap_with_cost(cost)
-    }
-
-    #[cfg(feature = "minimal")]
-    /// Get an element from Merk under a key; path should be resolved and proper
-    /// Merk should be loaded by this moment
-    pub fn get_optional_with_absolute_refs<'db, K: AsRef<[u8]>, S: StorageContext<'db>>(
+    pub(crate) fn get_optional_with_absolute_refs<'db, K: AsRef<[u8]>, S: StorageContext<'db>>(
         merk: &Merk<S>,
         path: &[&[u8]],
         key: K,
@@ -387,36 +352,8 @@ impl Element {
     }
 
     #[cfg(feature = "minimal")]
-    /// Get an element's value hash from Merk under a key
-    pub fn get_value_hash<'db, K: AsRef<[u8]>, S: StorageContext<'db>>(
-        merk: &Merk<S>,
-        key: K,
-        allow_cache: bool,
-        grove_version: &GroveVersion,
-    ) -> CostResult<Option<Hash>, Error> {
-        check_grovedb_v0_with_cost!(
-            "get_value_hash",
-            grove_version.grovedb_versions.element.get_value_hash
-        );
-        let mut cost = OperationCost::default();
-
-        let value_hash = cost_return_on_error!(
-            &mut cost,
-            merk.get_value_hash(
-                key.as_ref(),
-                allow_cache,
-                Some(&Element::value_defined_cost_for_serialized_value),
-                grove_version
-            )
-            .map_err(|e| Error::CorruptedData(e.to_string()))
-        );
-
-        Ok(value_hash).wrap_with_cost(cost)
-    }
-
-    #[cfg(feature = "minimal")]
     /// Get an element and its value hash from Merk under a key
-    pub fn get_with_value_hash<'db, K: AsRef<[u8]>, S: StorageContext<'db>>(
+    pub(crate) fn get_with_value_hash<'db, K: AsRef<[u8]>, S: StorageContext<'db>>(
         merk: &Merk<S>,
         key: K,
         allow_cache: bool,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

Changed visibility of several `Element`'s methods to crate only and cleaned up those that became unused.

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

GroveDb has huge public API, but in practice only a part shall be used by users. This PR is an attempt to address those visibility issues in `element` module.

## What was done?
<!--- Describe your changes in detail -->

Visibility of methods of `Element` except constructors was changed from `pub` to `pub (crate)`, that revealed dead code that was deleted as well.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- GroveDb tests
- Platform tests using this branch

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **Refactor**
  - Restricted visibility of multiple methods in the `Element` implementation across different modules
  - Removed several public methods related to querying, getting, inserting, and deleting elements
  - Reduced external access to internal database operations

- **Changes**
  - Methods in `delete.rs`, `exists.rs`, `get.rs`, `insert.rs`, and `query.rs` have been changed from `pub` to `pub(crate)`
  - Simplified method access and improved internal encapsulation of database functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->