### PR TITLE
fix(dense): ignore inclusive queries on empty trees

### DIFF
--- a/grovedb-dense-fixed-sized-merkle-tree/src/proof/mod.rs
+++ b/grovedb-dense-fixed-sized-merkle-tree/src/proof/mod.rs
@@ -64,11 +64,12 @@ pub(crate) fn query_to_positions(query: &Query, count: u16) -> Result<Vec<u16>, 
                 }
             }
             QueryItem::RangeInclusive(r) => {
+                // Validate bounds first so malformed inputs still error on empty trees.
+                let start = bytes_to_position(r.start())?;
+                let end = bytes_to_position(r.end())?;
                 if count == 0 {
                     continue;
                 }
-                let start = bytes_to_position(r.start())?;
-                let end = bytes_to_position(r.end())?;
                 let clamped_end = end.min(count.saturating_sub(1));
                 for p in start..=clamped_end {
                     positions.insert(p);
@@ -92,10 +93,10 @@ pub(crate) fn query_to_positions(query: &Query, count: u16) -> Result<Vec<u16>, 
                 }
             }
             QueryItem::RangeToInclusive(r) => {
+                let end = bytes_to_position(&r.end)?;
                 if count == 0 {
                     continue;
                 }
-                let end = bytes_to_position(&r.end)?;
                 let clamped_end = end.min(count.saturating_sub(1));
                 for p in 0..=clamped_end {
                     positions.insert(p);
@@ -115,11 +116,11 @@ pub(crate) fn query_to_positions(query: &Query, count: u16) -> Result<Vec<u16>, 
                 }
             }
             QueryItem::RangeAfterToInclusive(r) => {
+                let start = bytes_to_position(r.start())?;
+                let end = bytes_to_position(r.end())?;
                 if count == 0 {
                     continue;
                 }
-                let start = bytes_to_position(r.start())?;
-                let end = bytes_to_position(r.end())?;
                 let clamped_end = end.min(count.saturating_sub(1));
                 for p in start.saturating_add(1)..=clamped_end {
                     positions.insert(p);

--- a/grovedb-dense-fixed-sized-merkle-tree/src/proof/mod.rs
+++ b/grovedb-dense-fixed-sized-merkle-tree/src/proof/mod.rs
@@ -64,6 +64,9 @@ pub(crate) fn query_to_positions(query: &Query, count: u16) -> Result<Vec<u16>, 
                 }
             }
             QueryItem::RangeInclusive(r) => {
+                if count == 0 {
+                    continue;
+                }
                 let start = bytes_to_position(r.start())?;
                 let end = bytes_to_position(r.end())?;
                 let clamped_end = end.min(count.saturating_sub(1));
@@ -89,6 +92,9 @@ pub(crate) fn query_to_positions(query: &Query, count: u16) -> Result<Vec<u16>, 
                 }
             }
             QueryItem::RangeToInclusive(r) => {
+                if count == 0 {
+                    continue;
+                }
                 let end = bytes_to_position(&r.end)?;
                 let clamped_end = end.min(count.saturating_sub(1));
                 for p in 0..=clamped_end {
@@ -109,6 +115,9 @@ pub(crate) fn query_to_positions(query: &Query, count: u16) -> Result<Vec<u16>, 
                 }
             }
             QueryItem::RangeAfterToInclusive(r) => {
+                if count == 0 {
+                    continue;
+                }
                 let start = bytes_to_position(r.start())?;
                 let end = bytes_to_position(r.end())?;
                 let clamped_end = end.min(count.saturating_sub(1));

--- a/grovedb-dense-fixed-sized-merkle-tree/src/proof/tests.rs
+++ b/grovedb-dense-fixed-sized-merkle-tree/src/proof/tests.rs
@@ -721,6 +721,31 @@ mod proof_tests {
             .expect("should succeed");
             assert!(positions.is_empty());
         }
+
+        #[test]
+        fn empty_tree_malformed_bound_rejected() {
+            // Malformed inclusive bounds must still surface as InvalidData
+            // even when the tree is empty — the count==0 short-circuit must
+            // not skip bound validation.
+            use grovedb_query::QueryItem;
+            let mut q = Query::new();
+            q.items
+                .push(QueryItem::RangeInclusive(vec![0, 0, 0]..=vec![0]));
+            let err = query_to_positions(&q, 0)
+                .expect_err("malformed inclusive bound must error on empty tree");
+            assert!(
+                matches!(err, crate::DenseMerkleError::InvalidData(_)),
+                "expected InvalidData, got {:?}",
+                err
+            );
+
+            let mut q = Query::new();
+            q.items
+                .push(QueryItem::RangeInclusive(vec![0]..=vec![0, 0, 0]));
+            let err = query_to_positions(&q, 0)
+                .expect_err("malformed inclusive end must error on empty tree");
+            assert!(matches!(err, crate::DenseMerkleError::InvalidData(_)));
+        }
     }
 
     // =======================================================================
