### PR TITLE
fix: subset verification of a descending merged proof's branches (#815)

### DIFF
--- a/grovedb/src/operations/proof/generate.rs
+++ b/grovedb/src/operations/proof/generate.rs
@@ -1905,6 +1905,13 @@ impl GroveDb {
             .query
             .has_aggregate_count_and_sum_on_range_anywhere();
 
+        // `query.left_to_right` is used verbatim, synthesized levels
+        // included: this is the definition of the layer's op family, and
+        // changing it would change proof bytes. The verifier is the side
+        // that cannot reproduce this value — a subset query does not know
+        // what the generating query was — so for a synthesized one-key
+        // level it reads the orientation back off the op family instead.
+        // See `SinglePathSubquery::synthesized_path_component`.
         let mut merk_proof = cost_return_on_error!(
             &mut cost,
             self.generate_merk_proof(

--- a/grovedb/src/operations/proof/verify.rs
+++ b/grovedb/src/operations/proof/verify.rs
@@ -1400,9 +1400,57 @@ impl GroveDb {
                 query
             )))?;
 
+        // Which direction this layer's op stream is encoded in.
+        //
+        // For a real query node the direction is query semantics — it
+        // decides which end of a range fills a limit — so it comes from
+        // the query and nothing else. A *synthesized* path-component
+        // level is different: `query_items_at_path` manufactures it for
+        // every path component above the query's own path (and for
+        // positions inside a `subquery_path`), its item list is exactly
+        // one `QueryItem::Key`, and its `left_to_right` is a fixed
+        // placeholder. The generating query — which is what chose the
+        // op family the prover emitted at this path — is not
+        // recoverable from a subset query, so no fixed value is right:
+        // a merged descending query emits this layer inverted, and
+        // running the ascending bound-witness machinery over an
+        // inverted stream is wrong in both directions (it rejects
+        // honest proofs, and worse, it can read an absence out of a
+        // stream that proves presence).
+        //
+        // So for a one-key synthesized level, read the orientation off
+        // the proof's own op family. That is not trusting an
+        // attacker-chosen parameter: `execute` checks, per op, that
+        // upright pushes ascend and inverted pushes descend, so a
+        // stream cannot claim an orientation it does not have — and
+        // with a single `Key` item the direction cannot reorder,
+        // truncate or extend the answer either way. Everything that
+        // binds the result stays where it was: the reconstructed root
+        // hash still has to match what the parent layer committed, and
+        // `QueryItem::contains` still gates every returned key.
+        let single_key_synthesized_level = internal_query.synthesized_path_component
+            && matches!(
+                internal_query.items.as_slice(),
+                [grovedb_merk::proofs::query::QueryItem::Key(_)]
+            );
+        let left_to_right = if single_key_synthesized_level {
+            grovedb_merk::proofs::query::proof_stream_direction(merk_proof_bytes)
+                .map_err(|e| {
+                    Error::InvalidProof(
+                        query.clone(),
+                        format!("Invalid V1 proof op stream at path component layer: {}", e),
+                    )
+                })?
+                // An op-less stream carries no orientation; `execute`
+                // rejects it a moment later for having no root.
+                .unwrap_or(internal_query.left_to_right)
+        } else {
+            internal_query.left_to_right
+        };
+
         let level_query = Query {
             items: internal_query.items.to_vec(),
-            left_to_right: internal_query.left_to_right,
+            left_to_right,
             ..Default::default()
         };
 
@@ -1410,7 +1458,7 @@ impl GroveDb {
             .execute_proof(
                 merk_proof_bytes,
                 *limit_left,
-                internal_query.left_to_right,
+                left_to_right,
                 PROOF_VERSION_LATEST, // V1 proof: strict mode rejects items in value hash nodes
             )
             .unwrap()

--- a/grovedb/src/query/mod.rs
+++ b/grovedb/src/query/mod.rs
@@ -1577,6 +1577,28 @@ pub struct SinglePathSubquery<'a> {
     pub left_to_right: bool,
     /// In the path of the path_query, or in a subquery path
     pub in_path: Option<Cow<'a, Key>>,
+    /// True when this level was *synthesized* from a path component
+    /// instead of resolved to a real query node — the `Ordering::Less`
+    /// arm of [`PathQuery::query_items_at_path`] plus every
+    /// mid-`subquery_path` arm, all of which go through
+    /// [`SinglePathSubquery::from_key_when_in_path`].
+    ///
+    /// A synthesized level's `items` is exactly one `QueryItem::Key`,
+    /// so its `left_to_right` carries no query semantics at all: the
+    /// answer is that one key or nothing, and there is no ordering or
+    /// limit interaction to observe. The field is a placeholder, fixed
+    /// at `true`, because the direction the *generating* query used at
+    /// this path — which is what decided the op family the prover
+    /// emitted — is not recoverable from a subset query.
+    ///
+    /// Proof verifiers must therefore not take the stream's
+    /// orientation from `left_to_right` on a synthesized level; they
+    /// read it off the proof's own op family via
+    /// `grovedb_merk::proofs::query::proof_stream_direction`, which
+    /// `execute` independently pins to the stream's key ordering. Proof
+    /// *generation* keeps using `left_to_right` verbatim, so proof
+    /// bytes are unaffected.
+    pub synthesized_path_component: bool,
 }
 
 impl fmt::Display for SinglePathSubquery<'_> {
@@ -1593,6 +1615,11 @@ impl fmt::Display for SinglePathSubquery<'_> {
             Some(path) => writeln!(f, "  in_path: Some({})", hex_to_ascii(path)),
             None => writeln!(f, "  in_path: None"),
         }?;
