### PR TITLE
feat: add TreeFeatureType export for minimal and verify features

### DIFF
--- a/grovedb/src/lib.rs
+++ b/grovedb/src/lib.rs
@@ -180,6 +180,8 @@ pub use grovedb_merk::estimated_costs::{
 pub use grovedb_merk::proofs::query::query_item::QueryItem;
 #[cfg(any(feature = "minimal", feature = "verify"))]
 pub use grovedb_merk::proofs::Query;
+#[cfg(any(feature = "minimal", feature = "verify"))]
+pub use grovedb_merk::tree::TreeFeatureType;
 #[cfg(feature = "minimal")]
 use grovedb_merk::tree::kv::ValueDefinedCostType;
 #[cfg(feature = "minimal")]


### PR DESCRIPTION
Added the export of `TreeFeatureType` from `grovedb_merk::tree` when the "minimal" or "verify" features are enabled. This change allows users to access `TreeFeatureType` in configurations that require these features, enhancing the functionality and flexibility of the library.