@@ -1025,6 +1050,21 @@ mod proof_tests {
             .expect("should succeed");
             assert!(positions.is_empty());
         }
+
+        #[test]
+        fn empty_tree_malformed_bound_rejected() {
+            // Malformed inclusive end must still surface as InvalidData even
+            // when the tree is empty.
+            let mut q = Query::new();
+            q.insert_range_to_inclusive(..=vec![0, 0, 0]);
+            let err = query_to_positions(&q, 0)
+                .expect_err("malformed inclusive end must error on empty tree");
+            assert!(
+                matches!(err, crate::DenseMerkleError::InvalidData(_)),
+                "expected InvalidData, got {:?}",
+                err
+            );
+        }
     }
 
     mod range_after {
@@ -1280,6 +1320,27 @@ mod proof_tests {
             )
             .expect("should succeed");
             assert!(positions.is_empty());
+        }
+
+        #[test]
+        fn empty_tree_malformed_bound_rejected() {
+            // Malformed inclusive bounds must still surface as InvalidData
+            // even when the tree is empty.
+            let mut q = Query::new();
+            q.insert_range_after_to_inclusive(vec![0, 0, 0]..=vec![0xff, 0xff]);
+            let err = query_to_positions(&q, 0)
+                .expect_err("malformed inclusive start must error on empty tree");
+            assert!(
+                matches!(err, crate::DenseMerkleError::InvalidData(_)),
+                "expected InvalidData, got {:?}",
+                err
+            );
+
+            let mut q = Query::new();
+            q.insert_range_after_to_inclusive(vec![0xff, 0xff]..=vec![0, 0, 0]);
+            let err = query_to_positions(&q, 0)
+                .expect_err("malformed inclusive end must error on empty tree");
+            assert!(matches!(err, crate::DenseMerkleError::InvalidData(_)));
         }
     }
 

--- a/grovedb-dense-fixed-sized-merkle-tree/src/proof/tests.rs
+++ b/grovedb-dense-fixed-sized-merkle-tree/src/proof/tests.rs
@@ -707,6 +707,20 @@ mod proof_tests {
             assert_eq!(entries[0].0, 5);
             assert_eq!(entries[1].0, 6);
         }
+
+        #[test]
+        fn empty_tree_yields_no_positions() {
+            let positions = query_to_positions(
+                &{
+                    let mut q = Query::new();
+                    q.insert_range_inclusive(vec![0]..=vec![0]);
+                    q
+                },
+                0,
+            )
+            .expect("should succeed");
+            assert!(positions.is_empty());
+        }
     }
 
     // =======================================================================
@@ -997,6 +1011,20 @@ mod proof_tests {
             let entries = gen_and_verify(&tree, &query);
             assert_eq!(entries.len(), 7);
         }