+        writeln!(
+            f,
+            "  synthesized_path_component: {}",
+            self.synthesized_path_component
+        )?;
         write!(f, "}}")
     }
 }
@@ -1624,8 +1651,14 @@ impl<'a> SinglePathSubquery<'a> {
         SinglePathSubquery {
             items: Cow::Owned(vec![QueryItem::Key(key.clone())]),
             has_subquery: HasSubquery::NoSubquery,
+            // Placeholder — see `synthesized_path_component`. Nothing
+            // here knows which direction the generating query walked
+            // this level in, and for a one-key level nothing needs to:
+            // the direction is an encoding detail of the proof, which
+            // is where verifiers read it from.
             left_to_right: true,
             in_path,
+            synthesized_path_component: true,
         }
     }
 
@@ -1648,6 +1681,7 @@ impl<'a> SinglePathSubquery<'a> {
             has_subquery,
             left_to_right: query.left_to_right,
             in_path: None,
+            synthesized_path_component: false,
         }
     }
 }
@@ -2400,6 +2434,7 @@ mod tests {
                     has_subquery: HasSubquery::NoSubquery,
                     left_to_right: true,
                     in_path: Some(Cow::Borrowed(&root_path_key_2)),
+                    synthesized_path_component: true,
                 }
             );
         }
@@ -2420,6 +2455,7 @@ mod tests {
                                                         * subquery for one item */
                     left_to_right: true,
                     in_path: None,
+                    synthesized_path_component: false,
                 }
             );
         }
@@ -2442,7 +2478,8 @@ mod tests {
                     items: Cow::Owned(vec![QueryItem::Key(subquery_path_key_1.clone())]),
                     has_subquery: HasSubquery::NoSubquery,
                     left_to_right: true,
-                    in_path: Some(Cow::Borrowed(&subquery_path_key_1))
+                    in_path: Some(Cow::Borrowed(&subquery_path_key_1)),
+                    synthesized_path_component: true,
                 }
             );
         }
@@ -2466,7 +2503,8 @@ mod tests {
                     items: Cow::Owned(vec![QueryItem::Key(subquery_path_key_2.clone())]),
                     has_subquery: HasSubquery::NoSubquery,
                     left_to_right: true,
-                    in_path: Some(Cow::Borrowed(&subquery_path_key_2))
+                    in_path: Some(Cow::Borrowed(&subquery_path_key_2)),
+                    synthesized_path_component: true,
                 }
             );
         }
@@ -2493,6 +2531,7 @@ mod tests {
                                                         * add items underneath */
                     left_to_right: true,
                     in_path: None,
+                    synthesized_path_component: false,
                 }
             );
         }
@@ -2519,6 +2558,7 @@ mod tests {
                     has_subquery: HasSubquery::NoSubquery,
                     left_to_right: true,
                     in_path: None,
+                    synthesized_path_component: true,
                 }
             );
         }
@@ -2567,6 +2607,7 @@ mod tests {
                     has_subquery: HasSubquery::Always,
                     left_to_right: true,
                     in_path: None,
+                    synthesized_path_component: false,
                 }
             );
         }
@@ -2585,7 +2626,9 @@ mod tests {
                     items: Cow::Owned(vec![QueryItem::Key(quantum_key.clone())]),
                     has_subquery: HasSubquery::NoSubquery,
                     left_to_right: true,
-                    in_path: None, // There should be no path because we are at the end of the path
+                    // There should be no path: we are at the end of the path
+                    in_path: None,
+                    synthesized_path_component: true,
                 }
             );
         }
@@ -2640,6 +2683,7 @@ mod tests {
                     has_subquery: HasSubquery::NoSubquery,
                     left_to_right: true,
                     in_path: Some(Cow::Borrowed(&zero_vec)),
+                    synthesized_path_component: true,
                 }
             );
         }
@@ -2750,6 +2794,7 @@ mod tests {
                     )),
                     left_to_right: true,
                     in_path: None,
+                    synthesized_path_component: false,
                 }
             );
         }
@@ -2768,6 +2813,7 @@ mod tests {
                     has_subquery: HasSubquery::NoSubquery,
                     left_to_right: true,
                     in_path: Some(Cow::Borrowed(&identity_id)),
+                    synthesized_path_component: true,
                 }
             );
         }
