### PR TITLE
fix: small fix on finalizing non-regular trees

### DIFF
--- a/merk/src/merk/restore.rs
+++ b/merk/src/merk/restore.rs
@@ -455,7 +455,7 @@ impl<'db, S: StorageContext<'db>> Restorer<S> {
 
         if !self
             .merk
-            .verify(self.merk.tree_type == TreeType::NormalTree, grove_version)
+            .verify(self.merk.tree_type != TreeType::NormalTree, grove_version)
             .0
             .is_empty()
         {

--- a/tutorials/src/bin/replication.rs
+++ b/tutorials/src/bin/replication.rs
@@ -16,6 +16,8 @@ const KEY_INT_1: &[u8] = b"key_int_1";
 const KEY_INT_2: &[u8] = b"key_int_2";
 const KEY_INT_REF_0: &[u8] = b"key_int_ref_0";
 const KEY_INT_A: &[u8] = b"key_sum_0";
+
+const KEY_INT_COUNT: &[u8] = b"key_count_0";
 const ROOT_PATH: &[&[u8]] = &[];
 
 pub(crate) type SubtreePrefix = [u8; blake3::OUT_LEN];
@@ -70,6 +72,13 @@ fn populate_db(grovedb_path: String, grove_version: &GroveVersion) -> GroveDb {
     insert_range_values_db(&db, &[MAIN_ΚΕΥ, KEY_INT_A], 1, 500, &tx_3, &grove_version);
     insert_sum_element_db(&db, &[MAIN_ΚΕΥ, KEY_INT_A], 501, 550, &tx_3, &grove_version);
     let _ = db.commit_transaction(tx_3);
+
+    insert_empty_count_tree_db(&db, &[MAIN_ΚΕΥ], KEY_INT_COUNT, &grove_version);
+
+    let tx_4 = db.start_transaction();
+    insert_range_values_db(&db, &[MAIN_ΚΕΥ, KEY_INT_COUNT], 1, 50, &tx_4, &grove_version);
+    let _ = db.commit_transaction(tx_4);
+
     db
 }
 
@@ -122,6 +131,13 @@ fn main() {
 
     let query_path = &[MAIN_ΚΕΥ, KEY_INT_0];
     let query_key = (20487u32).to_be_bytes().to_vec();
+    println!("\n######## Query on db_checkpoint_0:");
+    query_db(&db_checkpoint_0, query_path, query_key.clone(), &grove_version);
+    println!("\n######## Query on db_destination:");
+    query_db(&db_destination, query_path, query_key.clone(), &grove_version);
+
+    let query_path = &[MAIN_ΚΕΥ, KEY_INT_COUNT];
+    let query_key = (40u32).to_be_bytes().to_vec();
     println!("\n######## Query on db_checkpoint_0:");
     query_db(&db_checkpoint_0, query_path, query_key.clone(), &grove_version);
     println!("\n######## Query on db_destination:");
@@ -202,6 +218,14 @@ fn insert_sum_element_db(db: &GroveDb, path: &[&[u8]], min_i: u32, max_i: u32, t
             .expect("successfully inserted values");
     }
 }
+
+fn insert_empty_count_tree_db(db: &GroveDb, path: &[&[u8]], key: &[u8], grove_version: &GroveVersion)
+{
+    db.insert(path, key, Element::empty_count_tree(), INSERT_OPTIONS, None, grove_version)
+        .unwrap()
+        .expect("successfully inserted tree");
+}
+
 fn generate_random_path(prefix: &str, suffix: &str, len: usize) -> String {
     let random_string: String = rand::thread_rng()
         .sample_iter(&Alphanumeric)


### PR DESCRIPTION
## Issue being fixed or feature implemented
When restoring non-regular trees, verify tree was failing.

## What was done?
Correct condition

## How Has This Been Tested?
Added sync of new non-regular trees and tested queries on them (replication tutorial)

## Breaking Changes
no

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted the restoration process to enforce proper error handling when encountering certain restoration conditions.

- **New Features**
  - Enhanced database replication by introducing a new count structure. The database setup now includes the creation and querying of an empty count tree, enabling improved verification of inserted values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->