### PR TITLE
feat: chunk packing

### DIFF
--- a/grovedb/src/replication/state_sync_session.rs
+++ b/grovedb/src/replication/state_sync_session.rs
@@ -21,7 +21,11 @@ use super::{
     utils::{decode_vec_ops, encode_global_chunk_id, path_to_string},
     CURRENT_STATE_SYNC_VERSION,
 };
-use crate::{replication, Element, Error, GroveDb, Transaction};
+use crate::{
+    replication,
+    replication::utils::{pack_nested_bytes, unpack_nested_bytes},
+    Element, Error, GroveDb, Transaction,
+};
 
 pub(crate) type SubtreePrefix = [u8; 32];
 
@@ -54,7 +58,7 @@ impl SubtreeStateSyncInfo<'_> {
     /// # Parameters
     /// - `chunk_id`: A byte slice representing the local chunk ID to be
     ///   applied.
-    /// - `chunk_data`: A vector of bytes containing the chunk proof operators,
+    /// - `chunk_data`: A byte slice containing the chunk proof operators,
     ///   encoded as bytes.
     /// - `grove_version`: A reference to the `GroveVersion` being used for
     ///   synchronization.
@@ -85,7 +89,7 @@ impl SubtreeStateSyncInfo<'_> {
     fn apply_inner_chunk(
         &mut self,
         chunk_id: &[u8],
-        chunk_data: Vec<u8>,
+        chunk_data: &[u8],
         grove_version: &GroveVersion,
     ) -> Result<Vec<Vec<u8>>, Error> {
         let mut res = vec![];
@@ -97,7 +101,7 @@ impl SubtreeStateSyncInfo<'_> {
         }
         self.pending_chunks.remove(chunk_id);
         if !chunk_data.is_empty() {
-            match decode_vec_ops(chunk_data) {
+            match decode_vec_ops(&chunk_data) {
                 Ok(ops) => {
                     match self.restorer.process_chunk(chunk_id, ops, grove_version) {
                         Ok(next_chunk_ids) => {
@@ -295,9 +299,10 @@ impl<'db> MultiStateSyncSession<'db> {
     /// # Parameters
     /// - `self`: A pinned mutable reference to the `MultiStateSyncSession`.
     /// - `db`: A reference to the `GroveDb` instance used for synchronization.
-    /// - `global_chunk_id`: A byte slice representing the global chunk ID being
-    ///   applied.
-    /// - `chunk`: A vector of bytes containing the encoded proof for the chunk.
+    /// - `packed_global_chunk_ids`: A byte slice representing the packed global
+    ///   chunk IDs being applied.
+    /// - `packed_global_chunks`: A byte slice containing packed encoded proof
+    ///   for the chunk.
     /// - `version`: The state synchronization protocol version being used.
     /// - `grove_version`: A reference to the `GroveVersion` specifying the
     ///   GroveDB version.
@@ -325,8 +330,8 @@ impl<'db> MultiStateSyncSession<'db> {
     pub fn apply_chunk(
         self: &mut Pin<Box<MultiStateSyncSession<'db>>>,
         db: &'db GroveDb,
-        global_chunk_id: &[u8],
-        chunk: Vec<u8>,
+        packed_global_chunk_ids: &[u8],
+        packed_global_chunks: &[u8],
         version: u16,
         grove_version: &GroveVersion,
     ) -> Result<Vec<Vec<u8>>, Error> {
@@ -342,78 +347,133 @@ impl<'db> MultiStateSyncSession<'db> {
             ));
         }
 
-        let mut next_chunk_ids = vec![];
+        let mut nested_global_chunk_ids: Vec<Vec<u8>> = vec![];
+        let mut nested_global_chunks: Vec<Vec<u8>> = vec![];
+        if self.app_hash == packed_global_chunk_ids {
+            nested_global_chunk_ids = vec![packed_global_chunk_ids.to_vec()];
+            nested_global_chunks = unpack_nested_bytes(packed_global_chunks)?;
+        } else {
+            nested_global_chunk_ids.extend(unpack_nested_bytes(packed_global_chunk_ids)?);
+            nested_global_chunks.extend(unpack_nested_bytes(packed_global_chunks)?);
+        }
 
-        let (chunk_prefix, _, _, chunk_id) =
-            replication::utils::decode_global_chunk_id(global_chunk_id, &self.app_hash)?;
-
+        if (nested_global_chunk_ids.len() != nested_global_chunks.len()) {
+            return Err(Error::InternalError(
+                "Packed num of global chunkIDs and chunks are not matching".to_string(),
+            ));
+        }
         if self.is_empty() {
             return Err(Error::InternalError(
                 "GroveDB is not in syncing mode".to_string(),
             ));
         }
 
-        let current_prefixes = self.as_mut().current_prefixes();
-        let Some(subtree_state_sync) = current_prefixes.get_mut(&chunk_prefix) else {
-            return Err(Error::InternalError(
-                "Unable to process incoming chunk".to_string(),
-            ));
-        };
-        let Ok(res) = subtree_state_sync.apply_inner_chunk(&chunk_id, chunk, grove_version) else {
-            return Err(Error::InternalError("Invalid incoming prefix".to_string()));
-        };
+        let mut next_global_chunk_ids: Vec<Vec<u8>> = vec![];
 
-        if !res.is_empty() {
-            for local_chunk_id in res.iter() {
-                next_chunk_ids.push(encode_global_chunk_id(
-                    chunk_prefix,
-                    subtree_state_sync.root_key.clone(),
-                    subtree_state_sync.tree_type,
-                    local_chunk_id.clone(),
+        for (index, (iter_global_chunk_id, iter_packed_chunks)) in nested_global_chunk_ids
+            .iter()
+            .zip(nested_global_chunks.iter())
+            .enumerate()
+        {
+            let mut next_chunk_ids = vec![];
+
+            let (chunk_prefix, _, _, nested_local_chunk_ids) =
+                replication::utils::decode_global_chunk_id(
+                    iter_global_chunk_id.as_slice(),
+                    &self.app_hash,
+                )?;
+
+            let iter_chunk_ds: Box<dyn Iterator<Item = Vec<u8>>> =
+                if nested_local_chunk_ids.is_empty() {
+                    Box::new(std::iter::once(vec![]))
+                } else {
+                    Box::new(nested_local_chunk_ids.into_iter())
+                };
+            let it_chunk_ids = iter_chunk_ds.collect::<Vec<_>>();
+
+            let current_nested_chunk_data = unpack_nested_bytes(iter_packed_chunks.as_slice())?;
+
+            if (it_chunk_ids.len() != current_nested_chunk_data.len()) {
+                return Err(Error::InternalError(
+                    "Packed num of chunkIDs and chunks are not matching #2".to_string(),
                 ));
             }
 
-            Ok(next_chunk_ids)
-        } else {
-            if !subtree_state_sync.pending_chunks.is_empty() {
-                return Ok(vec![]);
+            let current_prefixes = self.as_mut().current_prefixes();
+            let Some(subtree_state_sync) = current_prefixes.get_mut(&chunk_prefix) else {
+                return Err(Error::InternalError(
+                    "Unable to process incoming chunk".to_string(),
+                ));
+            };
+
+            let mut next_local_chunk_ids = vec![];
+            for (index, (current_local_chunk_id, current_local_chunks)) in it_chunk_ids
+                .iter()
+                .zip(current_nested_chunk_data.iter())
+                .enumerate()
+            {
+                next_local_chunk_ids.extend(subtree_state_sync.apply_inner_chunk(
+                    current_local_chunk_id.as_slice(),
+                    current_local_chunks.as_slice(),
+                    grove_version,
+                )?);
             }
 
-            let completed_path = subtree_state_sync.current_path.clone();
+            if !next_local_chunk_ids.is_empty() {
+                for grouped_ids in next_local_chunk_ids.chunks(32) {
+                    next_chunk_ids.push(encode_global_chunk_id(
+                        chunk_prefix,
+                        subtree_state_sync.root_key.clone(),
+                        subtree_state_sync.tree_type,
+                        grouped_ids.to_vec(),
+                    ));
+                }
+                next_global_chunk_ids.extend(next_chunk_ids);
+            } else {
+                if subtree_state_sync.pending_chunks.is_empty() {
+                    let completed_path = subtree_state_sync.current_path.clone();
 
-            // Subtree is finished. We can save it.
-            if subtree_state_sync.num_processed_chunks > 0 {
-                if let Some(prefix_data) = current_prefixes.remove(&chunk_prefix) {
-                    if let Err(err) = prefix_data.restorer.finalize(grove_version) {
-                        return Err(Error::InternalError(format!(
-                            "Unable to finalize Merk: {:?}",
-                            err
-                        )));
+                    // Subtree is finished. We can save it.
+                    if subtree_state_sync.num_processed_chunks > 0 {
+                        if let Some(prefix_data) = current_prefixes.remove(&chunk_prefix) {
+                            if let Err(err) = prefix_data.restorer.finalize(grove_version) {
+                                return Err(Error::InternalError(format!(
+                                    "Unable to finalize Merk: {:?}",
+                                    err
+                                )));
+                            }
+                        } else {
+                            return Err(Error::InternalError(format!(
+                                "Prefix {:?} does not exist in current_prefixes",
+                                chunk_prefix
+                            )));
+                        }
                     }
-                } else {
-                    return Err(Error::InternalError(format!(
-                        "Prefix {:?} does not exist in current_prefixes",
-                        chunk_prefix
-                    )));
+
+                    self.as_mut().processed_prefixes().insert(chunk_prefix);
+
+                    let new_subtrees_metadata =
+                        self.discover_new_subtrees_metadata(db, &completed_path, grove_version)?;
+
+                    if let Ok(res) =
+                        self.prepare_sync_state_sessions(db, new_subtrees_metadata, grove_version)
+                    {
+                        next_chunk_ids.extend(res);
+                        next_global_chunk_ids.extend(next_chunk_ids);
+                    } else {
+                        return Err(Error::InternalError(
+                            "Unable to discover Subtrees".to_string(),
+                        ));
+                    }
                 }
             }
-
-            self.as_mut().processed_prefixes().insert(chunk_prefix);
-
-            let new_subtrees_metadata =
-                self.discover_new_subtrees_metadata(db, &completed_path, grove_version)?;
-
-            if let Ok(res) =
-                self.prepare_sync_state_sessions(db, new_subtrees_metadata, grove_version)
-            {
-                next_chunk_ids.extend(res);
-                Ok(next_chunk_ids)
-            } else {
-                Err(Error::InternalError(
-                    "Unable to discover Subtrees".to_string(),
-                ))
-            }
         }
+
+        let mut res: Vec<Vec<u8>> = vec![];
+        for grouped_next_global_chunk_ids in next_global_chunk_ids.chunks(32) {
+            res.push(pack_nested_bytes(grouped_next_global_chunk_ids.to_vec()));
+        }
+        Ok(res)
     }
 
     /// Discovers new subtrees at the given path that need to be synchronized.

--- a/tutorials/src/bin/replication.rs
+++ b/tutorials/src/bin/replication.rs
@@ -281,7 +281,7 @@ fn sync_db_demo(
         num_chunks += 1;
         let ops = source_db.fetch_chunk(chunk_id.as_slice(), None, CURRENT_STATE_SYNC_VERSION, grove_version)?;
 
-        let more_chunks = session.apply_chunk(&target_db, chunk_id.as_slice(), ops, CURRENT_STATE_SYNC_VERSION, grove_version)?;
+        let more_chunks = session.apply_chunk(&target_db, chunk_id.as_slice(), &ops, CURRENT_STATE_SYNC_VERSION, grove_version)?;
         chunk_queue.extend(more_chunks);
     }
     println!("num_chunks: {}", num_chunks);


### PR DESCRIPTION
## Issue being fixed or feature implemented
This PR allows faster state sync by packing several chunks into one.

## What was done?
A two tier packing is made. 
One for packing N global_chunk_ids into one, and the second one is for packing local_chunk_ids belonging to the same subtree.

## How Has This Been Tested?
Tutorial replication

## Breaking Changes
No

## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