@@ -2788,6 +2834,7 @@ mod tests {
                     )),
                     left_to_right: true,
                     in_path: None,
+                    synthesized_path_component: false,
                 }
             );
         }
@@ -2806,6 +2853,7 @@ mod tests {
                     has_subquery: HasSubquery::NoSubquery,
                     left_to_right: true,
                     in_path: None,
+                    synthesized_path_component: false,
                 }
             );
         }

--- a/grovedb/src/tests/merged_descending_subset_bound_tests.rs
+++ b/grovedb/src/tests/merged_descending_subset_bound_tests.rs
@@ -1,0 +1,226 @@
+//! A merged proof must stay subset-verifiable in both directions.
+//!
+//! Shape from production (dashpay/platform's document cursor proofs): one
+//! layer holds a documents subtree (`"0"`), a queried index subtree
+//! (`"firstName"`), and unqueried sibling index subtrees. The cursor
+//! branch selects a key inside `"0"`, the main branch descends through
+//! `"firstName"`, and the two are merged — direction-aligned, as the
+//! merge requires — into one proof. Verifying the cursor branch alone
+//! (`verify_subset_query`) must succeed regardless of direction: the
+//! ascending and descending merged proofs commit the same data, and a
+//! subset query names keys only, never order-dependent content.
+
+#[cfg(test)]
+mod tests {
+    use grovedb_version::version::GroveVersion;
+
+    use crate::{
+        tests::{make_test_grovedb, TempGroveDb, TEST_LEAF},
+        Element, GroveDb, PathQuery, Query, SizedQuery,
+    };
+
+    /// `[TEST_LEAF, person]` with a documents subtree `"0"` (two items),
+    /// a queried index subtree `"firstName"` (one item), and an
+    /// unqueried sibling index subtree `"middleName"` that the proof
+    /// will abridge.
+    pub(super) fn build_layered_fixture(gv: &GroveVersion) -> TempGroveDb {
+        let db = make_test_grovedb(gv);
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"person",
+            Element::empty_tree(),
+            None,
+            None,
+            gv,
+        )
+        .unwrap()
+        .expect("insert person tree");
+        for subtree in [b"0".as_ref(), b"firstName", b"middleName"] {
+            db.insert(
+                [TEST_LEAF, b"person"].as_ref(),
+                subtree,
+                Element::empty_tree(),
+                None,
+                None,
+                gv,
+            )
+            .unwrap()
+            .expect("insert layer subtree");
+        }
+        for doc in [b"docA".as_ref(), b"docB"] {
+            db.insert(
+                [TEST_LEAF, b"person", b"0"].as_ref(),
+                doc,
+                Element::new_item(doc.to_vec()),
+                None,
+                None,
+                gv,
+            )
+            .unwrap()
+            .expect("insert document");
+        }
+        db.insert(
+            [TEST_LEAF, b"person", b"firstName"].as_ref(),
+            b"Chris",
+            Element::new_item(b"Chris".to_vec()),
+            None,
+            None,
+            gv,
+        )
+        .unwrap()
+        .expect("insert index row");
+        db.insert(
+            [TEST_LEAF, b"person", b"middleName"].as_ref(),
+            b"x",
+            Element::new_item(b"x".to_vec()),
+            None,
+            None,
+            gv,
+        )
+        .unwrap()
+        .expect("insert unqueried index row");
+        db
+    }
+
+    fn cursor_and_main_queries(left_to_right: bool) -> (PathQuery, PathQuery) {
+        let mut cursor_q = Query::new_with_direction(left_to_right);
+        cursor_q.insert_key(b"docA".to_vec());
+        let cursor_pq = PathQuery::new(
+            vec![TEST_LEAF.to_vec(), b"person".to_vec(), b"0".to_vec()],
+            SizedQuery::new(cursor_q, None, None),
+        );
+
+        let mut main_q = Query::new_with_direction(left_to_right);
+        main_q.insert_range_from(b"Chris".to_vec()..);
+        let main_pq = PathQuery::new(
+            vec![
+                TEST_LEAF.to_vec(),
+                b"person".to_vec(),
+                b"firstName".to_vec(),
+            ],
+            SizedQuery::new(main_q, None, None),
+        );
+
+        (cursor_pq, main_pq)
+    }
+
+    fn merged_subset_round_trip(left_to_right: bool) {
+        let gv = GroveVersion::latest();
+        let db = build_layered_fixture(gv);
+        let (cursor_pq, main_pq) = cursor_and_main_queries(left_to_right);
+
+        let merged = PathQuery::merge(vec![&cursor_pq, &main_pq], gv).expect("aligned merge");
+        let proof = db
+            .prove_query(&merged, None, gv)
+            .unwrap()
+            .expect("prove merged query");
+
+        // The whole merged query must verify...
+        GroveDb::verify_query(&proof, &merged, gv)
+            .unwrap_or_else(|e| panic!("full merged verify (ltr={left_to_right}): {e}"));
+
+        // ...and so must the cursor branch alone: subset verification is
+        // how a client extracts one branch (e.g. the pagination cursor
+        // document) from a combined proof.
+        let (_, proved) = GroveDb::verify_subset_query(&proof, &cursor_pq, gv)
+            .unwrap_or_else(|e| panic!("subset cursor verify (ltr={left_to_right}): {e}"));
+        assert_eq!(proved.len(), 1, "exactly the cursor document");
+        assert_eq!(proved[0].1, b"docA".to_vec());
+    }
+
+    #[test]
+    fn merged_ascending_proof_subset_verifies_cursor_branch() {
+        merged_subset_round_trip(true);
+    }
+
+    /// FAILS ON DEVELOP — deliberately not ignored: this test IS the bug
+    /// report.
+    ///
+    /// The full merged verify passes, but `verify_subset_query` of the
+    /// cursor branch rejects with "Cannot verify lower bound of queried
+    /// range". The prover classified the shared layer against the merged
+    /// (descending) query and emitted its ops inverted; subset
+    /// verification re-derives that layer from the cursor path query
+    /// alone, and `query_items_at_path` synthesizes path-component levels
+    /// with a hardcoded ascending direction
+    /// (`SinglePathSubquery::from_key_when_in_path`), so the verifier
+    /// runs the ascending bound-witness check against inverted pushes and
+    /// trips on the first hash-abridged sibling.
+    ///
+    /// Note for the fix: no fixed direction is correct for synthesized
+    /// levels — the generating query is unknowable from the subset query.
+    /// Hardcoding ascending is this bug; inheriting the subset query's
+    /// direction instead breaks proofs whose generation synthesized the
+    /// same level ascending (verified against dashpay/platform's
+    /// protocol-v13 frozen ascending cursor-proof test).
+    #[test]
+    fn merged_descending_proof_subset_verifies_cursor_branch() {
+        merged_subset_round_trip(false);
+    }
+}
+
+/// The same direction mismatch, seen from the soundness side.
+///
+/// A synthesized path-component level verified with the wrong
+/// orientation does not only reject honest proofs. When the first node
+/// the descending stream emits happens to be key-bearing, the
+/// ascending `last_push == None` arm reads it as "this is the leftmost
+/// node in the tree", the single `Key` item is consumed as satisfied,
+/// and the end-of-stream absence check never runs — so the verifier
+/// returns `Ok` with an empty result set for a subtree that provably
+/// exists, with the rest of the layer hash-abridged behind it.
+///
+/// A client asking "give me the cursor document" would read that empty
+/// result as "the document is not there".
+///
+/// This needs no merge: any query whose node at a shared layer is
+/// descending makes the prover emit that layer inverted.
+#[cfg(test)]
+mod false_absence_tests {
+    use grovedb_version::version::GroveVersion;
+
+    use super::tests::build_layered_fixture;
+    use crate::{tests::TEST_LEAF, GroveDb, PathQuery, Query, SizedQuery};
+
+    #[test]
+    fn descending_layer_must_not_prove_a_present_subtree_absent() {
+        let gv = GroveVersion::latest();
+        let db = build_layered_fixture(gv);
+
+        // Generating query: descend into the LAST key of the shared
+        // layer, right to left. `"middleName"` sorts above both `"0"`
+        // and `"firstName"`, so the inverted stream opens on a
+        // key-bearing node and abridges everything below it.
+        let mut generating = Query::new_with_direction(false);
+        generating.insert_key(b"middleName".to_vec());
+        generating.set_subquery(Query::new());
+        let generating_pq = PathQuery::new(
+            vec![TEST_LEAF.to_vec(), b"person".to_vec()],
+            SizedQuery::new(generating, None, None),
+        );
+
+        let proof = db
+            .prove_query(&generating_pq, None, gv)
+            .unwrap()
+            .expect("prove descending query");
+        GroveDb::verify_query(&proof, &generating_pq, gv).expect("full verify of its own query");
+
+        // Now subset-verify a *different* branch of the same layer:
+        // `"0"`, which exists and holds two documents, but which this
+        // proof hash-abridges.
+        let mut cursor = Query::new();
+        cursor.insert_key(b"docA".to_vec());
+        let cursor_pq = PathQuery::new(
+            vec![TEST_LEAF.to_vec(), b"person".to_vec(), b"0".to_vec()],
+            SizedQuery::new(cursor, None, None),
+        );
+
+        match GroveDb::verify_subset_query(&proof, &cursor_pq, gv) {
+            Err(_) => {}
+            Ok((_, proved)) => panic!(
+                "verifier accepted an abridged layer as proof that subtree \"0\" is \
+                 absent — it holds docA and docB. Result set: {proved:?}"
+            ),
+        }
+    }
+}

