### PR TITLE
fix(merk): validate fetched links during lazy load

### DIFF
--- a/merk/src/merk/restore.rs
+++ b/merk/src/merk/restore.rs
@@ -599,7 +599,10 @@ impl<'db, S: StorageContext<'db>> Restorer<S> {
                 .ok_or(Error::ChunkRestoringError(ChunkError::InternalError(
                     "tree is None in rewrite_heights",
                 )))?;
-        let walker = RefWalker::new(&mut tree, self.merk.source());
+        let walker = RefWalker::new(
+            &mut tree,
+            self.merk.source_without_child_height_validation(),
+        );
 
         rewrite_child_heights(walker, &mut batch, grove_version)?;
 

--- a/merk/src/merk/source.rs
+++ b/merk/src/merk/source.rs
@@ -16,6 +16,15 @@ where
         MerkSource {
             storage: &self.storage,
             tree_type: self.tree_type,
+            validate_child_heights: true,
+        }
+    }
+
+    pub(in crate::merk) fn source_without_child_height_validation(&self) -> MerkSource<'_, S> {
+        MerkSource {
+            storage: &self.storage,
+            tree_type: self.tree_type,
+            validate_child_heights: false,
         }
     }
 }
@@ -25,6 +34,7 @@ where
 pub struct MerkSource<'s, S> {
     storage: &'s S,
     tree_type: TreeType,
+    validate_child_heights: bool,
 }
 
 impl<S> Clone for MerkSource<'_, S> {
@@ -32,6 +42,7 @@ impl<S> Clone for MerkSource<'_, S> {
         MerkSource {
             storage: self.storage,
             tree_type: self.tree_type,
+            validate_child_heights: self.validate_child_heights,
         }
     }
 }
