### PR TITLE
feat: intermediate tx commiting in state sync

### DIFF
--- a/grovedb/src/replication.rs
+++ b/grovedb/src/replication.rs
@@ -240,6 +240,12 @@ impl GroveDb {
             ));
         }
 
+        if subtrees_batch_size == 0 {
+            return Err(Error::InternalError(
+                "subtrees_batch_size cannot be zero".to_string(),
+            ));
+        }
+
         let root_prefix = [0u8; 32];
 
         let mut session = self.start_syncing_session(app_hash, subtrees_batch_size);

--- a/grovedb/src/replication.rs
+++ b/grovedb/src/replication.rs
@@ -32,8 +32,12 @@ pub const CURRENT_STATE_SYNC_VERSION: u16 = 1;
 
 #[cfg(feature = "minimal")]
 impl GroveDb {
-    pub fn start_syncing_session(&self, app_hash: [u8; 32]) -> Pin<Box<MultiStateSyncSession>> {
-        MultiStateSyncSession::new(self.start_transaction(), app_hash)
+    pub fn start_syncing_session(
+        &self,
+        app_hash: [u8; 32],
+        subtrees_batch_size: usize,
+    ) -> Pin<Box<MultiStateSyncSession>> {
+        MultiStateSyncSession::new(self.start_transaction(), app_hash, subtrees_batch_size)
     }
 
     pub fn commit_session(&self, session: Pin<Box<MultiStateSyncSession>>) -> Result<(), Error> {
@@ -184,6 +188,8 @@ impl GroveDb {
     ///
     /// # Parameters
     /// - `app_hash`: The root hash of the application state to synchronize.
+    /// - `subtrees_batch_size`: Maximum number of subtrees that can be
+    ///   processed in a single batch.
     /// - `version`: The version of the state sync protocol to use.
     /// - `grove_version`: The version of GroveDB being used.
     ///
@@ -216,6 +222,7 @@ impl GroveDb {
     pub fn start_snapshot_syncing(
         &self,
         app_hash: CryptoHash,
+        subtrees_batch_size: usize,
         version: u16,
         grove_version: &GroveVersion,
     ) -> Result<Pin<Box<MultiStateSyncSession>>, Error> {
@@ -235,7 +242,7 @@ impl GroveDb {
 
         let root_prefix = [0u8; 32];
 
-        let mut session = self.start_syncing_session(app_hash);
+        let mut session = self.start_syncing_session(app_hash, subtrees_batch_size);
 
         session.add_subtree_sync_info(
             self,

--- a/grovedb/src/replication/state_sync_session.rs
+++ b/grovedb/src/replication/state_sync_session.rs
@@ -221,12 +221,11 @@ impl<'db> MultiStateSyncSession<'db> {
         unsafe { Pin::into_inner_unchecked(self) }.transaction
     }
 
-    pub unsafe fn set_new_transaction(
-        self: Pin<&mut Self>,
-        new_tx: Transaction<'db>,
-    ) -> Transaction<'db> {
-        let this = self.get_unchecked_mut();
-        mem::replace(&mut this.transaction, new_tx)
+    pub fn set_new_transaction(self: Pin<&mut Self>, new_tx: Transaction<'db>) -> Transaction<'db> {
+        unsafe {
+            let this = self.get_unchecked_mut();
+            mem::replace(&mut this.transaction, new_tx)
+        }
     }
 
     /// Adds synchronization information for a subtree into the current

--- a/tutorials/src/bin/replication.rs
+++ b/tutorials/src/bin/replication.rs
@@ -269,7 +269,8 @@ fn sync_db_demo(
 ) -> Result<(), grovedb::Error> {
     let start_time = Instant::now();
     let app_hash = source_db.root_hash(None, grove_version).value.unwrap();
-    let mut session = target_db.start_snapshot_syncing(app_hash, 2, CURRENT_STATE_SYNC_VERSION, grove_version)?;
+    const SUBTREES_BATCH_SIZE: u32 = 2; // Small value for demo purposes
+    let mut session = target_db.start_snapshot_syncing(app_hash, SUBTREES_BATCH_SIZE, CURRENT_STATE_SYNC_VERSION, grove_version)?;
 
     let mut chunk_queue : VecDeque<Vec<u8>> = VecDeque::new();
 
@@ -280,18 +281,8 @@ fn sync_db_demo(
     while let Some(chunk_id) = chunk_queue.pop_front() {
         num_chunks += 1;
         let ops = source_db.fetch_chunk(chunk_id.as_slice(), None, CURRENT_STATE_SYNC_VERSION, grove_version)?;
-        let (more_chunks, intermediate_commit) = session.apply_chunk(&target_db, chunk_id.as_slice(), &ops, CURRENT_STATE_SYNC_VERSION, grove_version)?;
-        if intermediate_commit {
-            let old_tx = unsafe {
-                session.as_mut().set_new_transaction(target_db.start_transaction())
-            };
-            target_db.commit_transaction(old_tx).value?;
-            let more_new_chunks = session.resume_sync(&target_db, CURRENT_STATE_SYNC_VERSION, grove_version)?;
-            chunk_queue.extend(more_new_chunks);
-        }
-        else {
-            chunk_queue.extend(more_chunks);
-        }
+        let more_chunks = session.apply_chunk(chunk_id.as_slice(), &ops, CURRENT_STATE_SYNC_VERSION, grove_version)?;
+        chunk_queue.extend(more_chunks);
     }
     println!("num_chunks: {}", num_chunks);
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
Because tx sessions on GroveDB are held in memory, single-tx state sync consumes excessive memory and has a very high failure risk (connection lost, timeout, crash, etc.) especially for mainnet syncing.


## What was done?
This PR allows state sync to be conducted with intermediate transaction commits instead of a single one.

## How Has This Been Tested?
Replication tutorial


## Breaking Changes



## Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the replication synchronization process with flexible batch processing for smoother and more efficient state updates.
  - Improved workflow for handling intermediate commits, ensuring robust and uninterrupted synchronization.
  - Introduced a new method to resume synchronization, allowing for better management of discovered subtrees.
  - Added a constant for subtree batch size in the synchronization demo, refining session initiation.

- **Documentation**
  - Updated guides to clearly explain the new synchronization options and improved processing flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->