--- a/grovedb/src/tests/merged_descending_subset_bound_tests.rs
+++ b/grovedb/src/tests/merged_descending_subset_bound_tests.rs
@@ -133,23 +133,23 @@ mod tests {
         merged_subset_round_trip(true);
     }
 
-    /// FAILS ON DEVELOP — deliberately not ignored: this test IS the bug
-    /// report.
+    /// Regression for issue #815.
     ///
-    /// The full merged verify passes, but `verify_subset_query` of the
-    /// cursor branch rejects with "Cannot verify lower bound of queried
-    /// range". The prover classified the shared layer against the merged
-    /// (descending) query and emitted its ops inverted; subset
+    /// The prover classifies the shared layer against the merged
+    /// (descending) query and emits its ops inverted; subset
     /// verification re-derives that layer from the cursor path query
-    /// alone, and `query_items_at_path` synthesizes path-component levels
-    /// with a hardcoded ascending direction
-    /// (`SinglePathSubquery::from_key_when_in_path`), so the verifier
-    /// runs the ascending bound-witness check against inverted pushes and
-    /// trips on the first hash-abridged sibling.
+    /// alone, where `query_items_at_path` synthesizes path-component
+    /// levels with a placeholder direction
+    /// (`SinglePathSubquery::from_key_when_in_path`). The verifier used
+    /// to run the ascending bound-witness check against the inverted
+    /// pushes and reject with "Cannot verify lower bound of queried
+    /// range" on the first hash-abridged sibling; it now reads the
+    /// level's orientation off the proof's own op family
+    /// (`proof_stream_direction`).
     ///
