### PR TITLE
docs: preserve V0 proof review policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# AGENTS.md
+
+## Code Review Rules
+
+- V0 proofs are frozen historical artifacts retained for posterity only.
+- Never propose modifying V0 proof generation or verification.
+- Do not report unchanged V0 behavior as a finding or blocker in current pull requests.
+- Review proof changes against V1 and later unless the user explicitly requests legacy analysis.


### PR DESCRIPTION
## Summary

- document that V0 proofs are frozen historical artifacts retained for posterity
- prevent unchanged V0 behavior from being raised as a finding or blocker
- scope proof reviews to V1 and later unless legacy analysis is explicitly requested

## Validation

- repository pre-commit checks passed
- documentation-only change; no runtime tests required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added code review guidance for preserving historical V0 proofs and focusing reviews on V1+ behavior.
  * Clarified that unchanged legacy behavior should not be included in findings unless specifically requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->