### PR TITLE
chore: fix clippy lints in test code (unused Results and friends)

### DIFF
--- a/grovedb-dense-fixed-sized-merkle-tree/src/test_utils.rs
+++ b/grovedb-dense-fixed-sized-merkle-tree/src/test_utils.rs
@@ -161,13 +161,13 @@ impl<'db> StorageContext<'db> for FailingStorageContext {
 
     fn get<K: AsRef<[u8]>>(&self, key: K) -> CostResult<Option<Vec<u8>>, grovedb_storage::Error> {
         let key_bytes = key.as_ref();
-        if let Some(fail_key) = *self.fail_on_get_key.borrow() {
-            if key_bytes == fail_key {
-                return Err(grovedb_storage::Error::StorageError(
-                    "simulated get failure".to_string(),
-                ))
-                .wrap_with_cost(OperationCost::default());
-            }
+        if let Some(fail_key) = *self.fail_on_get_key.borrow()
+            && key_bytes == fail_key
+        {
+            return Err(grovedb_storage::Error::StorageError(
+                "simulated get failure".to_string(),
+            ))
+            .wrap_with_cost(OperationCost::default());
         }
         Ok(self.data.borrow().get(key_bytes).cloned()).wrap_with_cost(OperationCost::default())
     }
@@ -180,13 +180,13 @@ impl<'db> StorageContext<'db> for FailingStorageContext {
         _cost_info: Option<KeyValueStorageCost>,
     ) -> CostResult<(), grovedb_storage::Error> {
         let key_bytes = key.as_ref();
-        if let Some(fail_key) = *self.fail_on_put_key.borrow() {
-            if key_bytes == fail_key {
-                return Err(grovedb_storage::Error::StorageError(
-                    "simulated put failure".to_string(),
-                ))
-                .wrap_with_cost(OperationCost::default());
-            }
+        if let Some(fail_key) = *self.fail_on_put_key.borrow()
+            && key_bytes == fail_key
+        {
+            return Err(grovedb_storage::Error::StorageError(
+                "simulated put failure".to_string(),
+            ))
+            .wrap_with_cost(OperationCost::default());
         }
         self.data
             .borrow_mut()

--- a/grovedb-query/src/merge.rs
+++ b/grovedb-query/src/merge.rs
@@ -1007,7 +1007,9 @@ mod tests {
             subquery: Some(Box::new(other_subquery.clone())),
         };
 
-        self_query.merge_default_subquery_branch(other_branch);
+        self_query
+            .merge_default_subquery_branch(other_branch)
+            .expect("merge should succeed");
 
         // After merge:
         // - default subquery should be other's (no path, so it applies broadly)

--- a/grovedb-query/src/proofs/mod.rs
+++ b/grovedb-query/src/proofs/mod.rs
@@ -657,7 +657,7 @@ mod tests {
     // additions show up as ~263 uncovered lines.
 
     fn round_trip_push(node: Node) {
-        use ed::{Decode, Encode};
+        use ed::Encode;
         let op = Op::Push(node.clone());
         let mut buf = Vec::new();
         op.encode_into(&mut buf).expect("encode push");

--- a/grovedb-query/src/proofs/tree_feature_type.rs
+++ b/grovedb-query/src/proofs/tree_feature_type.rs
@@ -594,7 +594,7 @@ mod tests {
     /// existing variant.
     #[test]
     fn decode_rejects_tag_byte_9() {
-        let buf = vec![9u8, 0];
+        let buf = [9u8, 0];
         let res = TreeFeatureType::decode(&buf[..]);
         assert!(res.is_err(), "decode must reject unknown tag byte");
     }

--- a/grovedb-query/src/query_item/mod.rs
+++ b/grovedb-query/src/query_item/mod.rs
@@ -1544,10 +1544,8 @@ mod test {
         // bound — exactly the stack-exhaustion case the depth guard
         // prevents.
         let depth_to_try = MAX_QUERY_ITEM_DECODE_DEPTH + 2;
-        let mut payload: Vec<u8> = Vec::new();
-        for _ in 0..depth_to_try {
-            payload.push(10u8); // AggregateCountOnRange variant tag
-        }
+        // AggregateCountOnRange variant tag, repeated to exceed the depth cap
+        let mut payload: Vec<u8> = vec![10u8; depth_to_try];
         // Innermost: Range(b"a", b"z"). Variant tag 1, then encoded start +
         // end Vec<u8>s in big-endian fixed-int config.
         payload.push(1u8);
@@ -1745,10 +1743,8 @@ mod test {
         // (AggregateSumOnRange) tag. Hits the depth guard inside
         // decode_with_depth on the sum branch.
         let depth_to_try = MAX_QUERY_ITEM_DECODE_DEPTH + 2;
-        let mut payload: Vec<u8> = Vec::new();
-        for _ in 0..depth_to_try {
-            payload.push(11u8); // AggregateSumOnRange variant tag
-        }
+        // AggregateSumOnRange variant tag, repeated to exceed the depth cap
+        let mut payload: Vec<u8> = vec![11u8; depth_to_try];
         // Innermost: Range. Variant tag 1, then start/end Vec<u8> bytes.
         payload.push(1u8);
         let inner = QueryItem::Range(b"a".to_vec()..b"z".to_vec());

--- a/grovedb-query/tests/merge_coverage.rs
+++ b/grovedb-query/tests/merge_coverage.rs
@@ -285,7 +285,8 @@ fn merge_default_branch_both_none_paths_both_have_subqueries() {
     q.merge_default_subquery_branch(SubqueryBranch {
         subquery_path: None,
         subquery: Some(Box::new(Query::new_single_key(k(20)))),
-    });
+    })
+    .expect("merge should succeed");
     let sq = q.default_subquery_branch.subquery.unwrap();
     assert!(sq.items.contains(&QueryItem::Key(k(10))));
     assert!(sq.items.contains(&QueryItem::Key(k(20))));
@@ -298,7 +299,8 @@ fn merge_default_branch_both_none_paths_self_has_no_subquery() {
     q.merge_default_subquery_branch(SubqueryBranch {
         subquery_path: None,
         subquery: Some(Box::new(Query::new_single_key(k(20)))),
-    });
+    })
+    .expect("merge should succeed");
     let sq = q.default_subquery_branch.subquery.unwrap();
     assert!(sq.items.contains(&QueryItem::Key(k(20))));
 }
@@ -317,7 +319,8 @@ fn merge_default_branch_same_paths() {
     q.merge_default_subquery_branch(SubqueryBranch {
         subquery_path: Some(vec![k(5), k(6)]),
         subquery: Some(Box::new(Query::new_single_key(k(20)))),
-    });
+    })
+    .expect("merge should succeed");
     assert_eq!(
         q.default_subquery_branch.subquery_path,
         Some(vec![k(5), k(6)])
@@ -341,7 +344,8 @@ fn merge_default_branch_no_common_prefix() {
     q.merge_default_subquery_branch(SubqueryBranch {
         subquery_path: Some(vec![k(2)]),
         subquery: Some(Box::new(Query::new_single_key(k(20)))),
-    });
+    })
+    .expect("merge should succeed");
     // No common prefix => subquery_path set to None
     assert_eq!(q.default_subquery_branch.subquery_path, None);
     let conds = q.conditional_subquery_branches.as_ref().unwrap();
@@ -363,7 +367,8 @@ fn merge_default_branch_left_path_longer() {
     q.merge_default_subquery_branch(SubqueryBranch {
         subquery_path: Some(vec![k(10), k(20)]),
         subquery: Some(Box::new(Query::new_single_key(k(2)))),
-    });
+    })
+    .expect("merge should succeed");
     // Common path is [10, 20]
     assert_eq!(
         q.default_subquery_branch.subquery_path,
@@ -391,7 +396,8 @@ fn merge_default_branch_right_path_longer() {
     q.merge_default_subquery_branch(SubqueryBranch {
         subquery_path: Some(vec![k(10), k(20), k(40)]),
         subquery: Some(Box::new(Query::new_single_key(k(2)))),
-    });
+    })
+    .expect("merge should succeed");
     assert_eq!(
         q.default_subquery_branch.subquery_path,
         Some(vec![k(10), k(20)])
@@ -417,7 +423,8 @@ fn merge_default_branch_ours_has_path_theirs_none() {
     q.merge_default_subquery_branch(SubqueryBranch {
         subquery_path: None,
         subquery: Some(Box::new(Query::new_single_key(k(20)))),
-    });
+    })
+    .expect("merge should succeed");
     // Path drops to None
     assert_eq!(q.default_subquery_branch.subquery_path, None);
     // Default subquery becomes the other's
@@ -436,7 +443,8 @@ fn merge_default_branch_ours_none_theirs_has_path() {
     q.merge_default_subquery_branch(SubqueryBranch {
         subquery_path: Some(vec![k(7), k(8)]),
         subquery: Some(Box::new(Query::new_single_key(k(20)))),
-    });
+    })
+    .expect("merge should succeed");
     // Path stays None
     assert_eq!(q.default_subquery_branch.subquery_path, None);
     let conds = q.conditional_subquery_branches.as_ref().unwrap();
@@ -506,7 +514,8 @@ fn merge_conditional_boxed_subquery_noop_on_empty_branch() {
             subquery_path: None,
             subquery: None,
         },
-    );
+    )
+    .expect("merge should succeed");
     assert!(q.conditional_subquery_branches.is_none());
 }
 