-    /// Note for the fix: no fixed direction is correct for synthesized
-    /// levels — the generating query is unknowable from the subset query.
-    /// Hardcoding ascending is this bug; inheriting the subset query's
+    /// No fixed direction is correct for synthesized levels — the
+    /// generating query is not recoverable from the subset query.
+    /// Hardcoding ascending was this bug; inheriting the subset query's
     /// direction instead breaks proofs whose generation synthesized the
     /// same level ascending (verified against dashpay/platform's
     /// protocol-v13 frozen ascending cursor-proof test).

--- a/grovedb/src/tests/mod.rs
+++ b/grovedb/src/tests/mod.rs
@@ -65,6 +65,7 @@ mod indexed_tree_secondary_drift_tests;
 mod indexed_tree_security_regression_tests;
 mod is_empty_tree_tests;
 mod merge_versioning_tests;
+mod merged_descending_subset_bound_tests;
 mod misc_coverage_tests;
 mod mmr_tree_tests;
 mod non_counted_tests;

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -41,8 +41,9 @@ use grovedb_version::version::GroveVersion;
 pub use map::{Map, MapBuilder};
 #[cfg(any(feature = "minimal", feature = "verify"))]
 pub use verify::{
-    boundaries_in_proof, key_exists_as_boundary_in_proof, ProofVerificationResult,
-    ProvedKeyOptionalValue, ProvedKeyValue, QueryProofVerify, VerifyOptions, PROOF_VERSION_LATEST,
+    boundaries_in_proof, key_exists_as_boundary_in_proof, proof_stream_direction,
+    ProofVerificationResult, ProvedKeyOptionalValue, ProvedKeyValue, QueryProofVerify,
+    VerifyOptions, PROOF_VERSION_LATEST,
 };
 #[cfg(feature = "minimal")]
 use {super::Op, std::collections::LinkedList};

--- a/merk/src/proofs/query/verify.rs
+++ b/merk/src/proofs/query/verify.rs
@@ -1115,6 +1115,55 @@ mod provable_count_provable_sum_tree_bound_regression_tests {
     }
 }
 