+
+        #[test]
+        fn empty_tree_yields_no_positions() {
+            let positions = query_to_positions(
+                &{
+                    let mut q = Query::new();
+                    q.insert_range_to_inclusive(..=vec![0]);
+                    q
+                },
+                0,
+            )
+            .expect("should succeed");
+            assert!(positions.is_empty());
+        }
     }
 
     mod range_after {
@@ -1239,6 +1267,20 @@ mod proof_tests {
             assert_eq!(entries[0].0, 4);
             assert_eq!(entries[2].0, 6);
         }
+
+        #[test]
+        fn empty_tree_yields_no_positions() {
+            let positions = query_to_positions(
+                &{
+                    let mut q = Query::new();
+                    q.insert_range_after_to_inclusive(vec![0xff, 0xff]..=vec![0xff, 0xff]);
+                    q
+                },
+                0,
+            )
+            .expect("should succeed");
+            assert!(positions.is_empty());
+        }
     }
 
     // =======================================================================
@@ -1461,6 +1503,51 @@ mod proof_tests {
             let proof = DenseTreeProof::generate_for_query(&tree, &query)
                 .unwrap()
                 .expect("should succeed for empty query on empty tree");
+            let (_root, entries) = proof
+                .verify_for_query::<Vec<(u16, Vec<u8>)>>(&query, 3, 0)
+                .expect("should succeed");
+            assert!(entries.is_empty());
+        }
+
+        #[test]
+        fn empty_tree_range_inclusive_query() {
+            let tree = DenseFixedSizedMerkleTree::new(3, MemStorageContext::new())
+                .expect("height 3 should be valid");
+            let mut query = Query::new();
+            query.insert_range_inclusive(vec![0]..=vec![0]);
+            let proof = DenseTreeProof::generate_for_query(&tree, &query)
+                .unwrap()
+                .expect("should succeed for inclusive query on empty tree");
+            let (_root, entries) = proof
+                .verify_for_query::<Vec<(u16, Vec<u8>)>>(&query, 3, 0)
+                .expect("should succeed");
+            assert!(entries.is_empty());
+        }
+
+        #[test]
+        fn empty_tree_range_to_inclusive_query() {
+            let tree = DenseFixedSizedMerkleTree::new(3, MemStorageContext::new())
+                .expect("height 3 should be valid");
+            let mut query = Query::new();
+            query.insert_range_to_inclusive(..=vec![0]);
+            let proof = DenseTreeProof::generate_for_query(&tree, &query)
+                .unwrap()
+                .expect("should succeed for inclusive query on empty tree");
+            let (_root, entries) = proof
+                .verify_for_query::<Vec<(u16, Vec<u8>)>>(&query, 3, 0)
+                .expect("should succeed");
+            assert!(entries.is_empty());
+        }
+
+        #[test]
+        fn empty_tree_range_after_to_inclusive_query() {
+            let tree = DenseFixedSizedMerkleTree::new(3, MemStorageContext::new())
+                .expect("height 3 should be valid");
+            let mut query = Query::new();
+            query.insert_range_after_to_inclusive(vec![0xff, 0xff]..=vec![0xff, 0xff]);
+            let proof = DenseTreeProof::generate_for_query(&tree, &query)
+                .unwrap()
+                .expect("should succeed for inclusive query on empty tree");
             let (_root, entries) = proof
                 .verify_for_query::<Vec<(u16, Vec<u8>)>>(&query, 3, 0)
                 .expect("should succeed");


### PR DESCRIPTION
# Summary

- return no dense proof positions for empty-tree inclusive queries
- cover `RangeInclusive`, `RangeToInclusive`, and
  `RangeAfterToInclusive` empty-tree conversions
- add end-to-end empty-tree proof generation/verification regressions

Fixes #713.

## Validation

- `cargo test --offline -p grovedb-dense-fixed-sized-merkle-tree --lib` —
  177 passed
- pre-PR code review gate: ship


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Fixed range query handling on empty datasets for inclusive range variants, ensuring results remain empty when the requested count is zero while still validating malformed range bounds.

## Tests
* Added additional test cases for inclusive range queries on empty trees, covering both empty-result behavior and proper invalid-data errors for malformed inputs.
* Extended query verification tests to confirm empty entries are returned on empty datasets for these query types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->