### PR TITLE
feat: add VerifyOptions to proofs module

### DIFF
--- a/grovedb/src/lib.rs
+++ b/grovedb/src/lib.rs
@@ -181,6 +181,8 @@ pub use grovedb_merk::proofs::query::query_item::QueryItem;
 #[cfg(any(feature = "minimal", feature = "verify"))]
 pub use grovedb_merk::proofs::Query;
 #[cfg(any(feature = "minimal", feature = "verify"))]
+pub use grovedb_merk::proofs::query::VerifyOptions;
+#[cfg(any(feature = "minimal", feature = "verify"))]
 pub use grovedb_merk::tree::TreeFeatureType;
 #[cfg(feature = "minimal")]
 use grovedb_merk::tree::kv::ValueDefinedCostType;


### PR DESCRIPTION
Added `VerifyOptions` to the `grovedb_merk::proofs::query` module. This change allows for enhanced verification options when querying proofs, improving flexibility and functionality for users requiring verification features.