+/// The orientation of a Merk layer proof's op stream, read off the op
+/// families in the bytes themselves.
+///
+/// Every proof op comes in an upright / inverted pair — `Push` /
+/// `PushInverted`, `Parent` / `ParentInverted`, `Child` /
+/// `ChildInverted` — and `create_proof` picks the family once per layer
+/// from a single `left_to_right`, so an honest layer proof is
+/// homogeneous: all upright (nodes emitted in ascending key order) or
+/// all inverted (descending).
+///
+/// This is deliberately **not** a trusted read of a proof-supplied
+/// parameter. [`execute`] independently checks, for every op it
+/// decodes, that an upright push's key is strictly greater than the
+/// previous key-bearing node's and an inverted push's key strictly
+/// less. A stream that claims one orientation while being ordered the
+/// other way is therefore rejected by `execute` itself, before any
+/// orientation-sensitive bound-witness check can be misapplied: the
+/// orientation reported here is pinned to a structural property of the
+/// same bytes, not chosen freely by whoever produced them.
+///
+/// Returns `Ok(Some(true))` for an all-upright stream, `Ok(Some(false))`
+/// for an all-inverted one, `Ok(None)` when there is no
+/// direction-bearing op at all (an empty stream, which `execute` then
+/// rejects on its own), and `Err` for a stream that mixes the two: no
+/// honest prover emits one, and a mixed stream has no single
+/// orientation for the bound-witness checks to be correct against, so
+/// it is refused rather than guessed at.
+pub fn proof_stream_direction(proof_bytes: &[u8]) -> Result<Option<bool>, Error> {
+    let mut direction: Option<bool> = None;
+    for op_result in Decoder::new(proof_bytes) {
+        let upright = match op_result? {
+            Op::Push(_) | Op::Parent | Op::Child => true,
+            Op::PushInverted(_) | Op::ParentInverted | Op::ChildInverted => false,
+        };
+        match direction {
+            None => direction = Some(upright),
+            Some(previous) if previous == upright => {}
+            Some(_) => {
+                return Err(Error::InvalidProofError(
+                    "Proof mixes upright and inverted ops; a layer proof is emitted \
+                     entirely in one direction"
+                        .to_string(),
+                ));
+            }
+        }
+    }
+    Ok(direction)
+}
+
 /// Returns all boundary keys found in the given merk proof bytes.
 /// Boundary keys appear as `KVDigest`, `KVDigestCount`, `KVDigestSum`,
 /// or `KVDigestCountSum` (dual-axis PCPS) nodes — they prove a key
@@ -1142,4 +1191,76 @@ pub fn boundaries_in_proof(proof_bytes: &[u8]) -> Result<Vec<Vec<u8>>, Error> {
         }
     }
     Ok(keys)
+}
+
+#[cfg(test)]
+mod proof_stream_direction_tests {
+    //! `proof_stream_direction` is what lets a verifier run the
+    //! orientation-sensitive bound-witness checks over a layer whose
+    //! generating direction it cannot know (a synthesized
+    //! path-component level under `verify_subset_query`). It must
+    //! report the op family faithfully and refuse to pick one when the
+    //! stream does not have a single family.
+
+    use grovedb_query::proofs::encode_into;
+
+    use super::proof_stream_direction;
+    use crate::proofs::{Node, Op};
+
+    fn encoded(ops: &[Op]) -> Vec<u8> {
+        let mut bytes = vec![];
+        encode_into(ops.iter(), &mut bytes);
+        bytes
+    }
+
+    #[test]
+    fn upright_stream_reads_as_left_to_right() {
+        let bytes = encoded(&[
+            Op::Push(Node::KV(vec![1], vec![1])),
+            Op::Push(Node::KV(vec![2], vec![2])),
+            Op::Parent,
+            Op::Push(Node::KV(vec![3], vec![3])),
+            Op::Child,
+        ]);
+        assert_eq!(proof_stream_direction(&bytes).expect("reads"), Some(true));
+    }
+
+    #[test]
+    fn inverted_stream_reads_as_right_to_left() {
+        let bytes = encoded(&[
+            Op::PushInverted(Node::KV(vec![3], vec![3])),
+            Op::PushInverted(Node::KV(vec![2], vec![2])),
+            Op::ParentInverted,
+            Op::PushInverted(Node::KV(vec![1], vec![1])),
+            Op::ChildInverted,
+        ]);
+        assert_eq!(proof_stream_direction(&bytes).expect("reads"), Some(false));
+    }
+
+    #[test]
+    fn empty_stream_has_no_direction() {
+        assert_eq!(proof_stream_direction(&[]).expect("reads"), None);
+    }
+
+    /// A mixed stream has no single orientation, so there is no correct
+    /// mirror of the bound-witness check to run against it. Refuse it
+    /// rather than pick from the first op — an all-but-the-first
+    /// inverted stream is exactly how a forger would try to get the
+    /// ascending checks applied to a descending stream.
+    #[test]
+    fn mixed_stream_is_refused() {
+        let bytes = encoded(&[
+            Op::Push(Node::KV(vec![9], vec![9])),
+            Op::PushInverted(Node::KV(vec![8], vec![8])),
+        ]);
+        proof_stream_direction(&bytes).expect_err("mixed families must not resolve to a direction");
+
+        // Mixed in the structural ops alone counts too.
+        let bytes = encoded(&[
+            Op::Push(Node::KV(vec![1], vec![1])),
+            Op::Push(Node::KV(vec![2], vec![2])),
+            Op::ParentInverted,
+        ]);
+        proof_stream_direction(&bytes).expect_err("mixed structural ops must not resolve");
+    }
 }

--- a/merk/src/proofs/query/verify.rs
+++ b/merk/src/proofs/query/verify.rs
@@ -7,7 +7,11 @@ use grovedb_element::ElementType;
 use crate::proofs::query::{Map, MapBuilder};
 use crate::{
     error::Error,
-    proofs::{hex_to_ascii, tree::execute, Decoder, Node, Op, Query},
+    proofs::{
+        hex_to_ascii,
+        tree::{execute, MAX_PROOF_OPS},
+        Decoder, Node, Op, Query,
+    },
     tree::{combine_hash, value_hash},
     CryptoHash as MerkHash, CryptoHash,
 };
