### PR TITLE
fix(merk): distinct keys are not available for 0..0 range

### DIFF
--- a/merk/Cargo.toml
+++ b/merk/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 documentation = "https://docs.rs/grovedb-merk"
 
 [dependencies]
-grovedb-costs = { version = "3.0.0" , path = "../costs" }
+grovedb-costs = { version = "3.0.0", path = "../costs" }
 grovedb-path = { version = "3.0.0", path = "../path" }
 grovedb-storage = { version = "3.0.0", path = "../storage", optional = true }
 grovedb-version = { version = "3.0.0", path = "../grovedb-version" }
@@ -47,26 +47,27 @@ default = ["full"]
 proof_debug = []
 serde = ["dep:serde", "indexmap/serde"]
 minimal = ["num_cpus",
-        "ed",
-        "blake3",
-        "grovedb-storage",
-        "grovedb-storage/rocksdb_storage"
+    "ed",
+    "blake3",
+    "grovedb-storage",
+    "grovedb-storage/rocksdb_storage"
 ]
 full = ["minimal",
-        "test_utils",
-        "colored_debug",
+    "test_utils",
+    "colored_debug",
 ]
 test_utils = ["rand"]
 colored_debug = ["colored"]
 verify = [
-        "ed",
-        "blake3"
+    "ed",
+    "blake3"
 ]
 grovedbg = ["full"]
 
 [dev-dependencies]
 tempfile = "3.10.1"
 criterion = "0.5.1"
+assert_matches = "1.5.0"
 
 [[bench]]
 name = "merk"

--- a/merk/src/proofs/query/insert.rs
+++ b/merk/src/proofs/query/insert.rs
@@ -147,7 +147,9 @@ impl Query {
             .items
             .iter()
             .filter_map(|our_item| {
-                if our_item.collides_with(&item) {
+                if our_item.is_key() && item.is_key() && our_item == &item {
+                    None
+                } else if our_item.collides_with(&item) {
                     item.merge_assign(our_item);
                     None
                 } else {
@@ -169,6 +171,32 @@ impl Query {
     pub fn insert_items(&mut self, items: Vec<QueryItem>) {
         for item in items {
             self.insert_item(item)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use assert_matches::assert_matches;
+
+    use super::*;
+
+    mod insert_item {
+        use super::*;
+
+        #[test]
+        fn test_insert_item_adds_only_one_key_for_equal_key_items() {
+            let value = vec![
+                3, 207, 99, 250, 114, 92, 207, 167, 120, 9, 236, 164, 124, 63, 102, 237, 201, 35,
+                86, 5, 23, 169, 147, 150, 61, 132, 155, 33, 225, 145, 85, 138,
+            ];
+
+            let mut query = Query::new();
+
+            query.insert_key(value.clone());
+            query.insert_key(value.clone());
+
+            assert_matches!(query.items.as_slice(), [QueryItem::Key(v)] if v == &value);
         }
     }
 }

--- a/merk/src/proofs/query/query_item/merge.rs
+++ b/merk/src/proofs/query/query_item/merge.rs
@@ -8,6 +8,10 @@ use crate::proofs::query::query_item::QueryItem;
 #[cfg(any(feature = "minimal", feature = "verify"))]
 impl QueryItem {
     pub(crate) fn merge(&self, other: &Self) -> Self {
+        if self.is_key() && other.is_key() && self == other {
+            return self.clone();
+        }
+
         let lower_unbounded = self.lower_unbounded() || other.lower_unbounded();
         let upper_unbounded = self.upper_unbounded() || other.upper_unbounded();
 
@@ -69,5 +73,27 @@ impl QueryItem {
 
     pub(crate) fn merge_assign(&mut self, other: &Self) {
         *self = self.merge(other);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use assert_matches::assert_matches;
+
+    use super::*;
+
+    #[test]
+    fn test_merge_of_two_equal_keys_must_be_the_same_key() {
+        let value = vec![
+            3, 207, 99, 250, 114, 92, 207, 167, 120, 9, 236, 164, 124, 63, 102, 237, 201, 35, 86,
+            5, 23, 169, 147, 150, 61, 132, 155, 33, 225, 145, 85, 138,
+        ];
+
+        let key1 = QueryItem::Key(value.clone());
+        let key2 = key1.clone();
+
+        let merged = key1.merge(&key2);
+
+        assert_matches!(merged, QueryItem::Key(v) if v == value);
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
```
merk error: invalid operation error distinct keys are not available for ranges using more or less than 1 byte
```
when inserting two identical keys to query

## What was done?
<!--- Describe your changes in detail -->
- Skip duplicate key on query insert
- Return the same key on merge

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Changes covered with unit tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved configuration consistency and organization, including the addition of a new development dependency.
- **Bug Fixes**
  - Enhanced query key handling to prevent duplicate entries during insertion.
  - Refined merging logic to consistently return a single instance when identical keys are combined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->