### PR TITLE
feat: add ASCII check before appending string to hex display

### DIFF
--- a/grovedb/src/reference_path.rs
+++ b/grovedb/src/reference_path.rs
@@ -147,9 +147,11 @@ fn display_path(path: &[Vec<u8>]) -> String {
         .map(|bytes| {
             let mut hx = hex::encode(bytes);
             if let Ok(s) = String::from_utf8(bytes.clone()) {
-                hx.push('(');
-                hx.push_str(&s);
-                hx.push(')');
+                if s.is_ascii() {
+                    hx.push('(');
+                    hx.push_str(&s);
+                    hx.push(')');
+                }
             }
 
             hx


### PR DESCRIPTION
Updated the `display_path` function to include a check for ASCII characters before appending the UTF-8 string representation to the hex display. This change ensures that only valid ASCII strings are included in the output, preventing potential issues with non-ASCII characters.