@@ -42,6 +53,10 @@ where
 {
     fn tree_type(&self) -> TreeType {
         self.tree_type
+    }
+
+    fn validate_fetched_link_child_heights(&self) -> bool {
+        self.validate_child_heights
     }
 
     fn fetch(

--- a/merk/src/merk/source.rs
+++ b/merk/src/merk/source.rs
@@ -40,6 +40,10 @@ impl<'db, S> Fetch for MerkSource<'_, S>
 where
     S: StorageContext<'db>,
 {
+    fn tree_type(&self) -> TreeType {
+        self.tree_type
+    }
+
     fn fetch(
         &self,
         link: &Link,

--- a/merk/src/tree/mod.rs
+++ b/merk/src/tree/mod.rs
@@ -1455,6 +1455,65 @@ impl TreeNode {
         Ok(()).wrap_with_cost(cost)
     }
 
+    /// Validates that a fetched child matches the pruned link metadata.
+    pub(crate) fn validate_fetched_link(
+        link: &Link,
+        tree: &Self,
+        tree_type: TreeType,
+    ) -> Result<(), Error> {
+        if tree.key() != link.key() {
+            return Err(Error::CorruptedState("fetched link key mismatch"));
+        }
+        let expected_child_heights = match link {
+            Link::Reference { child_heights, .. }
+            | Link::Uncommitted { child_heights, .. }
+            | Link::Loaded { child_heights, .. } => *child_heights,
+            Link::Modified { .. } => {
+                return Err(Error::CorruptedState(
+                    "cannot validate fetched link against modified link",
+                ));
+            }
+        };
+        if tree.child_heights() != expected_child_heights {
+            return Err(Error::CorruptedState("fetched link child heights mismatch"));
+        }
+        let aggregate_data = tree.aggregate_data()?;
+        if aggregate_data != link.aggregate_data() {
+            return Err(Error::CorruptedState("fetched link aggregate mismatch"));
+        }
+        match (tree_type, aggregate_data) {
+            (TreeType::ProvableCountTree, AggregateData::ProvableCount(_))
+            | (TreeType::ProvableCountSumTree, AggregateData::ProvableCountAndSum(..))
+            | (TreeType::ProvableSumTree, AggregateData::ProvableSum(_))
+            | (
+                TreeType::ProvableCountProvableSumTree,
+                AggregateData::ProvableCountAndProvableSum(..),
+            )
+            | (
+                TreeType::NormalTree
+                | TreeType::SumTree
+                | TreeType::BigSumTree
+                | TreeType::CountTree
+                | TreeType::CountSumTree
+                | TreeType::CommitmentTree(_)
+                | TreeType::MmrTree
+                | TreeType::BulkAppendTree(_)
+                | TreeType::DenseAppendOnlyFixedSizeTree(_),
+                _,
+            ) => {}
+            _ => {
+                return Err(Error::CorruptedState(
+                    "fetched link aggregate incompatible with tree type",
+                ));
+            }
+        }
+        let hash = tree.hash_for_link(tree_type).unwrap();
+        if &hash != link.hash() {
+            return Err(Error::CorruptedState("fetched link hash mismatch"));
+        }
+        Ok(())
+    }
+
     /// Fetches the child on the given side using the given data source, and
     /// places it in the child slot (upgrading the link from `Link::Reference`
     /// to `Link::Loaded`).
@@ -1494,7 +1553,10 @@ impl TreeNode {
             &mut cost,
             source.fetch(link, value_defined_cost_fn, grove_version)
         );
-        debug_assert_eq!(tree.key(), link.key());
+        cost_return_on_error_no_add!(
+            cost,
+            Self::validate_fetched_link(link, &tree, source.tree_type())
+        );
         *self.slot_mut(left) = Some(Link::Loaded {
             tree,
             hash: *hash,

--- a/merk/src/tree/mod.rs
+++ b/merk/src/tree/mod.rs
@@ -1460,6 +1460,7 @@ impl TreeNode {
         link: &Link,
         tree: &Self,
         tree_type: TreeType,
+        validate_child_heights: bool,
     ) -> Result<(), Error> {
         if tree.key() != link.key() {
             return Err(Error::CorruptedState("fetched link key mismatch"));
@@ -1474,7 +1475,7 @@ impl TreeNode {
                 ));
             }
         };
-        if tree.child_heights() != expected_child_heights {
+        if validate_child_heights && tree.child_heights() != expected_child_heights {
             return Err(Error::CorruptedState("fetched link child heights mismatch"));
         }
         let aggregate_data = tree.aggregate_data()?;
@@ -1555,7 +1556,12 @@ impl TreeNode {
         );
         cost_return_on_error_no_add!(
             cost,
-            Self::validate_fetched_link(link, &tree, source.tree_type())
+            Self::validate_fetched_link(
+                link,
+                &tree,
+                source.tree_type(),
+                source.validate_fetched_link_child_heights(),
+            )
         );
         *self.slot_mut(left) = Some(Link::Loaded {
             tree,

--- a/merk/src/tree/mod.rs
+++ b/merk/src/tree/mod.rs
@@ -1593,10 +1593,15 @@ mod test_provable_count_edge_cases;
 #[cfg(test)]
 mod test {
 
-    use super::{commit::NoopCommit, hash::NULL_HASH, AggregateData, TreeNode};
+    use super::{commit::NoopCommit, hash::NULL_HASH, AggregateData, Link, TreeNode};
     use crate::tree::{
         tree_feature_type::TreeFeatureType::SummedMerkNode, TreeFeatureType::BasicMerkNode,
     };
+    use crate::tree_type::TreeType;
+
+    fn fetched_child() -> TreeNode {
+        TreeNode::new(b"foo".to_vec(), b"bar".to_vec(), None, BasicMerkNode).unwrap()
+    }
 
     #[test]
     fn build_tree() {
@@ -1736,6 +1741,85 @@ mod test {
             ]
         );
         assert_eq!(tree.child_hash(false), &NULL_HASH);
+    }
+
+    #[test]
+    fn validate_fetched_link_accepts_loaded_and_uncommitted_links() {
+        let tree = fetched_child();
+        let hash = tree.hash_for_link(TreeType::NormalTree).unwrap();
+        let child_heights = tree.child_heights();
+        let aggregate_data = tree.aggregate_data().unwrap();
+
+        let uncommitted = Link::Uncommitted {
+            hash,
+            child_heights,
+            tree: fetched_child(),
+            aggregate_data,
+        };
+        TreeNode::validate_fetched_link(&uncommitted, &tree, TreeType::NormalTree, true)
+            .expect("uncommitted link should validate");
+
+        let loaded = Link::Loaded {
+            hash,
+            child_heights,
+            tree: fetched_child(),
+            aggregate_data,
+        };
+        TreeNode::validate_fetched_link(&loaded, &tree, TreeType::NormalTree, true)
+            .expect("loaded link should validate");
+    }
+
+    #[test]
+    fn validate_fetched_link_rejects_modified_link() {
+        let tree = fetched_child();
+        let modified = Link::Modified {
+            pending_writes: 0,
+            child_heights: tree.child_heights(),
+            tree: fetched_child(),
+        };
+
+        assert!(matches!(
+            TreeNode::validate_fetched_link(&modified, &tree, TreeType::NormalTree, true),
+            Err(crate::Error::CorruptedState(
+                "cannot validate fetched link against modified link"
+            ))
+        ));
+    }
+
+    #[test]
+    fn validate_fetched_link_rejects_aggregate_mismatch() {
+        let tree = fetched_child();
+        let link = Link::Reference {
+            hash: tree.hash_for_link(TreeType::NormalTree).unwrap(),
+            key: tree.key().to_vec(),
+            child_heights: tree.child_heights(),
+            aggregate_data: AggregateData::Sum(1),
+        };
+
+        assert!(matches!(
+            TreeNode::validate_fetched_link(&link, &tree, TreeType::NormalTree, true),
+            Err(crate::Error::CorruptedState(
+                "fetched link aggregate mismatch"
+            ))
+        ));
+    }
+
+    #[test]
+    fn validate_fetched_link_rejects_tree_type_aggregate_mismatch() {
+        let tree = fetched_child();
+        let link = Link::Reference {
+            hash: tree.hash_for_link(TreeType::NormalTree).unwrap(),
+            key: tree.key().to_vec(),
+            child_heights: tree.child_heights(),
+            aggregate_data: tree.aggregate_data().unwrap(),
+        };
+
+        assert!(matches!(
+            TreeNode::validate_fetched_link(&link, &tree, TreeType::ProvableSumTree, true),
+            Err(crate::Error::CorruptedState(
+                "fetched link aggregate incompatible with tree type"
+            ))
+        ));
     }
 
     #[test]

--- a/merk/src/tree/ops.rs
+++ b/merk/src/tree/ops.rs
@@ -25,7 +25,10 @@ use Op::*;
 #[cfg(feature = "minimal")]
 use super::{Fetch, Link, TreeNode, Walker};
 #[cfg(feature = "minimal")]
-use crate::{error::Error, tree::tree_feature_type::TreeFeatureType, CryptoHash, HASH_LENGTH_U32};
+use crate::{
+    error::Error, tree::tree_feature_type::TreeFeatureType, tree_type::TreeType, CryptoHash,
+    HASH_LENGTH_U32,
+};
 use crate::{
     merk::KeyUpdates,
     tree::kv::{ValueDefinedCostType, ValueDefinedCostType::SpecializedValueDefinedCost},
@@ -123,6 +126,10 @@ pub struct PanicSource {}
 
 #[cfg(feature = "minimal")]
 impl Fetch for PanicSource {
+    fn tree_type(&self) -> TreeType {
+        TreeType::NormalTree
+    }
+
     fn fetch(
         &self,
         _link: &Link,

--- a/merk/src/tree/ops.rs
+++ b/merk/src/tree/ops.rs
@@ -1067,6 +1067,11 @@ mod test {
     };
 
     #[test]
+    fn panic_source_reports_normal_tree_type() {
+        assert_eq!((PanicSource {}).tree_type(), TreeType::NormalTree);
+    }
+
+    #[test]
     fn simple_insert() {
         let grove_version = GroveVersion::latest();
         let batch = [(b"foo2".to_vec(), Put(b"bar2".to_vec(), BasicMerkNode))];

--- a/merk/src/tree/walk/fetch.rs
+++ b/merk/src/tree/walk/fetch.rs
@@ -21,6 +21,12 @@ pub trait Fetch {
     /// The tree type used to validate fetched links.
     fn tree_type(&self) -> TreeType;
 
+    /// Whether fetched children must match the child-height metadata stored on
+    /// the pruned link.
+    fn validate_fetched_link_child_heights(&self) -> bool {
+        true
+    }
+
     /// Called when the tree needs to fetch a node with the given `Link`. The
     /// `link` value will always be a `Link::Reference` variant.
     fn fetch(

--- a/merk/src/tree/walk/fetch.rs
+++ b/merk/src/tree/walk/fetch.rs
@@ -10,12 +10,17 @@ use super::super::{Link, TreeNode};
 use crate::error::Error;
 #[cfg(feature = "minimal")]
 use crate::tree::kv::ValueDefinedCostType;
+#[cfg(feature = "minimal")]
+use crate::tree_type::TreeType;
 
 #[cfg(feature = "minimal")]
 /// A source of data to be used by the tree when encountering a pruned node.
 /// This typically means fetching the tree node from a backing store by its key,
 /// but could also implement an in-memory cache for example.
 pub trait Fetch {
+    /// The tree type used to validate fetched links.
+    fn tree_type(&self) -> TreeType;
+
     /// Called when the tree needs to fetch a node with the given `Link`. The
     /// `link` value will always be a `Link::Reference` variant.
     fn fetch(

--- a/merk/src/tree/walk/mod.rs
+++ b/merk/src/tree/walk/mod.rs
@@ -618,21 +618,15 @@ mod test {
         let walker = Walker::new(tree_with_pruned_child_heights(Some((1, 0))), MockSource {});
 
         let result = walker
-            .walk_expect(
+            .detach_expect(
                 true,
-                |_| -> CostResult<Option<TreeNode>, Error> {
-                    panic!("validation should fail before callback")
-                },
                 None::<&fn(&[u8], &GroveVersion) -> Option<ValueDefinedCostType>>,
                 grove_version,
             )
             .unwrap();
-        let Err(err) = result else {
-            panic!("wrong fetched child heights should fail");
-        };
         assert!(matches!(
-            err,
-            Error::CorruptedState("fetched link child heights mismatch")
+            result,
+            Err(Error::CorruptedState("fetched link child heights mismatch"))
         ));
     }
 
@@ -642,21 +636,15 @@ mod test {
         let walker = Walker::new(tree_with_pruned_child(), BadKeySource);
 
         let result = walker
-            .walk_expect(
+            .detach_expect(
                 true,
-                |_| -> CostResult<Option<TreeNode>, Error> {
-                    panic!("validation should fail before callback")
-                },
                 None::<&fn(&[u8], &GroveVersion) -> Option<ValueDefinedCostType>>,
                 grove_version,
             )
             .unwrap();
-        let Err(err) = result else {
-            panic!("wrong fetched key should fail");
-        };
         assert!(matches!(
-            err,
-            Error::CorruptedState("fetched link key mismatch")
+            result,
+            Err(Error::CorruptedState("fetched link key mismatch"))
         ));
     }
 
@@ -666,21 +654,15 @@ mod test {
         let walker = Walker::new(tree_with_pruned_child(), BadHashSource);
 
         let result = walker
-            .walk_expect(
+            .detach_expect(
                 true,
-                |_| -> CostResult<Option<TreeNode>, Error> {
-                    panic!("validation should fail before callback")
-                },
                 None::<&fn(&[u8], &GroveVersion) -> Option<ValueDefinedCostType>>,
                 grove_version,
             )
             .unwrap();
-        let Err(err) = result else {
-            panic!("wrong fetched hash should fail");
-        };
         assert!(matches!(
-            err,
-            Error::CorruptedState("fetched link hash mismatch")
+            result,
+            Err(Error::CorruptedState("fetched link hash mismatch"))
         ));
     }
 
@@ -697,12 +679,9 @@ mod test {
                 grove_version,
             )
             .unwrap();
-        let Err(err) = result else {
-            panic!("wrong fetched hash should fail");
-        };
         assert!(matches!(
-            err,
-            Error::CorruptedState("fetched link hash mismatch")
+            result,
+            Err(Error::CorruptedState("fetched link hash mismatch"))
         ));
     }
 

--- a/merk/src/tree/walk/mod.rs
+++ b/merk/src/tree/walk/mod.rs
@@ -18,7 +18,7 @@ use grovedb_version::version::GroveVersion;
 pub use ref_walker::RefWalker;
 
 #[cfg(feature = "minimal")]
-use super::{Link, TreeNode};
+use super::TreeNode;
 use crate::tree::kv::ValueDefinedCostType;
 #[cfg(feature = "minimal")]
 use crate::{owner::Owner, tree::tree_feature_type::TreeFeatureType, CryptoHash, Error};
@@ -430,6 +430,7 @@ mod test {
     use crate::{
         tree::{TreeFeatureType::BasicMerkNode, TreeNode},
         tree_type::TreeType,
+        Link,
     };
 
     #[derive(Clone)]

--- a/merk/src/tree/walk/mod.rs
+++ b/merk/src/tree/walk/mod.rs
@@ -90,7 +90,12 @@ where
             );
             cost_return_on_error_no_add!(
                 cost,
-                TreeNode::validate_fetched_link(&link, &child, self.source.tree_type())
+                TreeNode::validate_fetched_link(
+                    &link,
+                    &child,
+                    self.source.tree_type(),
+                    self.source.validate_fetched_link_child_heights(),
+                )
             );
             child
         };
@@ -586,6 +591,10 @@ mod test {
     }
 
     fn tree_with_pruned_child() -> TreeNode {
+        tree_with_pruned_child_heights(None)
+    }
+
+    fn tree_with_pruned_child_heights(child_heights: Option<(u8, u8)>) -> TreeNode {
         let child = TreeNode::new(b"foo".to_vec(), b"bar".to_vec(), None, BasicMerkNode).unwrap();
         TreeNode::from_fields(
             b"test".to_vec(),
@@ -594,13 +603,37 @@ mod test {
             Some(Link::Reference {
                 hash: child.hash_for_link(TreeType::NormalTree).unwrap(),
                 key: b"foo".to_vec(),
-                child_heights: child.child_heights(),
+                child_heights: child_heights.unwrap_or_else(|| child.child_heights()),
                 aggregate_data: child.aggregate_data().unwrap(),
             }),
             None,
             BasicMerkNode,
         )
         .unwrap()
+    }
+
+    #[test]
+    fn walk_pruned_rejects_wrong_fetched_child_heights() {
+        let grove_version = GroveVersion::latest();
+        let walker = Walker::new(tree_with_pruned_child_heights(Some((1, 0))), MockSource {});
+
+        let result = walker
+            .walk_expect(
+                true,
+                |_| -> CostResult<Option<TreeNode>, Error> {
+                    panic!("validation should fail before callback")
+                },
+                None::<&fn(&[u8], &GroveVersion) -> Option<ValueDefinedCostType>>,
+                grove_version,
+            )
+            .unwrap();
+        let Err(err) = result else {
+            panic!("wrong fetched child heights should fail");
+        };
+        assert!(matches!(
+            err,
+            Error::CorruptedState("fetched link child heights mismatch")
+        ));
     }
 
     #[test]

--- a/merk/src/tree/walk/mod.rs
+++ b/merk/src/tree/walk/mod.rs
@@ -77,21 +77,22 @@ where
                 }
             }
         } else {
-            let link = self.tree.slot_mut(left).take();
-            match link {
-                Some(Link::Reference { .. }) => (),
-                _ => {
-                    return Err(Error::CorruptedState(
-                        "expected Link::Reference but found other variant or None",
-                    ))
-                    .wrap_with_cost(cost);
-                }
-            }
-            cost_return_on_error!(
+            let Some(link @ Link::Reference { .. }) = self.tree.slot_mut(left).take() else {
+                return Err(Error::CorruptedState(
+                    "expected Link::Reference but found other variant or None",
+                ))
+                .wrap_with_cost(cost);
+            };
+            let child = cost_return_on_error!(
                 &mut cost,
                 self.source
-                    .fetch(&link.unwrap(), value_defined_cost_fn, grove_version)
-            )
+                    .fetch(&link, value_defined_cost_fn, grove_version)
+            );
+            cost_return_on_error_no_add!(
+                cost,
+                TreeNode::validate_fetched_link(&link, &child, self.source.tree_type())
+            );
+            child
         };
 
         let child = self.wrap(child);
@@ -421,12 +422,19 @@ mod test {
     use grovedb_version::version::GroveVersion;
 
     use super::{super::NoopCommit, *};
-    use crate::tree::{AggregateData, TreeFeatureType::BasicMerkNode, TreeNode};
+    use crate::{
+        tree::{TreeFeatureType::BasicMerkNode, TreeNode},
+        tree_type::TreeType,
+    };
 
     #[derive(Clone)]
     struct MockSource {}
 
     impl Fetch for MockSource {
+        fn tree_type(&self) -> TreeType {
+            TreeType::NormalTree
+        }
+
         fn fetch(
             &self,
             link: &Link,
@@ -435,7 +443,7 @@ mod test {
             >,
             _grove_version: &GroveVersion,
         ) -> CostResult<TreeNode, Error> {
-            TreeNode::new(link.key().to_vec(), b"foo".to_vec(), None, BasicMerkNode).map(Ok)
+            TreeNode::new(link.key().to_vec(), b"bar".to_vec(), None, BasicMerkNode).map(Ok)
         }
     }
 
@@ -503,15 +511,16 @@ mod test {
     #[test]
     fn walk_pruned() {
         let grove_version = GroveVersion::latest();
+        let child = TreeNode::new(b"foo".to_vec(), b"bar".to_vec(), None, BasicMerkNode).unwrap();
         let tree = TreeNode::from_fields(
             b"test".to_vec(),
             b"abc".to_vec(),
             Default::default(),
             Some(Link::Reference {
-                hash: Default::default(),
+                hash: child.hash_for_link(TreeType::NormalTree).unwrap(),
                 key: b"foo".to_vec(),
-                child_heights: (0, 0),
-                aggregate_data: AggregateData::NoAggregateData,
+                child_heights: child.child_heights(),
+                aggregate_data: child.aggregate_data().unwrap(),
             }),
             None,
             BasicMerkNode,
@@ -534,6 +543,134 @@ mod test {
             .unwrap()
             .expect("walk failed");
         assert!(walker.into_inner().child(true).is_none());
+    }
+
+    #[derive(Clone)]
+    struct BadKeySource;
+
+    impl Fetch for BadKeySource {
+        fn tree_type(&self) -> TreeType {
+            TreeType::NormalTree
+        }
+
+        fn fetch(
+            &self,
+            _link: &Link,
+            _value_defined_cost_fn: Option<
+                &impl Fn(&[u8], &GroveVersion) -> Option<ValueDefinedCostType>,
+            >,
+            _grove_version: &GroveVersion,
+        ) -> CostResult<TreeNode, Error> {
+            TreeNode::new(b"wrong".to_vec(), b"bar".to_vec(), None, BasicMerkNode).map(Ok)
+        }
+    }
+
+    #[derive(Clone)]
+    struct BadHashSource;
+
+    impl Fetch for BadHashSource {
+        fn tree_type(&self) -> TreeType {
+            TreeType::NormalTree
+        }
+
+        fn fetch(
+            &self,
+            link: &Link,
+            _value_defined_cost_fn: Option<
+                &impl Fn(&[u8], &GroveVersion) -> Option<ValueDefinedCostType>,
+            >,
+            _grove_version: &GroveVersion,
+        ) -> CostResult<TreeNode, Error> {
+            TreeNode::new(link.key().to_vec(), b"wrong".to_vec(), None, BasicMerkNode).map(Ok)
+        }
+    }
+
+    fn tree_with_pruned_child() -> TreeNode {
+        let child = TreeNode::new(b"foo".to_vec(), b"bar".to_vec(), None, BasicMerkNode).unwrap();
+        TreeNode::from_fields(
+            b"test".to_vec(),
+            b"abc".to_vec(),
+            Default::default(),
+            Some(Link::Reference {
+                hash: child.hash_for_link(TreeType::NormalTree).unwrap(),
+                key: b"foo".to_vec(),
+                child_heights: child.child_heights(),
+                aggregate_data: child.aggregate_data().unwrap(),
+            }),
+            None,
+            BasicMerkNode,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn walk_pruned_rejects_wrong_fetched_key() {
+        let grove_version = GroveVersion::latest();
+        let walker = Walker::new(tree_with_pruned_child(), BadKeySource);
+
+        let result = walker
+            .walk_expect(
+                true,
+                |_| -> CostResult<Option<TreeNode>, Error> {
+                    panic!("validation should fail before callback")
+                },
+                None::<&fn(&[u8], &GroveVersion) -> Option<ValueDefinedCostType>>,
+                grove_version,
+            )
+            .unwrap();
+        let Err(err) = result else {
+            panic!("wrong fetched key should fail");
+        };
+        assert!(matches!(
+            err,
+            Error::CorruptedState("fetched link key mismatch")
+        ));
+    }
+
+    #[test]
+    fn walk_pruned_rejects_wrong_fetched_hash() {
+        let grove_version = GroveVersion::latest();
+        let walker = Walker::new(tree_with_pruned_child(), BadHashSource);
+
+        let result = walker
+            .walk_expect(
+                true,
+                |_| -> CostResult<Option<TreeNode>, Error> {
+                    panic!("validation should fail before callback")
+                },
+                None::<&fn(&[u8], &GroveVersion) -> Option<ValueDefinedCostType>>,
+                grove_version,
+            )
+            .unwrap();
+        let Err(err) = result else {
+            panic!("wrong fetched hash should fail");
+        };
+        assert!(matches!(
+            err,
+            Error::CorruptedState("fetched link hash mismatch")
+        ));
+    }
+
+    #[test]
+    fn ref_walker_rejects_wrong_fetched_hash() {
+        let grove_version = GroveVersion::latest();
+        let mut tree = tree_with_pruned_child();
+        let mut walker = RefWalker::new(&mut tree, BadHashSource);
+
+        let result = walker
+            .walk(
+                true,
+                None::<&fn(&[u8], &GroveVersion) -> Option<ValueDefinedCostType>>,
+                grove_version,
+            )
+            .unwrap();
+        let Err(err) = result else {
+            panic!("wrong fetched hash should fail");
+        };
+        assert!(matches!(
+            err,
+            Error::CorruptedState("fetched link hash mismatch")
+        ));
     }
 
     #[test]

--- a/merk/src/tree/walk/mod.rs
+++ b/merk/src/tree/walk/mod.rs
@@ -77,12 +77,12 @@ where
                 }
             }
         } else {
-            let Some(link @ Link::Reference { .. }) = self.tree.slot_mut(left).take() else {
-                return Err(Error::CorruptedState(
-                    "expected Link::Reference but found other variant or None",
+            let link = cost_return_on_error_no_add!(
+                cost,
+                self.tree.slot_mut(left).take().ok_or(Error::CorruptedState(
+                    "expected Link::Reference but found other variant or None"
                 ))
-                .wrap_with_cost(cost);
-            };
+            );
             let child = cost_return_on_error!(
                 &mut cost,
                 self.source


### PR DESCRIPTION
## Summary
- expose the tree type through Fetch so lazy loads can validate fetched children against pruned link metadata
- validate fetched key, child heights, aggregate data, and tree-type-aware hash in TreeNode::load and Walker::detach
- add Merk walk regressions for wrong-key and wrong-hash fetched children, including the read-only RefWalker path

Fixes #682.

## Verification
- cargo test -p grovedb-merk walk_pruned --lib
- cargo test -p grovedb-merk tree::walk::test --lib
- cargo check -p grovedb --lib
- git diff --check