--- a/grovedb-query/tests/query_terminal_and_merge.rs
+++ b/grovedb-query/tests/query_terminal_and_merge.rs
@@ -365,7 +365,8 @@ fn merge_apis_cover_default_and_conditional_paths() {
     left.merge_default_subquery_branch(SubqueryBranch {
         subquery_path: Some(vec![k(1), k(3)]),
         subquery: Some(Box::new(Query::new_single_key(k(30)))),
-    });
+    })
+    .expect("merge should succeed");
 
     assert_eq!(left.default_subquery_branch.subquery_path, Some(vec![k(1)]));
     let merged_conditionals = left

--- a/storage/src/rocksdb_storage/tests.rs
+++ b/storage/src/rocksdb_storage/tests.rs
@@ -1417,7 +1417,7 @@ mod storage_management {
         }
 
         // Verify DB is still functional after wipe — can insert new data
-        drop(verify_ctx);
+        let _ = verify_ctx;
         storage
             .commit_transaction(verify_tx)
             .unwrap()


### PR DESCRIPTION
## What

Fixes the `unused_must_use` errors that `cargo clippy --all-targets -- -D warnings` reports in grovedb-query test code: ignored `Result`s from `merge_default_subquery_branch` (9 call sites across `tests/merge_coverage.rs`, `tests/query_terminal_and_merge.rs`, and the unit test in `src/merge.rs`) and one from `merge_conditional_boxed_subquery`. Every site intends a successful merge, so each now asserts with `.expect("merge should succeed")` instead of dropping the Result.