@@ -1142,9 +1146,25 @@ mod provable_count_provable_sum_tree_bound_regression_tests {
 /// honest prover emits one, and a mixed stream has no single
 /// orientation for the bound-witness checks to be correct against, so
 /// it is refused rather than guessed at.
+///
+/// The scan enforces the same [`MAX_PROOF_OPS`] bound as [`execute`]:
+/// this pass runs on untrusted bytes *before* the bounded execution
+/// pass, so without its own cap an oversized stream would be fully
+/// decoded — node allocations included — only to be rejected by
+/// `execute` at op 50,001. Any stream over the cap fails verification
+/// regardless, so rejecting it here changes no verdict, only how much
+/// work the verifier spends reaching it.
 pub fn proof_stream_direction(proof_bytes: &[u8]) -> Result<Option<bool>, Error> {
     let mut direction: Option<bool> = None;
+    let mut op_count: usize = 0;
     for op_result in Decoder::new(proof_bytes) {
+        op_count += 1;
+        if op_count > MAX_PROOF_OPS {
+            return Err(Error::InvalidProofError(format!(
+                "Proof exceeds maximum operation count ({})",
+                MAX_PROOF_OPS
+            )));
+        }
         let upright = match op_result? {
             Op::Push(_) | Op::Parent | Op::Child => true,
             Op::PushInverted(_) | Op::ParentInverted | Op::ChildInverted => false,
@@ -1262,5 +1282,34 @@ mod proof_stream_direction_tests {
             Op::ParentInverted,
         ]);
         proof_stream_direction(&bytes).expect_err("mixed structural ops must not resolve");
+    }
+
+    /// The scan runs on untrusted bytes before the bounded execution
+    /// pass, so it must enforce the same op-count cap as `execute` —
+    /// otherwise an oversized homogeneous stream would be fully decoded
+    /// here only to be rejected there. Exactly at the cap still reads
+    /// (matching `execute`, which errors only when the count exceeds
+    /// it); one past the cap is refused.
+    #[test]
+    fn oversized_stream_is_refused_at_the_execute_cap() {
+        use crate::proofs::tree::MAX_PROOF_OPS;
+
+        let at_cap: Vec<Op> = (0..MAX_PROOF_OPS)
+            .map(|_| Op::Push(Node::Hash([0u8; 32])))
+            .collect();
+        assert_eq!(
+            proof_stream_direction(&encoded(&at_cap)).expect("at-cap stream reads"),
+            Some(true)
+        );
+
+        let over_cap: Vec<Op> = (0..=MAX_PROOF_OPS)
+            .map(|_| Op::Push(Node::Hash([0u8; 32])))
+            .collect();
+        let err = proof_stream_direction(&encoded(&over_cap))
+            .expect_err("over-cap stream must be refused before full decode");
+        assert!(
+            err.to_string().contains("maximum operation count"),
+            "unexpected error: {err}"
+        );
     }
 }


### PR DESCRIPTION
## Problem

`GroveDb::verify_subset_query` of any branch of a **descending** merged proof rejects with `Cannot verify lower bound of queried range`, while the full merged verify of the same bytes passes. Ascending works. Reported with a repro in #815 (whose tests this PR includes); blocks the dashpay/platform#4382 re-pin, since platform's document cursor proofs (`startAt`/`startAfter` with a descending order-by) hit this after #801 made merges direction-aligned.

## Root cause

The prover picks each layer's op family (`Push…` vs `…Inverted`) from the **generating** query's direction at that path. The subset verifier re-derives the layer from the cursor path query alone, and `query_items_at_path` synthesizes path-component levels with a **hardcoded ascending** direction (`SinglePathSubquery::from_key_when_in_path`, `left_to_right: true`). The verifier then runs the ascending bound-witness machinery over an inverted stream:

- when the stream opens on a hash-abridged sibling, it trips `Cannot verify lower bound of queried range` — the reported false reject;
- **worse**, when the stream opens on a key-bearing node, the ascending `last_push == None` arm reads it as "leftmost node in the tree", the synthesized `Key` item is consumed as satisfied, the end-of-stream absence check never runs, and the verifier returns `Ok` with an **empty result set for a subtree that provably exists** — a false absence. Confirmed empirically against develop; covered by the new `descending_layer_must_not_prove_a_present_subtree_absent` test.

No fixed direction is correct for a synthesized level: the generating query is unknowable from the subset query (hardcoding ascending is this bug; inheriting the subset query's direction breaks platform's frozen protocol-v13 ascending cursor-proof test).

## Fix

For a synthesized single-`Key` path-component level — and only there — the V1 verifier reads the layer's orientation off the proof's own op family, via a new `proof_stream_direction` helper that **refuses mixed-family streams**.

Why this is not "trusting attacker bytes for a bound check":

1. **The direction is not free.** `execute` independently checks, per op, that upright pushes strictly ascend and inverted pushes strictly descend. Homogeneous + per-op monotone ⟹ the stream is globally in-order (or reverse in-order). A stream cannot claim an orientation it does not have. The homogeneity requirement is load-bearing: taking "the first op's family" without it would itself be the vulnerability.
2. **The hash chain is direction-blind** — the reconstructed root must still match what the parent layer committed.
3. **Membership is direction-blind** — `QueryItem::contains` gates every returned key.
4. **For a single `Key` item, direction carries zero query semantics** — the answer is that one key or nothing; no ordering to permute, no limit to fill from the wrong end. Real query nodes (where direction *is* semantics) are untouched.
5. **Absence is still bracketed on both sides** — with the orientation right, both in-order neighbours of the key's slot must be unabridged, in whichever orientation the stream actually has.

Net: newly accepted = honest inverted synthesized layers; newly rejected = the false-absence forgeries above plus mixed-family streams at synthesized levels (which no honest prover emits); unchanged = every all-upright layer, i.e. every layer of every ascending proof. As a bonus the fix removes a malleability weakness: pre-fix, re-encoding an honest ascending layer as its (legal) inverted encoding could fabricate an absence.

## Changes

- `merk/src/proofs/query/verify.rs`: new `proof_stream_direction(proof_bytes)` — `Some(true)` all-upright, `Some(false)` all-inverted, `None` op-less, `Err` mixed; plus unit tests.
- `grovedb/src/query/mod.rs`: `SinglePathSubquery::synthesized_path_component` marker, `true` only in `from_key_when_in_path`, documenting that its `left_to_right` is a placeholder. (dashpay/platform has zero references to this struct — checked.)
- `grovedb/src/operations/proof/verify.rs`: `verify_layer_proof_v1` derives the level direction from the proof stream when `synthesized_path_component && items == [Key(_)]`; otherwise unchanged.
- `grovedb/src/operations/proof/generate.rs`: comment only, recording the prover/verifier asymmetry.
- Tests: #815's repro module, extended with the false-absence regression test.

## What is deliberately NOT changed

- **V0 prover/verifier: untouched** (`verify_layer_proof`, no `_v1` suffix). The same mismatch is theoretically reachable on V0 via a hand-built descending nested query, but not via `merge` (slot 0 gives merged roots the default ascending), and V0 is locked wire format.
- **Prover: untouched.** No proof bytes change anywhere.

## Version gating: none, deliberately

- No proof bytes change, so there is no prover-side divergence to gate.
- V0-vs-V1 verification dispatches on the **proof envelope**, not the passed `GroveVersion`; a GroveVersion gate would make identical bytes verify differently based on a parameter the proof doesn't commit to.
- A V4 gate would be actively harmful: V1 envelopes start at grove v3 — exactly where platform's re-pin needs both the false reject and the false absence fixed.
- Verification is not on the consensus path (platform verifies proofs client-side, not during block execution), so an unversioned verifier change cannot fork consensus.

Caveat: this is still a verifier behavior change — anything that pinned the old buggy outcome (e.g. asserting an empty result from a descending subset verify) will see a difference. Platform's frozen protocol-v13 ascending cursor-proof expectation is unaffected: ascending layers are all-upright, derive `true`, and verify bit-identically.

## Testing

- #815 repro: ascending **and** descending now pass (descending failed on develop with the reported error).
- New false-absence regression test: on develop the verifier returned `Ok` with `[]` for a present subtree; now rejects with `Proof is missing data for query` — the correct "this proof doesn't answer you" semantics.
- Negative control: with the fix disabled by a one-token edit, both descending tests fail and ascending still passes.
- `cargo test -p grovedb`: 2761 passed, 0 failed. `-p grovedb-merk`: 729 passed. `-p grovedb-query`: 398 passed. `cargo fmt --check` and CI's `cargo clippy --workspace --all-features -- -D warnings` clean.

## Adjacent finding (reported, not fixed here)

While hardening the helper I confirmed empirically that `execute_proof` accepts **mixed-family op streams** in general (both V0 and V1), which lets a prover reconstruct the true tree — true root hash — while emitting nodes out of in-order, silently dropping in-range keys from the result set (demonstrated: 3 of 5 keys dropped on a `RangeInclusive` with the root verifying). This PR closes it only at synthesized path-component levels. It deserves its own fix (homogeneity enforcement in `execute_proof`, gated on the existing `proof_version` parameter to keep V0 untouched) — filing separately.

Closes #815.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved verification of synthesized path proofs by correctly detecting traversal direction from proof data.
  * Malformed, oversized, or directionally inconsistent proof streams are now rejected as invalid.
  * Prevented valid existing subtrees from being incorrectly reported as absent during descending proof verification.

* **Tests**
  * Added coverage for ascending and descending merged proof verification, including false-absence scenarios and proof-size boundary checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->