### PR TITLE
fix: correct proof verification logic in GroveDb

### DIFF
--- a/grovedb/src/lib.rs
+++ b/grovedb/src/lib.rs
@@ -179,15 +179,15 @@ pub use grovedb_merk::estimated_costs::{
 #[cfg(any(feature = "minimal", feature = "verify"))]
 pub use grovedb_merk::proofs::query::query_item::QueryItem;
 #[cfg(any(feature = "minimal", feature = "verify"))]
-pub use grovedb_merk::proofs::Query;
-#[cfg(any(feature = "minimal", feature = "verify"))]
 pub use grovedb_merk::proofs::query::VerifyOptions;
 #[cfg(any(feature = "minimal", feature = "verify"))]
-pub use grovedb_merk::tree::TreeFeatureType;
+pub use grovedb_merk::proofs::Query;
 #[cfg(feature = "minimal")]
 use grovedb_merk::tree::kv::ValueDefinedCostType;
 #[cfg(feature = "minimal")]
 pub use grovedb_merk::tree::AggregateData;
+#[cfg(any(feature = "minimal", feature = "verify"))]
+pub use grovedb_merk::tree::TreeFeatureType;
 #[cfg(any(feature = "minimal", feature = "verify"))]
 pub use grovedb_merk::tree_type::{MaybeTree, TreeType};
 #[cfg(feature = "minimal")]


### PR DESCRIPTION
Updated the proof verification logic in the `GroveDb` implementation. The changes ensure that when a query item is not found at a specified path, the system correctly processes the path and updates the result accordingly to return a tree item as that is what we are looking for. This addresses potential issues with proof validation, specifically in scenarios where the expected tree structure does not match the provided proof. The logic for handling limits on query results has also been refined to prevent premature termination of the verification process.