Also clears the small clippy tail in the same targets so the touched crates are clean under `--all-targets -D warnings`:

- `grovedb-query/src/proofs/mod.rs` — unused `Decode` import in a test helper
- `grovedb-query/src/query_item/mod.rs` — `same_item_push` in the two decode-depth tests (loop replaced with `vec![tag; n]`)
- `grovedb-query/src/proofs/tree_feature_type.rs` — `useless_vec`
- `storage/src/rocksdb_storage/tests.rs` — `drop_non_drop` on a storage context (replaced with `let _ =`)
- `grovedb-dense-fixed-sized-merkle-tree/src/test_utils.rs` — two `collapsible_if`s (let-chains, crate is edition 2024)

Test-only changes; no behavior change to any library code path.

## Verification

- `cargo clippy --workspace --all-features -- -D warnings` (the CI gate) passes
- `cargo clippy -p grovedb-query --all-targets -- -D warnings` passes
- `cargo test -p grovedb-query` — 410 tests pass
- `cargo test -p grovedb-storage -p grovedb-dense-fixed-sized-merkle-tree` — all pass

Note: a full-workspace `cargo clippy --all-targets -- -D warnings` still fails on ~160 pre-existing lint sites in `merk` and `grovedb` test code (CI runs clippy without `--all-targets`, so these never gated). That sweep is left for a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)