### PR TITLE
fix(tests): deflake test_wal_and_sst_storage_overhead against vanished files

### DIFF
--- a/grovedb/src/tests/test_compaction_sizes.rs
+++ b/grovedb/src/tests/test_compaction_sizes.rs
@@ -23,7 +23,14 @@ mod tests {
             .filter(|entry| entry.path().extension().is_some_and(|ext| ext == extension))
             // Background compaction can delete a file between the read_dir
             // listing and the metadata() call; skip vanished files.
-            .filter_map(|entry| entry.metadata().ok())
+            .filter_map(|entry| match entry.metadata() {
+                Ok(metadata) => Some(metadata),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+                Err(error) => panic!(
+                    "cannot read metadata for {}: {error}",
+                    entry.path().display()
+                ),
+            })
             .map(|metadata| metadata.len())
             .sum()
     }

--- a/grovedb/src/tests/test_compaction_sizes.rs
+++ b/grovedb/src/tests/test_compaction_sizes.rs
@@ -21,7 +21,10 @@ mod tests {
             .expect("cannot read dir")
             .filter_map(|entry| entry.ok())
             .filter(|entry| entry.path().extension().is_some_and(|ext| ext == extension))
-            .map(|entry| entry.metadata().unwrap().len())
+            // Background compaction can delete a file between the read_dir
+            // listing and the metadata() call; skip vanished files.
+            .filter_map(|entry| entry.metadata().ok())
+            .map(|metadata| metadata.len())
             .sum()
     }
 


### PR DESCRIPTION
## Problem

`get_files_size` in `grovedb/src/tests/test_compaction_sizes.rs` lists a directory with `fs::read_dir` and then calls `entry.metadata().unwrap()` on each entry. RocksDB background compaction can delete a WAL/SST file between the `read_dir` listing and the `metadata()` call, making `test_wal_and_sst_storage_overhead` flaky on CI with `Os { code: 2, kind: NotFound }` (seen on PR #808, actions run 31806719166).

## Fix

Skip entries whose metadata can no longer be read (`.filter_map(|entry| entry.metadata().ok())`) instead of unwrapping. Measurement semantics are otherwise unchanged — a file deleted by compaction mid-scan simply doesn't count toward the total, which is the correct reading anyway.

## Testing

`cargo test -p grovedb --all-features --lib test_wal_and_sst_storage_overhead` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when checking directory sizes by safely handling files that are removed during the scan.
  * Prevented unexpected failures caused by transient file metadata errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->