### PR TITLE
feat(append-only): fixed per-append cost for the commitment tree — churn buffer, fixed dense model, amortized compaction, constant-price frontier (GROVE_V4)

### DIFF
--- a/docs/book/src/bulk-append-tree.md
+++ b/docs/book/src/bulk-append-tree.md
@@ -213,7 +213,7 @@ All BulkAppendTree data lives in the **data** namespace, keyed with single-chara
 | `b` + `{index}` | `b` + u32 BE | 5B | Buffer entry at index |
 | `e` + `{index}` | `e` + u64 BE | 9B | Chunk blob at index |
 | `m` + `{pos}` | `m` + u64 BE | 9B | MMR node at position |
-| `h` + `{index}` | `h` + u16 BE | 3B | Buffer hash record at index (GROVE_V4+, see Chapter 16) |
+| `h` + `{index}` | `h` + u16 BE | 3B | Path record of the insert at index (GROVE_V4+, see Chapter 16) |
 
 **Metadata** stores `mmr_size` (8 bytes BE). The `total_count` and `chunk_power` are
 stored in the Element itself (in the parent Merk), not in data namespace metadata.
@@ -475,7 +475,7 @@ Each operation's hash cost is tracked explicitly:
 | Operation | Blake3 calls | Notes |
 |---|---|---|
 | Single append (no compaction), GROVE_V1..V3 | 2·k + 1 | Full buffer walk over the k filled positions + 1 for state root |
-| Single append (no compaction), GROVE_V4+ | 2 + d + 1 | Leaf + one per ancestor level (d = depth of the new position ≤ chunk_power − 1) + state root |
+| Single append (no compaction), GROVE_V4+ | model(chunk_power) + 1 | The height's fixed model (`2 + ⌈avg depth⌉` blake3: 12 at chunk_power 11) + state root — the same at every position |
 | Single append (with compaction) | 1 + MMR merges + 1 | Chunk-leaf hash + MMR push/bagging + state root (no buffer work: the buffer is full and the overflow value goes into the blob) |
 | `get_value` from chunk | 0 | Pure deserialization, no hashing |
 | `get_value` from buffer | 0 | Direct key lookup |
@@ -484,20 +484,21 @@ Each operation's hash cost is tracked explicitly:
 
 **Per-append cost**: under GROVE_V1..V3 the k-th append of an epoch re-walks k
 positions, so the amortized cost is ~chunk_size hashes per append (≈ 2k at
-chunk_power 11, peaking at ≈ 4k). From GROVE_V4 an append costs `3 + depth` blake3
-calls plus O(chunk_power) hash-record reads and writes, independent of the fill;
-the compacting append reads the epoch back (C reads) and hashes the blob once. A
-buffer filled under GROVE_V1..V3 pays one full walk at its first GROVE_V4 append to
-derive its records. The GROVE_V4 estimators keep the full-walk hash bound for that
-catch-up and add the records' storage; the `PrivateDocumentStore` (V4-born) is
-estimated on the record model alone.
+chunk_power 11, peaking at ≈ 4k). From GROVE_V4 every buffered append is charged the
+buffer's fixed model for its height (12 blake3 calls and 18 record reads at
+chunk_power 11) plus one slot put and one record put, whatever the position; its
+storage charge is its long-term footprint — the chunk-blob share (`added`) — while
+the slot and record are churn (`replaced`). The compacting append reads the epoch
+back (C reads) and hashes the blob once. A buffer filled under GROVE_V1..V3 is
+caught up from its values by the V4 appends that need it, read-only and billed the
+same model.
 
 ## Comparison with MmrTree
 
 | | BulkAppendTree | MmrTree |
 |---|---|---|
 | **Architecture** | Two-level (buffer + chunk MMR) | Single MMR |
-| **Per-append hash cost** | 3 + depth (GROVE_V4+) | ~2 |
+| **Per-append hash cost** | fixed model: 2 + ⌈avg depth⌉ + 1 (GROVE_V4+) | ~2 |
 | **Proof granularity** | Range queries over positions | Individual leaf proofs |
 | **Immutable snapshots** | Yes (chunk blobs) | No |
 | **CDN-friendly** | Yes (chunk blobs cacheable) | No |

--- a/docs/book/src/bulk-append-tree.md
+++ b/docs/book/src/bulk-append-tree.md
@@ -214,6 +214,7 @@ All BulkAppendTree data lives in the **data** namespace, keyed with single-chara
 | `e` + `{index}` | `e` + u64 BE | 9B | Chunk blob at index |
 | `m` + `{pos}` | `m` + u64 BE | 9B | MMR node at position |
 | `h` + `{index}` | `h` + u16 BE | 3B | Path record of the insert at index (GROVE_V4+, see Chapter 16) |
+| `r` | 1 byte | 1B | Persisted chunk-MMR root, written at each compaction (GROVE_V4+) so a reopened tree does not bag the peaks' blobs |
 
 **Metadata** stores `mmr_size` (8 bytes BE). The `total_count` and `chunk_power` are
 stored in the Element itself (in the parent Merk), not in data namespace metadata.
@@ -476,7 +477,8 @@ Each operation's hash cost is tracked explicitly:
 |---|---|---|
 | Single append (no compaction), GROVE_V1..V3 | 2·k + 1 | Full buffer walk over the k filled positions + 1 for state root |
 | Single append (no compaction), GROVE_V4+ | model(chunk_power) + 1 | The height's fixed model (`2 + ⌈avg depth⌉` blake3: 12 at chunk_power 11) + state root — the same at every position |
-| Single append (with compaction) | 1 + MMR merges + 1 | Chunk-leaf hash + MMR push/bagging + state root (no buffer work: the buffer is full and the overflow value goes into the blob) |
+| Single append (with compaction), GROVE_V4+ | model(chunk_power) + 1 | Charged exactly like a buffered append: the compaction's chunk-leaf hash and MMR merges are amortized as one blake3 on every append; physically it hashes the blob once and merges the MMR, reading the buffer back |
+| Single append (with compaction), GROVE_V1..V3 | 1 + MMR merges + 1 | Chunk-leaf hash + MMR push/bagging + state root, billed where they happen |
 | `get_value` from chunk | 0 | Pure deserialization, no hashing |
 | `get_value` from buffer | 0 | Direct key lookup |
 | Proof generation | Depends on chunk count | Dense Merkle root per chunk + MMR proof |
@@ -484,14 +486,18 @@ Each operation's hash cost is tracked explicitly:
 
 **Per-append cost**: under GROVE_V1..V3 the k-th append of an epoch re-walks k
 positions, so the amortized cost is ~chunk_size hashes per append (≈ 2k at
-chunk_power 11, peaking at ≈ 4k). From GROVE_V4 every buffered append is charged the
-buffer's fixed model for its height (12 blake3 calls and 18 record reads at
-chunk_power 11) plus one slot put and one record put, whatever the position; its
-storage charge is its long-term footprint — the chunk-blob share (`added`) — while
-the slot and record are churn (`replaced`). The compacting append reads the epoch
-back (C reads) and hashes the blob once. A buffer filled under GROVE_V1..V3 is
-caught up from its values by the V4 appends that need it, read-only and billed the
-same model.
+chunk_power 11, peaking at ≈ 4k), and the compacting append pays the blob and MMR
+work where it happens. From GROVE_V4 **every append is charged the same fixed
+model**, whatever its position: the buffer's root-maintenance model for its height
+(12 blake3 calls and 18 record reads at chunk_power 11), one amortized compaction
+blake3, its long-term footprint as `added` (the chunk-blob share plus the epoch's
+share of the blob framing and MMR nodes — 1 byte at chunk_power 11) and its churn as
+`replaced` (slot, path record, its part of the blob rewrite). The compacting append
+writes the blob, the MMR nodes and the persisted MMR root prepaid and is charged the
+same; physically it still reads the epoch back and hashes the blob once. The only
+residual is its commit-time seek count (blob + MMR nodes instead of slot + record),
+bounded and once per epoch. A buffer filled under GROVE_V1..V3 is caught up from its
+values by the V4 appends that need it, read-only and billed the same model.
 
 ## Comparison with MmrTree
 

--- a/docs/book/src/bulk-append-tree.md
+++ b/docs/book/src/bulk-append-tree.md
@@ -477,7 +477,7 @@ Each operation's hash cost is tracked explicitly:
 |---|---|---|
 | Single append (no compaction), GROVE_V1..V3 | 2·k + 1 | Full buffer walk over the k filled positions + 1 for state root |
 | Single append (no compaction), GROVE_V4+ | model(chunk_power) + 1 | The height's fixed model (`2 + ⌈avg depth⌉` blake3: 12 at chunk_power 11) + state root — the same at every position |
-| Single append (with compaction), GROVE_V4+ | model(chunk_power) + 1 | Charged exactly like a buffered append: the compaction's chunk-leaf hash and MMR merges are amortized as one blake3 on every append; physically it hashes the blob once and merges the MMR, reading the buffer back |
+| Single append (with compaction), GROVE_V4+ | model(chunk_power) + ⌈65 / 2^chunk_power⌉ | Charged exactly like a buffered append: the compaction's chunk-leaf hash, MMR merges and bagging (≤ 65 per chunk) are amortized over the epoch as a bound on every append (1 blake3 from chunk_power 7); physically it hashes the blob once and merges the MMR, reading the buffer back |
 | Single append (with compaction), GROVE_V1..V3 | 1 + MMR merges + 1 | Chunk-leaf hash + MMR push/bagging + state root, billed where they happen |
 | `get_value` from chunk | 0 | Pure deserialization, no hashing |
 | `get_value` from buffer | 0 | Direct key lookup |
@@ -489,9 +489,12 @@ positions, so the amortized cost is ~chunk_size hashes per append (≈ 2k at
 chunk_power 11, peaking at ≈ 4k), and the compacting append pays the blob and MMR
 work where it happens. From GROVE_V4 **every append is charged the same fixed
 model**, whatever its position: the buffer's root-maintenance model for its height
-(12 blake3 calls and 18 record reads at chunk_power 11), one amortized compaction
-blake3, its long-term footprint as `added` (the chunk-blob share plus the epoch's
-share of the blob framing and MMR nodes — 1 byte at chunk_power 11) and its churn as
+(12 blake3 calls and 18 record reads at chunk_power 11), the amortized compaction
+bound (⌈65 / 2^chunk_power⌉ blake3 — 1 at chunk_power 11), its long-term footprint as
+`added` (the chunk-blob share, plus the variable format's 4-byte per-entry prefix
+unless the owner declared a fixed entry size with `with_fixed_entry_size` — the
+commitment tree and the private document store do — plus the epoch's share of the
+blob framing and MMR nodes — 1 byte at chunk_power 11) and its churn as
 `replaced` (slot, path record, its part of the blob rewrite). The compacting append
 writes the blob, the MMR nodes and the persisted MMR root prepaid and is charged the
 same; physically it still reads the epoch back and hashes the blob once. The only

--- a/docs/book/src/bulk-append-tree.md
+++ b/docs/book/src/bulk-append-tree.md
@@ -214,7 +214,7 @@ All BulkAppendTree data lives in the **data** namespace, keyed with single-chara
 | `e` + `{index}` | `e` + u64 BE | 9B | Chunk blob at index |
 | `m` + `{pos}` | `m` + u64 BE | 9B | MMR node at position |
 | `h` + `{index}` | `h` + u16 BE | 3B | Path record of the insert at index (GROVE_V4+, see Chapter 16) |
-| `r` | 1 byte | 1B | Persisted chunk-MMR root, written at each compaction (GROVE_V4+) so a reopened tree does not bag the peaks' blobs |
+| `r` | 1 byte | 1B | Persisted chunk-MMR root, written at each compaction (GROVE_V4+) so a reopened tree does not bag the peaks' blobs; a tree that last compacted before V4 gets it backfilled by its first V4 append |
 
 **Metadata** stores `mmr_size` (8 bytes BE). The `total_count` and `chunk_power` are
 stored in the Element itself (in the parent Merk), not in data namespace metadata.

--- a/docs/book/src/commitment-tree.md
+++ b/docs/book/src/commitment-tree.md
@@ -262,6 +262,7 @@ the same column using distinct key prefixes. No aux namespace is used.
 │    b"b" || index (u64 BE)→ buffer entries (cmx||rho||cv_net||ciphertext) │
 │    b"e" || chunk (u64 BE)→ chunk blobs (compacted buffer)         │
 │    b"h" || index (u16 BE)→ buffer path records (GROVE_V4+, §16)   │
+│    b"r"                  → persisted chunk-MMR root (GROVE_V4+)   │
 │    b"M"                  → BulkAppendTree metadata                │
 │                                                                   │
 │  Sinsemilla frontier:                                             │
@@ -934,12 +935,12 @@ and ZK circuit cost.
 
 | Component | Average case | Worst case |
 |---|---|---|
-| Sinsemilla hashes | 33 (32 root + 1 ommer avg) | 64 (32 root + 32 ommers) |
+| Sinsemilla hashes | GROVE_V4+: fixed 33 (32 root + the average ommer merge); GROVE_V1..V3: 32 + trailing_ones(position) | GROVE_V4+: 33; GROVE_V1..V3: 64 |
 | Frontier I/O seeks | 2 (get + put) | 2 |
-| Frontier bytes loaded | 554 (~16 ommers) | 1,066 (32 ommers) |
-| Frontier bytes written | 554 | 1,066 |
-| BulkAppendTree hashes | GROVE_V4+: fixed model (13 at chunk_power 11, every buffered append); GROVE_V1..V3: 2·(buffer fill) + 1 | GROVE_V4+: the same model buffered, 1 + MMR merges compacting; GROVE_V1..V3: ≈ 2·chunk_size on the last buffered append |
-| BulkAppendTree I/O | GROVE_V4+: the model's record reads (18 at chunk_power 11) + slot put + record put (churn: `replaced`, never `added`) | + epoch read-back and MMR writes on chunk compaction |
+| Frontier bytes loaded | GROVE_V4+: fixed 554 (the average frontier); GROVE_V1..V3: the actual 42 + 32·popcount(position) | GROVE_V4+: 554; GROVE_V1..V3: 1,066 |
+| Frontier bytes written | GROVE_V4+: 554 `replaced`; GROVE_V1..V3: actual | same |
+| BulkAppendTree hashes | GROVE_V4+: fixed model (12 + 1 amortized compaction + 1 state root at chunk_power 11, every append, compacting included); GROVE_V1..V3: 2·(buffer fill) + 1 | GROVE_V4+: the same; GROVE_V1..V3: ≈ 2·chunk_size on the last buffered append |
+| BulkAppendTree I/O | GROVE_V4+: the model's record reads (18 at chunk_power 11), slot + record puts (churn: `replaced`, never `added`), blob share + 1 B amortized framing `added` | GROVE_V4+: the same, the compacting append's commit-time puts aside; GROVE_V1..V3: + epoch read-back and MMR writes on chunk compaction |
 
 **Cost estimation constants** (from `average_case_costs.rs` and
 `worst_case_costs.rs`):

--- a/docs/book/src/commitment-tree.md
+++ b/docs/book/src/commitment-tree.md
@@ -261,7 +261,7 @@ the same column using distinct key prefixes. No aux namespace is used.
 │    b"m" || pos (u64 BE)  → MMR node blobs                        │
 │    b"b" || index (u64 BE)→ buffer entries (cmx||rho||cv_net||ciphertext) │
 │    b"e" || chunk (u64 BE)→ chunk blobs (compacted buffer)         │
-│    b"h" || index (u16 BE)→ buffer hash records (GROVE_V4+, §16)   │
+│    b"h" || index (u16 BE)→ buffer path records (GROVE_V4+, §16)   │
 │    b"M"                  → BulkAppendTree metadata                │
 │                                                                   │
 │  Sinsemilla frontier:                                             │
@@ -938,8 +938,8 @@ and ZK circuit cost.
 | Frontier I/O seeks | 2 (get + put) | 2 |
 | Frontier bytes loaded | 554 (~16 ommers) | 1,066 (32 ommers) |
 | Frontier bytes written | 554 | 1,066 |
-| BulkAppendTree hashes | GROVE_V4+: 3 + depth (≤ chunk_power + 2); GROVE_V1..V3: 2·(buffer fill) + 1 | GROVE_V4+: chunk_power + 2 buffered, 1 + MMR merges compacting; GROVE_V1..V3: ≈ 2·chunk_size on the last buffered append |
-| BulkAppendTree I/O | 2-3 seeks (metadata + buffer) + O(chunk_power) hash-record writes (GROVE_V4+) | + epoch read-back and MMR writes on chunk compaction |
+| BulkAppendTree hashes | GROVE_V4+: fixed model (13 at chunk_power 11, every buffered append); GROVE_V1..V3: 2·(buffer fill) + 1 | GROVE_V4+: the same model buffered, 1 + MMR merges compacting; GROVE_V1..V3: ≈ 2·chunk_size on the last buffered append |
+| BulkAppendTree I/O | GROVE_V4+: the model's record reads (18 at chunk_power 11) + slot put + record put (churn: `replaced`, never `added`) | + epoch read-back and MMR writes on chunk compaction |
 
 **Cost estimation constants** (from `average_case_costs.rs` and
 `worst_case_costs.rs`):

--- a/docs/book/src/commitment-tree.md
+++ b/docs/book/src/commitment-tree.md
@@ -939,7 +939,7 @@ and ZK circuit cost.
 | Frontier I/O seeks | 2 (get + put) | 2 |
 | Frontier bytes loaded | GROVE_V4+: fixed 554 (the average frontier); GROVE_V1..V3: the actual 42 + 32·popcount(position) | GROVE_V4+: 554; GROVE_V1..V3: 1,066 |
 | Frontier bytes written | GROVE_V4+: 554 `replaced`; GROVE_V1..V3: actual | same |
-| BulkAppendTree hashes | GROVE_V4+: fixed model (12 + 1 amortized compaction + 1 state root at chunk_power 11, every append, compacting included); GROVE_V1..V3: 2·(buffer fill) + 1 | GROVE_V4+: the same; GROVE_V1..V3: ≈ 2·chunk_size on the last buffered append |
+| BulkAppendTree hashes | GROVE_V4+: fixed model (12 + ⌈65 / 2^chunk_power⌉ = 1 amortized compaction + 1 state root at chunk_power 11, every append, compacting included); GROVE_V1..V3: 2·(buffer fill) + 1 | GROVE_V4+: the same; GROVE_V1..V3: ≈ 2·chunk_size on the last buffered append |
 | BulkAppendTree I/O | GROVE_V4+: the model's record reads (18 at chunk_power 11), slot + record puts (churn: `replaced`, never `added`), blob share + 1 B amortized framing `added` | GROVE_V4+: the same, the compacting append's commit-time puts aside; GROVE_V1..V3: + epoch read-back and MMR writes on chunk compaction |
 
 **Cost estimation constants** (from `average_case_costs.rs` and

--- a/docs/book/src/dense-tree.md
+++ b/docs/book/src/dense-tree.md
@@ -80,29 +80,44 @@ small capacities, but as the buffer of the append-only family (Chapter 14, 15) t
 tree reaches 2,047 positions in the shielded pool, where the last insert of every
 epoch cost ≈ 2k reads and ≈ 4k blake3 calls.
 
-### Hash Records (GROVE_V4+)
+### Path Records (GROVE_V4+)
 
-From GROVE_V4 (`dense_tree_versions.root_maintenance = 1`) the tree persists a
-**hash record** for every filled position under the key `b'h' || position`:
+From GROVE_V4 (`dense_tree_versions.root_maintenance = 1`) every insert writes one
+**path record** under its own position's key `b'h' || position`:
 
 ```text
-HashRecord = generation (u64 BE) || value_hash (32) || node_hash (32)     // 72 bytes
+PathRecord = generation (u64 BE) || present (u16 BE) || value_hash (32)
+             || entry[0..height] (32 each)          // 42 + 32·height bytes, fixed per tree
 ```
 
-- `value_hash = blake3(value)`, so re-hashing an ancestor never reads its value back;
-- `node_hash` is the position's subtree hash as of the last insert into it;
+- `value_hash = blake3(value)` of the inserting position — so when it is later an
+  ancestor, re-hashing it never reads its value back;
+- `entry[depth]` is the node hash of the path position at that depth, as of this
+  insert (`present` marks the depths that hold one: `0..=depth(position)`);
 - `generation` is the epoch tag: the bulk-append tree reuses the same position keys
   every epoch (its chunk count is the tag, advanced by `reset`), and a record carrying
   another generation is never trusted.
 
-An insert at position `p` (depth `d`) hashes the new leaf (`blake3(value)`, then
-`blake3(value_hash || 0 || 0)` — both children are beyond `count`), writes `p`'s
-record, and walks up: for each ancestor the on-path child's hash was just computed,
-the off-path sibling's hash is its record's `node_hash` (or `[0; 32]` beyond
-`count`), and the ancestor's own record supplies its `value_hash`; one blake3 and one
-record rewrite per level. That is `2 + d` blake3 calls, at most `2d` record reads and
-`d + 1` record writes — O(height), whatever the fill. The root is the record at
-position 0 (one read).
+Because positions fill in BFS order, the record of the **last insert into a subtree**
+holds that subtree's current hash (no later insert touched it), and every position's
+own record holds its value hash for good — both are located arithmetically from
+`count` (`last_filled_in_subtree`), so no record is ever rewritten. An insert at
+position `p` (depth `d`) hashes the new leaf (`blake3(value)`, then
+`blake3(value_hash || 0 || 0)` — both children are beyond `count`) and walks up: for
+each ancestor the on-path child's hash was just computed, the off-path sibling's hash
+is read from the record of the last insert into its subtree (or `[0; 32]` beyond
+`count`), and the ancestor's own record supplies its `value_hash`; one blake3 per
+level. That is `2 + d` blake3 calls, at most `2d` record reads and **one** record
+write — O(height), whatever the fill. The root is `entry[0]` of the last insert's
+record (one read).
+
+**What an insert is charged** is not the work of its particular position but a
+**fixed model for the tree's height** (`v1_insert_model_cost`): the blake3 calls
+(`2 + avg depth`) and record reads averaged over every position of a full buffer,
+rounded up — at `chunk_power` 11: 12 blake3 calls, 18 record reads of 394 bytes —
+plus the two puts (slot, record), each of a size that does not depend on the
+position. Appending to a tree of a given height therefore costs the same whatever
+the position, and an estimator can charge exactly it.
 
 Records are derived state: `root_hash` trusts them, so integrity audits
 (`verify_grovedb`, the binding check at the end of a state-sync restore) derive the
@@ -113,9 +128,10 @@ report a position-0 record that disagrees with the walked root as its own issue
 
 A record that is absent (a buffer filled under GROVE_V1..V3) or stale (an earlier
 generation) is recomputed from the values — the version-0 walk over that subtree —
-and recorded, so the catch-up costs at most one version-0 walk per buffer, once.
-Stored values, positions, proofs and roots are identical under both versions; only
-the records (and the work an insert is charged) differ.
+read-only and billed the same model; for the append-only family's rolling buffer
+that catch-up ends with the epoch the switch happened in. Stored values, positions,
+proofs and roots are identical under both versions; only the records (and the work
+an insert is charged) differ.
 
 ## The Element Variant
 
@@ -156,7 +172,7 @@ Storage keys:
   ...
 ```
 
-From GROVE_V4 a hash record sits beside each value under a 3-byte key (`b'h' || position`
+From GROVE_V4 a path record sits beside each value under a 3-byte key (`b'h' || position`
 as big-endian `u16`); the 2-byte slot keys and 3-byte record keys cannot collide.
 
 The Element itself (stored in the parent Merk) carries the `count` and `height`.
@@ -164,9 +180,10 @@ The root hash flows as the Merk child hash. This means:
 - **Reading the root hash** is one record read from GROVE_V4 (O(n) recomputation from
   storage under GROVE_V1..V3)
 - **Reading a value by position is O(1)** — single storage lookup
-- **Inserting is O(height)** from GROVE_V4 — one slot write, the ancestor path's
-  record reads/writes and `2 + depth` blake3 calls (O(n) hashing under GROVE_V1..V3:
-  one storage write + full root hash recomputation)
+- **Inserting is O(height)** from GROVE_V4 — one slot write, one record write, the
+  ancestor path's record reads and `2 + depth` blake3 calls, charged as the height's
+  fixed model (O(n) hashing under GROVE_V1..V3: one storage write + full root hash
+  recomputation)
 
 ## Operations
 

--- a/docs/book/src/dense-tree.md
+++ b/docs/book/src/dense-tree.md
@@ -101,7 +101,9 @@ PathRecord = generation (u64 BE) || present (u16 BE) || value_hash (32)
 Because positions fill in BFS order, the record of the **last insert into a subtree**
 holds that subtree's current hash (no later insert touched it), and every position's
 own record holds its value hash for good — both are located arithmetically from
-`count` (`last_filled_in_subtree`), so no record is ever rewritten. An insert at
+`count` (`last_filled_in_subtree`), so within an epoch no record is ever rewritten
+(the bulk-append tree's next epoch reuses the same keys; its records then carry a
+newer `generation`, which marks the previous epoch's as stale). An insert at
 position `p` (depth `d`) hashes the new leaf (`blake3(value)`, then
 `blake3(value_hash || 0 || 0)` — both children are beyond `count`) and walks up: for
 each ancestor the on-path child's hash was just computed, the off-path sibling's hash
@@ -160,15 +162,15 @@ via `insert_subtree`'s `subtree_root_hash` parameter.
 ## Storage Layout
 
 Like MmrTree and BulkAppendTree, the DenseAppendOnlyFixedSizeTree stores data in the
-**data** namespace (not a child Merk). Values are keyed by their position as a big-endian `u64`:
+**data** namespace (not a child Merk). Values are keyed by their position as a big-endian `u16`:
 
 ```text
 Subtree path: blake3(parent_path || key)
 
 Storage keys:
-  [0, 0, 0, 0, 0, 0, 0, 0] → value at position 0 (root)
-  [0, 0, 0, 0, 0, 0, 0, 1] → value at position 1
-  [0, 0, 0, 0, 0, 0, 0, 2] → value at position 2
+  [0, 0] → value at position 0 (root)
+  [0, 1] → value at position 1
+  [0, 2] → value at position 2
   ...
 ```
 

--- a/docs/crates/costs.md
+++ b/docs/crates/costs.md
@@ -133,21 +133,21 @@ records exist only under `dense_tree_versions.root_maintenance = 1`):
 | write | GROVE_V1..V3 (v0) | GROVE_V4 (v1, issue #822) |
 |---|---|---|
 | buffer slot, any epoch | key + value `added` | value `replaced` (its own paid size); nothing added, key not charged, nothing read |
-| entry's chunk-blob share | — (blob charged at compaction) | entry bytes `added` at the entry's own append |
-| compaction blob | key + whole blob `added` | entry bytes `replaced`, framing + key `added` |
-| MMR internal nodes | `added` | `added` |
-| frontier rewrite | key + value `added` every save | value `replaced`, growth `added`; first save fully `added` |
+| entry's chunk-blob share | — (blob charged at compaction) | entry bytes `added` at the entry's own append, plus the epoch's share of the blob framing and MMR nodes (`amortized_compaction_added_bytes`, 1 byte at `chunk_power` 11) |
+| entry's part of the blob rewrite | — | entry bytes `replaced` at the entry's own append |
+| compaction blob, MMR internal nodes, persisted MMR root (`r`) | key + whole blob `added`; nodes `added`; no persisted root | prepaid: zero-byte cost information |
+| frontier rewrite | key + value `added` every save | the model's 554 bytes `replaced` every save (`frontier_cost_model`), first save included |
 | buffer path record (one per append, `42 + 32·chunk_power` bytes) | — (no records) | `replaced` (its own paid size); nothing added, key not charged |
 
 Under v0 every note is billed roughly twice over its life (slot + blob) and
 the whole blob (≈ 630 KB at `chunk_power` 11) lands on one append per
 epoch. Under v1 each entry's `added_bytes` are its long-term footprint —
-its permanent bytes charged once, at its own append, plus, on the compacting
-append, the blob framing and the MMR nodes that compaction creates (the
-estimators reserve those at the merge-count bound on every append, since the
-appender chooses when it compacts) — and everything else (the rolling
-buffer's slots and records, the blob itself, the frontier) is replacement;
-the dense buffer's
+its permanent bytes charged once, at its own append, plus the epoch's share
+of the blob framing and MMR nodes — and everything else (the rolling
+buffer's slots and records, its part of the blob rewrite, the frontier) is
+replacement; the compacting append is charged the same as any other (its
+hashes are amortized as one blake3 per append, its writes are prepaid, and
+it is charged the slot / record churn it does not write); the dense buffer's
 physical bytes, a bounded per-tree overhead rewritten every epoch, are
 deliberately charged to nobody as growth. `removed_bytes` stays
 `NoStorageRemoval` in both — a rolling buffer refunds nobody. Stored bytes,

--- a/docs/crates/costs.md
+++ b/docs/crates/costs.md
@@ -133,7 +133,7 @@ records exist only under `dense_tree_versions.root_maintenance = 1`):
 | write | GROVE_V1..V3 (v0) | GROVE_V4 (v1, issue #822) |
 |---|---|---|
 | buffer slot, any epoch | key + value `added` | value `replaced` (its own paid size); nothing added, key not charged, nothing read |
-| entry's chunk-blob share | — (blob charged at compaction) | entry bytes `added` at the entry's own append, plus the epoch's share of the blob framing and MMR nodes (`amortized_compaction_added_bytes`, 1 byte at `chunk_power` 11) |
+| entry's chunk-blob share | — (blob charged at compaction) | entry bytes `added` at the entry's own append (plus the variable format's 4-byte per-entry prefix unless the owner declared a fixed entry size — the commitment tree and the private document store do), plus the epoch's share of the blob framing and MMR nodes (`amortized_compaction_added_bytes`, 1 byte at `chunk_power` 11) |
 | entry's part of the blob rewrite | — | entry bytes `replaced` at the entry's own append |
 | compaction blob, MMR internal nodes, persisted MMR root (`r`) | key + whole blob `added`; nodes `added`; no persisted root | prepaid: zero-byte cost information |
 | frontier rewrite | key + value `added` every save | 556 bytes `replaced` every save — the model's 554-byte frontier plus its two-byte length varint (`frontier_cost_model`), first save included |
@@ -146,8 +146,9 @@ its permanent bytes charged once, at its own append, plus the epoch's share
 of the blob framing and MMR nodes — and everything else (the rolling
 buffer's slots and records, its part of the blob rewrite, the frontier) is
 replacement; the compacting append is charged the same as any other (its
-hashes are amortized as one blake3 per append, its writes are prepaid, and
-it is charged the slot / record churn it does not write); the dense buffer's
+hashes — at most 65 per chunk — are amortized as a bound over the epoch,
+`⌈65 / 2^chunk_power⌉` blake3 per append, its writes are prepaid, and it
+is charged the slot / record churn it does not write); the dense buffer's
 physical bytes, a bounded per-tree overhead rewritten every epoch, are
 deliberately charged to nobody as growth. `removed_bytes` stays
 `NoStorageRemoval` in both — a rolling buffer refunds nobody. Stored bytes,

--- a/docs/crates/costs.md
+++ b/docs/crates/costs.md
@@ -121,10 +121,10 @@ Count trees add overhead for maintaining element counts:
 
 The append-only family writes four kinds of data rows: dense-buffer slots
 (one per position, keys reused every epoch), from GROVE_V4 the buffer's
-hash records (one per position, `b'h' || position`, rewritten along the
-inserted position's ancestor path), the chunk blob an epoch is compacted
-into (plus the MMR internal nodes), and — for the commitment tree — the
-frontier, one value rewritten on every append. How those writes are
+path records (one per append, under the inserting position's key
+`b'h' || position`, never rewritten within an epoch), the chunk blob an
+epoch is compacted into (plus the MMR internal nodes), and — for the
+commitment tree — the frontier, one value rewritten on every append. How those writes are
 reported to the fee layer is version-gated
 (`bulk_append_tree_versions.cost.append_storage_accounting`,
 `commitment_tree_versions.cost.frontier_save_storage_accounting`; the
@@ -142,9 +142,12 @@ records exist only under `dense_tree_versions.root_maintenance = 1`):
 Under v0 every note is billed roughly twice over its life (slot + blob) and
 the whole blob (≈ 630 KB at `chunk_power` 11) lands on one append per
 epoch. Under v1 each entry's `added_bytes` are its long-term footprint —
-its permanent bytes charged once, at its own append, plus the amortized blob
-framing and MMR nodes — and everything else (the rolling buffer's slots and
-records, the blob itself, the frontier) is replacement; the dense buffer's
+its permanent bytes charged once, at its own append, plus, on the compacting
+append, the blob framing and the MMR nodes that compaction creates (the
+estimators reserve those at the merge-count bound on every append, since the
+appender chooses when it compacts) — and everything else (the rolling
+buffer's slots and records, the blob itself, the frontier) is replacement;
+the dense buffer's
 physical bytes, a bounded per-tree overhead rewritten every epoch, are
 deliberately charged to nobody as growth. `removed_bytes` stays
 `NoStorageRemoval` in both — a rolling buffer refunds nobody. Stored bytes,

--- a/docs/crates/costs.md
+++ b/docs/crates/costs.md
@@ -136,7 +136,7 @@ records exist only under `dense_tree_versions.root_maintenance = 1`):
 | entry's chunk-blob share | — (blob charged at compaction) | entry bytes `added` at the entry's own append, plus the epoch's share of the blob framing and MMR nodes (`amortized_compaction_added_bytes`, 1 byte at `chunk_power` 11) |
 | entry's part of the blob rewrite | — | entry bytes `replaced` at the entry's own append |
 | compaction blob, MMR internal nodes, persisted MMR root (`r`) | key + whole blob `added`; nodes `added`; no persisted root | prepaid: zero-byte cost information |
-| frontier rewrite | key + value `added` every save | the model's 554 bytes `replaced` every save (`frontier_cost_model`), first save included |
+| frontier rewrite | key + value `added` every save | 556 bytes `replaced` every save — the model's 554-byte frontier plus its two-byte length varint (`frontier_cost_model`), first save included |
 | buffer path record (one per append, `42 + 32·chunk_power` bytes) | — (no records) | `replaced` (its own paid size); nothing added, key not charged |
 
 Under v0 every note is billed roughly twice over its life (slot + blob) and

--- a/docs/crates/costs.md
+++ b/docs/crates/costs.md
@@ -132,45 +132,44 @@ records exist only under `dense_tree_versions.root_maintenance = 1`):
 
 | write | GROVE_V1..V3 (v0) | GROVE_V4 (v1, issue #822) |
 |---|---|---|
-| buffer slot, first epoch | key + value `added` | key + value `added` |
-| buffer slot, epoch ≥ 2 | key + value `added` | value `replaced` (growth `added`, shrink not credited); key not charged |
+| buffer slot, any epoch | key + value `added` | value `replaced` (its own paid size); nothing added, key not charged, nothing read |
 | entry's chunk-blob share | — (blob charged at compaction) | entry bytes `added` at the entry's own append |
 | compaction blob | key + whole blob `added` | entry bytes `replaced`, framing + key `added` |
 | MMR internal nodes | `added` | `added` |
 | frontier rewrite | key + value `added` every save | value `replaced`, growth `added`; first save fully `added` |
-| buffer hash record, key absent in committed storage | — (no records) | key + 72-byte record `added` |
-| buffer hash record, key present | — (no records) | 72 bytes `replaced`; key not charged |
+| buffer path record (one per append, `42 + 32·chunk_power` bytes) | — (no records) | `replaced` (its own paid size); nothing added, key not charged |
 
 Under v0 every note is billed roughly twice over its life (slot + blob) and
 the whole blob (≈ 630 KB at `chunk_power` 11) lands on one append per
-epoch. Under v1 each entry's permanent bytes are charged once, at its own
-append, and the rest of the churn is replacement; the sum of `added_bytes`
-over an epoch matches the database growth. `removed_bytes` stays
+epoch. Under v1 each entry's `added_bytes` are its long-term footprint —
+its permanent bytes charged once, at its own append, plus the amortized blob
+framing and MMR nodes — and everything else (the rolling buffer's slots and
+records, the blob itself, the frontier) is replacement; the dense buffer's
+physical bytes, a bounded per-tree overhead rewritten every epoch, are
+deliberately charged to nobody as growth. `removed_bytes` stays
 `NoStorageRemoval` in both — a rolling buffer refunds nobody. Stored bytes,
 roots and proofs are identical under both versions.
 
-Mechanically: `BulkAppendTree` reads the committed value of a slot that
-already holds one (judged against the count at open; never this session's
-cache) before rewriting it — one billed seek plus the value's bytes — and
-asks the dense tree for `SlotWriteAccounting::Overwrite { previous_value_len }`,
-which attaches `KeyValueStorageCost::for_in_place_value_rewrite`; the MMR
-`MmrStore` takes a `LeafValueStorageCost::PartlyPrepaid` policy that the
-bulk tree feeds `chunk_blob_entry_bytes`; the `Result`-returning appends
-report a `storage_accounting_cost` (the prepaid share plus the slot read)
-for the caller to bill, while the `CostResult`-returning
-`append_deferred_roots` already includes it in its cost.
+Mechanically: the MMR `MmrStore` takes a `LeafValueStorageCost::PartlyPrepaid`
+policy that the bulk tree feeds `chunk_blob_entry_bytes`; the
+`Result`-returning appends report a `storage_accounting_cost` (the prepaid
+share plus the buffer model's reads) for the caller to bill, while the
+`CostResult`-returning `append_deferred_roots` already includes it in its
+cost.
 
-Hash records (GROVE_V4 root maintenance) size their own writes from the
-read that resolving the record performs anyway: a record the session read
-from committed storage, or wrote over one, is rewritten in place
-(`for_in_place_value_rewrite(72, 72)`); one whose key did not exist is new
-storage. The new leaf's record can pre-exist only when its slot does
-(`SlotWriteAccounting::Overwrite`), in which case it is read once. The
-`Result`-returning appends still bill only the dense tree's hash count
-(now `2 + depth` instead of `2 * count`) plus `storage_accounting_cost` —
-the record reads are dropped there, as the buffer-walk reads always were —
-while `append_deferred_roots` (the `PrivateDocumentStore` path) bills the
-record reads too. Record writes reach every caller at commit.
+Under v1 the bulk-append tree asks the dense tree for
+`SlotWriteAccounting::Churn`: the slot put and the path record put are
+issued as in-place replacements of their own size
+(`for_in_place_value_rewrite(len, len)`), whatever the keys held — the
+buffer is not an entry's long-term storage, so nothing of it is ever
+`added` and nothing is read to size a rewrite. The dense tree's
+root-maintenance charge is a fixed model for the buffer's height
+(`v1_insert_model_cost`: the blake3 calls and record reads averaged over a
+full buffer, rounded up); the `Result`-returning appends forward it as
+`hash_count` plus the reads in `storage_accounting_cost`, and
+`append_deferred_roots` (the `PrivateDocumentStore` path) bills it directly.
+A standalone `DenseAppendOnlyFixedSizeTree` keeps `AsNew`: its buffer is its
+long-term storage, so its records are new storage.
 
 ## Cost Context
 

--- a/grovedb-bulk-append-tree/Cargo.toml
+++ b/grovedb-bulk-append-tree/Cargo.toml
@@ -30,6 +30,7 @@ grovedb-costs = { version = "5.0.1", path = "../costs" }
 grovedb-version = { version = "5.0.1", path = "../grovedb-version" }
 grovedb-storage = { version = "5.0.1", path = "../storage", optional = true }
 blake3 = { workspace = true }
+integer-encoding = { workspace = true }
 bincode = { workspace = true, features = ["derive"] }
 hex = { workspace = true }
 thiserror = { workspace = true }

--- a/grovedb-bulk-append-tree/src/cost/mod.rs
+++ b/grovedb-bulk-append-tree/src/cost/mod.rs
@@ -16,8 +16,10 @@
 //!   slot rewritten in epoch 2+, and the chunk blob that supersedes the
 //!   buffer, are both billed as permanent growth. v1 charges each entry's
 //!   permanent bytes once — its chunk-blob share, at its own append — and
-//!   reports the slot rewrite and the compaction blob as replacements of
-//!   the bytes they supersede.
+//!   reports every buffer write (slot and path record, which are churn: the
+//!   buffer is rewritten each epoch and is not the entry's long-term
+//!   storage) and the compaction blob as replacements, never as growth; it
+//!   also bills the buffer's fixed root-maintenance model.
 
 mod v0;
 mod v1;
@@ -28,16 +30,18 @@ use grovedb_version::{error::GroveVersionError, version::GroveVersion};
 
 use crate::BulkAppendError;
 
-/// How the dense-buffer slot write is sized for the storage cost layer.
+/// How the dense-buffer slot write — and the path record written beside it
+/// — is sized for the storage cost layer.
 #[cfg(feature = "storage")]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum SlotRewriteAccounting {
     /// Every slot write is new storage (no cost information on the put).
     AsNew,
-    /// A slot that holds a committed value is read first (the read is
-    /// billed) and the write is reported as its replacement; a slot written
-    /// for the first time stays new storage.
-    AgainstCommitted,
+    /// The buffer is churn: every slot and record write is reported as an
+    /// in-place replacement of its own size — nothing added, no key charged,
+    /// nothing read to size it. The entry's long-term bytes are its chunk-blob
+    /// share, prepaid at its append.
+    Churn,
 }
 
 /// How an append's data-storage writes are reported to the storage cost
@@ -45,13 +49,19 @@ pub(crate) enum SlotRewriteAccounting {
 #[cfg(feature = "storage")]
 #[derive(Clone, Copy)]
 pub(crate) struct AppendStorageAccounting {
-    /// How the dense-buffer slot write is sized.
+    /// How the dense-buffer slot (and record) write is sized.
     pub slot_rewrite: SlotRewriteAccounting,
     /// How the chunk-blob leaf is reported when the MMR overlay is flushed.
     pub chunk_leaf: LeafValueStorageCost,
     /// Whether the entry's chunk-blob share is charged as added storage at
     /// its own append (so the later blob write can be a replacement).
     prepay_chunk_share: bool,
+    /// Whether the dense buffer's own reads (its root-maintenance model,
+    /// from GROVE_V4 a fixed figure per insert) are billed by the
+    /// `Result`-returning appends through `storage_accounting_cost`, on top
+    /// of the hash count they have always forwarded. The shipped accounting
+    /// dropped them.
+    pub bill_dense_io: bool,
 }
 
 #[cfg(feature = "storage")]

--- a/grovedb-bulk-append-tree/src/cost/mod.rs
+++ b/grovedb-bulk-append-tree/src/cost/mod.rs
@@ -71,10 +71,39 @@ pub(crate) struct AppendStorageAccounting {
     pub fixed_model: bool,
 }
 
+/// The most blake3 calls one compaction can perform: the chunk-leaf hash,
+/// the MMR push's merges (one per trailing one bit of the chunk index) and
+/// the root bagging (one per peak beyond the first). MMR positions are
+/// 32-bit keys, so the chunk MMR never exceeds 2^31 leaves: at most 31
+/// merges and 31 bagging folds — bounded by 32 each here.
+pub const MAX_COMPACTION_HASHES_PER_CHUNK: u32 = 1 + 32 + 32;
+
 /// The blake3 calls a compaction performs, amortized over the epoch it
-/// serves: the chunk-leaf hash and the MMR merges and bagging are at most a
-/// few dozen per `2^chunk_power` appends, so one per append covers them.
-pub const AMORTIZED_COMPACTION_HASHES: u32 = 1;
+/// serves and charged on every append under the fixed model: the per-chunk
+/// bound spread over `2^chunk_power` appends, rounded up — one per append
+/// from `chunk_power` 7 (so at the shielded pool's 11), and 33 at the
+/// smallest `chunk_power`. Charging the bound rather than the average keeps
+/// every prefix of the tree's life prepaid: a chunk's charge
+/// (`2^chunk_power` × this) is never below its actual work, so no run of
+/// small or late epochs can fall behind.
+pub fn amortized_compaction_hashes(chunk_power: u8) -> u32 {
+    MAX_COMPACTION_HASHES_PER_CHUNK.div_ceil(1u32 << chunk_power.min(16) as u32)
+}
+
+/// The largest per-append compaction hash share the type permits — the
+/// smallest epoch, `chunk_power` 1.
+pub fn max_amortized_compaction_hashes() -> u32 {
+    amortized_compaction_hashes(1)
+}
+
+/// The per-entry framing a variable-format chunk blob carries: a four-byte
+/// length prefix before every entry (`serialize_variable`). A tree whose
+/// entries are all one size serializes the fixed format (no per-entry
+/// framing); the bulk-append tree cannot know which format an epoch will
+/// take until it compacts, so an owner that does not declare a fixed entry
+/// size (`BulkAppendTree::with_fixed_entry_size`) is charged this bound on
+/// every entry.
+pub const VARIABLE_ENTRY_FRAMING_BYTES: u32 = 4;
 
 /// Bytes a compaction adds beyond the epoch's entry bytes, amortized over
 /// the epoch: the chunk blob's framing (its MMR leaf key with the 32-byte
@@ -93,11 +122,15 @@ pub fn amortized_compaction_added_bytes(epoch_size: u64) -> u32 {
 #[cfg(feature = "storage")]
 impl AppendStorageAccounting {
     /// The entry's chunk-blob share to charge as added storage at its append:
-    /// its own bytes, or nothing when the blob is charged in full at
-    /// compaction instead.
-    pub fn prepaid_chunk_bytes(&self, value_len: usize) -> u32 {
+    /// its own bytes plus the per-entry blob framing the owner has not ruled
+    /// out (`entry_framing`: [`VARIABLE_ENTRY_FRAMING_BYTES`] unless the tree
+    /// declares a fixed entry size), or nothing when the blob is charged in
+    /// full at compaction instead.
+    pub fn prepaid_chunk_bytes(&self, value_len: usize, entry_framing: u32) -> u32 {
         if self.prepay_chunk_share {
-            u32::try_from(value_len).unwrap_or(u32::MAX)
+            u32::try_from(value_len)
+                .unwrap_or(u32::MAX)
+                .saturating_add(entry_framing)
         } else {
             0
         }
@@ -146,7 +179,7 @@ pub(crate) fn append_storage_accounting(
 /// `hash_count_for_push` expects); `mmr_size_after_push` is the size the MMR
 /// reached, which determines how many peaks the compaction's `get_root` had
 /// to fold. Version 1 reports nothing here: the compaction is amortized into
-/// every append ([`AMORTIZED_COMPACTION_HASHES`]).
+/// every append ([`amortized_compaction_hashes`]).
 pub(crate) fn compaction_hash_count(
     leaf_count: u64,
     mmr_size_after_push: u64,

--- a/grovedb-bulk-append-tree/src/cost/mod.rs
+++ b/grovedb-bulk-append-tree/src/cost/mod.rs
@@ -18,8 +18,10 @@
 //!   permanent bytes once — its chunk-blob share, at its own append — and
 //!   reports every buffer write (slot and path record, which are churn: the
 //!   buffer is rewritten each epoch and is not the entry's long-term
-//!   storage) and the compaction blob as replacements, never as growth; it
-//!   also bills the buffer's fixed root-maintenance model.
+//!   storage) as replacements, never as growth; it charges every append the
+//!   fixed model — the buffer's root-maintenance model plus the compaction
+//!   amortized over the epoch — and bills the compacting append nothing
+//!   extra (the blob and MMR nodes it writes are prepaid).
 
 mod v0;
 mod v1;
@@ -56,12 +58,36 @@ pub(crate) struct AppendStorageAccounting {
     /// Whether the entry's chunk-blob share is charged as added storage at
     /// its own append (so the later blob write can be a replacement).
     prepay_chunk_share: bool,
-    /// Whether the dense buffer's own reads (its root-maintenance model,
-    /// from GROVE_V4 a fixed figure per insert) are billed by the
-    /// `Result`-returning appends through `storage_accounting_cost`, on top
-    /// of the hash count they have always forwarded. The shipped accounting
-    /// dropped them.
-    pub bill_dense_io: bool,
+    /// Whether an append is charged the FIXED per-append model instead of
+    /// the work of its particular position: the dense buffer's
+    /// root-maintenance model (`v1_insert_model_cost`, reads and hashes) on
+    /// every append — buffered or compacting — plus the compaction amortized
+    /// over the epoch (one blake3 per append, the entry's own bytes as the
+    /// blob rewrite it will be part of, and a share of the blob framing and
+    /// MMR nodes as added storage), with the compacting append's own work
+    /// (the read-back, the chunk-leaf hash, the MMR merges) billed nothing
+    /// extra. The shipped accounting bills the dense walk's hashes and the
+    /// compaction's hashes where they happen and drops the reads.
+    pub fixed_model: bool,
+}
+
+/// The blake3 calls a compaction performs, amortized over the epoch it
+/// serves: the chunk-leaf hash and the MMR merges and bagging are at most a
+/// few dozen per `2^chunk_power` appends, so one per append covers them.
+pub const AMORTIZED_COMPACTION_HASHES: u32 = 1;
+
+/// Bytes a compaction adds beyond the epoch's entry bytes, amortized over
+/// the epoch: the chunk blob's framing (its MMR leaf key with the 32-byte
+/// path prefix, the leaf envelope, the blob header and length varints —
+/// ≈ 88 bytes) and the MMR internal node the push creates on average (one
+/// per chunk: key, 33-byte node, length — 71 bytes).
+pub const COMPACTION_OVERHEAD_BYTES_PER_EPOCH: u32 = 88 + 71;
+
+/// The compaction overhead an append is charged as added storage under the
+/// fixed model: the epoch's share of [`COMPACTION_OVERHEAD_BYTES_PER_EPOCH`],
+/// rounded up.
+pub fn amortized_compaction_added_bytes(epoch_size: u64) -> u32 {
+    (COMPACTION_OVERHEAD_BYTES_PER_EPOCH as u64).div_ceil(epoch_size.max(1)) as u32
 }
 
 #[cfg(feature = "storage")]
@@ -72,6 +98,18 @@ impl AppendStorageAccounting {
     pub fn prepaid_chunk_bytes(&self, value_len: usize) -> u32 {
         if self.prepay_chunk_share {
             u32::try_from(value_len).unwrap_or(u32::MAX)
+        } else {
+            0
+        }
+    }
+
+    /// The compaction overhead — blob framing and MMR node — an append is
+    /// charged as added storage under the fixed model: the epoch's share,
+    /// rounded up (one byte at `chunk_power` 11). Nothing when the
+    /// compaction is charged where it happens.
+    pub fn amortized_compaction_added_bytes(&self, epoch_size: u64) -> u32 {
+        if self.fixed_model {
+            amortized_compaction_added_bytes(epoch_size)
         } else {
             0
         }
@@ -101,12 +139,14 @@ pub(crate) fn append_storage_accounting(
     }
 }
 
-/// Hashes to report for a compacting append.
+/// Hashes to report for a compacting append, on top of what every append
+/// reports.
 ///
 /// `leaf_count` is the MMR leaf count BEFORE the push (what
 /// `hash_count_for_push` expects); `mmr_size_after_push` is the size the MMR
 /// reached, which determines how many peaks the compaction's `get_root` had
-/// to fold.
+/// to fold. Version 1 reports nothing here: the compaction is amortized into
+/// every append ([`AMORTIZED_COMPACTION_HASHES`]).
 pub(crate) fn compaction_hash_count(
     leaf_count: u64,
     mmr_size_after_push: u64,

--- a/grovedb-bulk-append-tree/src/cost/v0.rs
+++ b/grovedb-bulk-append-tree/src/cost/v0.rs
@@ -31,6 +31,6 @@ pub(super) fn append_storage_accounting() -> AppendStorageAccounting {
         slot_rewrite: SlotRewriteAccounting::AsNew,
         chunk_leaf: LeafValueStorageCost::New,
         prepay_chunk_share: false,
-        bill_dense_io: false,
+        fixed_model: false,
     }
 }

--- a/grovedb-bulk-append-tree/src/cost/v0.rs
+++ b/grovedb-bulk-append-tree/src/cost/v0.rs
@@ -31,5 +31,6 @@ pub(super) fn append_storage_accounting() -> AppendStorageAccounting {
         slot_rewrite: SlotRewriteAccounting::AsNew,
         chunk_leaf: LeafValueStorageCost::New,
         prepay_chunk_share: false,
+        bill_dense_io: false,
     }
 }

--- a/grovedb-bulk-append-tree/src/cost/v1.rs
+++ b/grovedb-bulk-append-tree/src/cost/v1.rs
@@ -1,7 +1,7 @@
 //! Fixed-model accounting. Used from GROVE_V4.
 //!
 //! The compaction's hashes are amortized into every append
-//! (`AMORTIZED_COMPACTION_HASHES`), so a compacting append reports nothing
+//! (`amortized_compaction_hashes`), so a compacting append reports nothing
 //! extra here; and each append's storage writes are charged as its long-term
 //! footprint plus churn (issue #822).
 
@@ -13,7 +13,7 @@ use super::{AppendStorageAccounting, SlotRewriteAccounting};
 
 /// A compacting append reports no hashes of its own: the chunk-leaf hash, the
 /// MMR merges and the root bagging are amortized over the epoch as one blake3
-/// per append (`AMORTIZED_COMPACTION_HASHES`), charged on every append.
+/// per append (`amortized_compaction_hashes`), charged on every append.
 pub(super) fn compaction_hash_count(_leaf_count: u64, _mmr_size_after_push: u64) -> u32 {
     0
 }

--- a/grovedb-bulk-append-tree/src/cost/v1.rs
+++ b/grovedb-bulk-append-tree/src/cost/v1.rs
@@ -19,23 +19,26 @@ pub(super) fn compaction_hash_count(leaf_count: u64, mmr_size_after_push: u64) -
     hash_count_for_push(leaf_count).saturating_add(hash_count_for_root_bagging(mmr_size_after_push))
 }
 
-/// Churn-as-replacement storage accounting (issue #822). Used from GROVE_V4.
+/// Long-term-bytes storage accounting (issue #822). Used from GROVE_V4.
 ///
 /// - The entry's chunk-blob share (its own bytes) is charged as added
 ///   storage at its append — these are the bytes that persist.
-/// - The buffer slot write is sized against the value the slot already holds
-///   in committed storage, which is read first (and the read billed): a
-///   rewrite (epoch 2 onward) is replaced, growth is added, shrink is not
-///   credited; a slot written for the first time stays fully added and is
-///   not read.
+/// - The dense buffer is churn: every slot write and every path record write
+///   is reported as an in-place replacement of its own size — epoch 1
+///   included, nothing added, no key charged, nothing read to size it. The
+///   buffer is a fixed-size per-tree scratch area rewritten every epoch, not
+///   any entry's long-term storage.
 /// - The compaction blob is reported as a replacement of the entry bytes it
 ///   supersedes (all prepaid), leaving only its framing — and the MMR
 ///   internal nodes — as added storage.
+/// - The buffer's root-maintenance model (a fixed figure per insert for the
+///   tree's height) is billed alongside the hash count.
 #[cfg(feature = "storage")]
 pub(super) fn append_storage_accounting() -> AppendStorageAccounting {
     AppendStorageAccounting {
-        slot_rewrite: SlotRewriteAccounting::AgainstCommitted,
+        slot_rewrite: SlotRewriteAccounting::Churn,
         chunk_leaf: LeafValueStorageCost::PartlyPrepaid(chunk_blob_entry_bytes),
         prepay_chunk_share: true,
+        bill_dense_io: true,
     }
 }

--- a/grovedb-bulk-append-tree/src/cost/v1.rs
+++ b/grovedb-bulk-append-tree/src/cost/v1.rs
@@ -1,44 +1,47 @@
-//! Corrected compaction hash count.
+//! Fixed-model accounting. Used from GROVE_V4.
 //!
-//! Adds the peak-bagging merges [`v0`](super::v0) omitted. Used from GROVE_V4.
+//! The compaction's hashes are amortized into every append
+//! (`AMORTIZED_COMPACTION_HASHES`), so a compacting append reports nothing
+//! extra here; and each append's storage writes are charged as its long-term
+//! footprint plus churn (issue #822).
 
 #[cfg(feature = "storage")]
 use grovedb_merkle_mountain_range::LeafValueStorageCost;
-use grovedb_merkle_mountain_range::{hash_count_for_push, hash_count_for_root_bagging};
 
 #[cfg(feature = "storage")]
 use super::{AppendStorageAccounting, SlotRewriteAccounting};
-#[cfg(feature = "storage")]
-use crate::chunk::chunk_blob_entry_bytes;
 
-pub(super) fn compaction_hash_count(leaf_count: u64, mmr_size_after_push: u64) -> u32 {
-    // Derived from the MMR shape rather than read back out of the accumulated
-    // `OperationCost`, so this stays correct regardless of whether
-    // `MMR::get_root`'s own charge is enabled for the caller's version — the
-    // two gates are independent.
-    hash_count_for_push(leaf_count).saturating_add(hash_count_for_root_bagging(mmr_size_after_push))
+/// A compacting append reports no hashes of its own: the chunk-leaf hash, the
+/// MMR merges and the root bagging are amortized over the epoch as one blake3
+/// per append (`AMORTIZED_COMPACTION_HASHES`), charged on every append.
+pub(super) fn compaction_hash_count(_leaf_count: u64, _mmr_size_after_push: u64) -> u32 {
+    0
 }
 
 /// Long-term-bytes storage accounting (issue #822). Used from GROVE_V4.
 ///
 /// - The entry's chunk-blob share (its own bytes) is charged as added
-///   storage at its append — these are the bytes that persist.
+///   storage at its append — these are the bytes that persist — together
+///   with its share of the blob framing and MMR nodes, amortized over the
+///   epoch.
 /// - The dense buffer is churn: every slot write and every path record write
 ///   is reported as an in-place replacement of its own size — epoch 1
 ///   included, nothing added, no key charged, nothing read to size it. The
 ///   buffer is a fixed-size per-tree scratch area rewritten every epoch, not
 ///   any entry's long-term storage.
-/// - The compaction blob is reported as a replacement of the entry bytes it
-///   supersedes (all prepaid), leaving only its framing — and the MMR
-///   internal nodes — as added storage.
-/// - The buffer's root-maintenance model (a fixed figure per insert for the
-///   tree's height) is billed alongside the hash count.
+/// - The compaction blob and the MMR nodes are prepaid: their puts carry
+///   zero-byte cost information. Each append is charged its own bytes once
+///   more as `replaced` — its part of the blob rewrite — so the epoch's blob
+///   write is spread over the epoch's appends.
+/// - Every append — buffered or compacting — is charged the buffer's fixed
+///   root-maintenance model for its height plus one amortized compaction
+///   blake3, whatever its position.
 #[cfg(feature = "storage")]
 pub(super) fn append_storage_accounting() -> AppendStorageAccounting {
     AppendStorageAccounting {
         slot_rewrite: SlotRewriteAccounting::Churn,
-        chunk_leaf: LeafValueStorageCost::PartlyPrepaid(chunk_blob_entry_bytes),
+        chunk_leaf: LeafValueStorageCost::Prepaid,
         prepay_chunk_share: true,
-        bill_dense_io: true,
+        fixed_model: true,
     }
 }

--- a/grovedb-bulk-append-tree/src/lib.rs
+++ b/grovedb-bulk-append-tree/src/lib.rs
@@ -20,6 +20,8 @@ pub mod test_utils;
 // Re-export main types
 pub use chunk::{chunk_blob_entry_bytes, deserialize_chunk_blob, serialize_chunk_blob};
 pub use error::BulkAppendError;
+#[cfg(feature = "storage")]
+pub use grovedb_dense_fixed_sized_merkle_tree::{v1_insert_model_cost, V1InsertModel};
 pub use grovedb_dense_fixed_sized_merkle_tree::{DenseFixedSizedMerkleTree, DenseTreeProof};
 #[cfg(feature = "storage")]
 pub use grovedb_merkle_mountain_range::{MmrKeySize, MmrStore};

--- a/grovedb-bulk-append-tree/src/lib.rs
+++ b/grovedb-bulk-append-tree/src/lib.rs
@@ -20,8 +20,9 @@ pub mod test_utils;
 // Re-export main types
 pub use chunk::{chunk_blob_entry_bytes, deserialize_chunk_blob, serialize_chunk_blob};
 pub use cost::{
-    amortized_compaction_added_bytes, AMORTIZED_COMPACTION_HASHES,
-    COMPACTION_OVERHEAD_BYTES_PER_EPOCH,
+    amortized_compaction_added_bytes, amortized_compaction_hashes, max_amortized_compaction_hashes,
+    COMPACTION_OVERHEAD_BYTES_PER_EPOCH, MAX_COMPACTION_HASHES_PER_CHUNK,
+    VARIABLE_ENTRY_FRAMING_BYTES,
 };
 pub use error::BulkAppendError;
 pub use grovedb_dense_fixed_sized_merkle_tree::path_record_len;

--- a/grovedb-bulk-append-tree/src/lib.rs
+++ b/grovedb-bulk-append-tree/src/lib.rs
@@ -19,13 +19,20 @@ pub mod test_utils;
 
 // Re-export main types
 pub use chunk::{chunk_blob_entry_bytes, deserialize_chunk_blob, serialize_chunk_blob};
+pub use cost::{
+    amortized_compaction_added_bytes, AMORTIZED_COMPACTION_HASHES,
+    COMPACTION_OVERHEAD_BYTES_PER_EPOCH,
+};
 pub use error::BulkAppendError;
+pub use grovedb_dense_fixed_sized_merkle_tree::path_record_len;
 #[cfg(feature = "storage")]
 pub use grovedb_dense_fixed_sized_merkle_tree::{v1_insert_model_cost, V1InsertModel};
 pub use grovedb_dense_fixed_sized_merkle_tree::{DenseFixedSizedMerkleTree, DenseTreeProof};
 #[cfg(feature = "storage")]
 pub use grovedb_merkle_mountain_range::{MmrKeySize, MmrStore};
 pub use proof::{position_range_query, BulkAppendTreeProof, BulkAppendTreeProofResult};
+#[cfg(feature = "storage")]
+pub use tree::MMR_ROOT_KEY;
 pub use tree::{
     hash::compute_state_root, leaf_count_to_mmr_size, BufferRecordMismatch, BulkAppendTree,
     RangePage,

--- a/grovedb-bulk-append-tree/src/test_utils.rs
+++ b/grovedb-bulk-append-tree/src/test_utils.rs
@@ -29,6 +29,8 @@ pub struct MemStorageContext {
     /// Every data `put` in order, with the cost information it carried —
     /// what a real storage context would hand the commit path to bill.
     pub puts: RefCell<Vec<(Vec<u8>, Option<KeyValueStorageCost>)>>,
+    /// Every data `get` in order, by key — what an append actually reads.
+    pub gets: RefCell<Vec<Vec<u8>>>,
 }
 
 impl MemStorageContext {
@@ -64,6 +66,7 @@ impl<'db> StorageContext<'db> for MemStorageContext {
             ))
             .wrap_with_cost(OperationCost::default());
         }
+        self.gets.borrow_mut().push(key.as_ref().to_vec());
         Ok(self.data.borrow().get(key.as_ref()).cloned()).wrap_with_cost(OperationCost::default())
     }
 

--- a/grovedb-bulk-append-tree/src/tree/append.rs
+++ b/grovedb-bulk-append-tree/src/tree/append.rs
@@ -15,7 +15,7 @@ use crate::{
     chunk::serialize_chunk_blob,
     cost::{
         append_storage_accounting, compaction_hash_count, AppendStorageAccounting,
-        SlotRewriteAccounting, AMORTIZED_COMPACTION_HASHES,
+        SlotRewriteAccounting, VARIABLE_ENTRY_FRAMING_BYTES,
     },
     BulkAppendError,
 };
@@ -43,7 +43,48 @@ impl<'db, S: StorageContext<'db>> BulkAppendTree<S> {
             mmr_overlay: Vec::new(),
             // Empty tree → empty MMR → zero root.
             last_mmr_root: Some([0u8; 32]),
+            fixed_entry_size: None,
         })
+    }
+
+    /// Declare that every entry of this tree is exactly `entry_size` bytes:
+    /// an append of any other length is rejected with `InvalidInput` before
+    /// anything is written, every chunk blob therefore takes the fixed
+    /// format, and the fixed cost model (GROVE_V4) charges no per-entry
+    /// blob framing. Owners that enforce one entry size anyway
+    /// (`CommitmentTree`, `PrivateDocumentStore`) declare it so their
+    /// appends are charged exactly their long-term bytes; a tree without the
+    /// declaration is charged the variable format's four-byte prefix per
+    /// entry as a bound.
+    pub fn with_fixed_entry_size(mut self, entry_size: u32) -> Self {
+        self.fixed_entry_size = Some(entry_size);
+        self
+    }
+
+    /// The per-entry chunk-blob framing this tree's entries are charged:
+    /// none under a declared fixed entry size, the variable format's prefix
+    /// otherwise.
+    fn entry_framing_bytes(&self) -> u32 {
+        if self.fixed_entry_size.is_some() {
+            0
+        } else {
+            VARIABLE_ENTRY_FRAMING_BYTES
+        }
+    }
+
+    /// Reject a value that breaks the declared fixed entry size — before any
+    /// write, so a rejected append leaves the tree untouched.
+    fn check_entry_size(&self, value: &[u8]) -> Result<(), BulkAppendError> {
+        if let Some(expected) = self.fixed_entry_size
+            && value.len() != expected as usize
+        {
+            return Err(BulkAppendError::InvalidInput(format!(
+                "entry has {} bytes, the tree's fixed entry size is {}",
+                value.len(),
+                expected
+            )));
+        }
+        Ok(())
     }
 
     /// Restore from persisted state.
@@ -76,6 +117,7 @@ impl<'db, S: StorageContext<'db>> BulkAppendTree<S> {
             // Lazy: the restored MMR may not be readable until an append occurs,
             // so don't compute the root here. The first append fills the cache.
             last_mmr_root: None,
+            fixed_entry_size: None,
         })
     }
 
@@ -138,6 +180,7 @@ impl<'db, S: StorageContext<'db>> BulkAppendTree<S> {
     ) -> Result<AppendNoStateRootResult, BulkAppendError> {
         let mut hash_count: u32 = 0;
         let global_position = self.total_count;
+        self.check_entry_size(value)?;
         let accounting = append_storage_accounting(grove_version)?;
         let mut storage_accounting_cost = OperationCost::default();
         let slot_write = self.slot_write_accounting(&accounting);
@@ -165,7 +208,8 @@ impl<'db, S: StorageContext<'db>> BulkAppendTree<S> {
         })?;
         if accounting.fixed_model {
             let model = v1_insert_model_cost(self.dense_tree.height());
-            hash_count += model.hash_node_calls + AMORTIZED_COMPACTION_HASHES;
+            hash_count += model.hash_node_calls
+                + crate::cost::amortized_compaction_hashes(self.dense_tree.height());
             storage_accounting_cost.seek_count = storage_accounting_cost
                 .seek_count
                 .saturating_add(model.seek_count);
@@ -225,7 +269,7 @@ impl<'db, S: StorageContext<'db>> BulkAppendTree<S> {
         storage_accounting_cost.storage_cost.added_bytes = storage_accounting_cost
             .storage_cost
             .added_bytes
-            .saturating_add(accounting.prepaid_chunk_bytes(value.len()))
+            .saturating_add(accounting.prepaid_chunk_bytes(value.len(), self.entry_framing_bytes()))
             .saturating_add(accounting.amortized_compaction_added_bytes(epoch_size));
 
         Ok(AppendNoStateRootResult {
@@ -263,6 +307,9 @@ impl<'db, S: StorageContext<'db>> BulkAppendTree<S> {
     ) -> CostResult<AppendNoStateRootResult, BulkAppendError> {
         let mut cost = OperationCost::default();
         let global_position = self.total_count;
+        if let Err(e) = self.check_entry_size(value) {
+            return Err(e).wrap_with_cost(cost);
+        }
         let accounting = match append_storage_accounting(grove_version) {
             Ok(a) => a,
             Err(e) => return Err(e).wrap_with_cost(cost),
@@ -295,7 +342,8 @@ impl<'db, S: StorageContext<'db>> BulkAppendTree<S> {
             // on a compacting append, which writes no slot and no record —
             // their churn all the same.
             let mut model = v1_insert_model_cost(self.dense_tree.height());
-            model.hash_node_calls += AMORTIZED_COMPACTION_HASHES;
+            model.hash_node_calls +=
+                crate::cost::amortized_compaction_hashes(self.dense_tree.height());
             model.storage_cost.replaced_bytes = u32::try_from(value.len()).unwrap_or(u32::MAX);
             if try_result.is_none() {
                 model.storage_cost.replaced_bytes = model
@@ -347,7 +395,7 @@ impl<'db, S: StorageContext<'db>> BulkAppendTree<S> {
         // of the compaction overhead) is billed here, in the returned cost;
         // the mirror field is informational for this path (see its doc).
         let prepaid_chunk_bytes = accounting
-            .prepaid_chunk_bytes(value.len())
+            .prepaid_chunk_bytes(value.len(), self.entry_framing_bytes())
             .saturating_add(accounting.amortized_compaction_added_bytes(epoch_size));
         cost.storage_cost.added_bytes = cost
             .storage_cost

--- a/grovedb-bulk-append-tree/src/tree/append.rs
+++ b/grovedb-bulk-append-tree/src/tree/append.rs
@@ -141,6 +141,7 @@ impl<'db, S: StorageContext<'db>> BulkAppendTree<S> {
         let accounting = append_storage_accounting(grove_version)?;
         let mut storage_accounting_cost = OperationCost::default();
         let slot_write = self.slot_write_accounting(&accounting);
+        self.ensure_mmr_root_resolved(&accounting, grove_version)?;
 
         // 1. Try to insert into the dense tree buffer.
         //
@@ -268,6 +269,9 @@ impl<'db, S: StorageContext<'db>> BulkAppendTree<S> {
         };
         let mut storage_accounting_cost = OperationCost::default();
         let slot_write = self.slot_write_accounting(&accounting);
+        if let Err(e) = self.ensure_mmr_root_resolved(&accounting, grove_version) {
+            return Err(e).wrap_with_cost(cost);
+        }
 
         let insert_ctx =
             self.dense_tree
@@ -678,7 +682,18 @@ impl<'db, S: StorageContext<'db>> BulkAppendTree<S> {
                     root.copy_from_slice(&bytes);
                     return Ok(root).wrap_with_cost(cost);
                 }
-                Ok(_) => {}
+                // A present value of any other length is not a state this
+                // tree ever writes: corruption at the key, not a legacy tree.
+                Ok(Some(bytes)) => {
+                    return Err(BulkAppendError::CorruptedData(format!(
+                        "persisted MMR root has {} bytes, expected 32",
+                        bytes.len()
+                    )))
+                    .wrap_with_cost(cost);
+                }
+                // Absent: a tree whose last compaction predates the fixed
+                // model. Bag the peaks; the append path backfills the key.
+                Ok(None) => {}
                 Err(e) => {
                     return Err(BulkAppendError::StorageError(format!(
                         "MMR root read failed: {}",
@@ -689,6 +704,71 @@ impl<'db, S: StorageContext<'db>> BulkAppendTree<S> {
             }
         }
         self.bag_mmr_root_with_cost(grove_version).add_cost(cost)
+    }
+
+    /// Persist the chunk-MMR root under [`MMR_ROOT_KEY`] — prepaid like the
+    /// MMR nodes (zero-byte cost information), so the append that issues it
+    /// keeps the fixed model's storage figure.
+    fn persist_mmr_root(&self, root: &[u8; 32]) -> Result<(), BulkAppendError> {
+        let cost_info = Some(
+            grovedb_costs::storage_cost::key_value_cost::KeyValueStorageCost {
+                key_storage_cost: Default::default(),
+                value_storage_cost: Default::default(),
+                new_node: false,
+                needs_value_verification: false,
+            },
+        );
+        self.dense_tree
+            .storage
+            .put(MMR_ROOT_KEY, root, None, cost_info)
+            .unwrap()
+            .map_err(|e| BulkAppendError::StorageError(format!("MMR root put failed: {}", e)))
+    }
+
+    /// Under the fixed-model accounting, make sure a reopened tree's MMR root
+    /// is known before an append: read the persisted root (one of the two
+    /// root reads the model charges on every state-root derivation), or —
+    /// for a tree whose last compaction predates the fixed model and so has
+    /// none — bag the peaks once and BACKFILL the key, prepaid, so the
+    /// bagging (which loads a leaf peak's whole chunk blob when the chunk
+    /// count is odd) happens at most once per tree and the reads that follow
+    /// are the modelled ones. The one-time catch-up is not billed, like the
+    /// dense buffer's read-only catch-up; it is bounded by the peak count and
+    /// over for good once the key exists. Cached for the session either way.
+    fn ensure_mmr_root_resolved(
+        &mut self,
+        accounting: &AppendStorageAccounting,
+        grove_version: &GroveVersion,
+    ) -> Result<(), BulkAppendError> {
+        if !accounting.fixed_model || self.last_mmr_root.is_some() || self.mmr_size() == 0 {
+            return Ok(());
+        }
+        let persisted = self
+            .dense_tree
+            .storage
+            .get(MMR_ROOT_KEY)
+            .unwrap()
+            .map_err(|e| BulkAppendError::StorageError(format!("MMR root read failed: {}", e)))?;
+        let root = match persisted {
+            Some(bytes) if bytes.len() == 32 => {
+                let mut root = [0u8; 32];
+                root.copy_from_slice(&bytes);
+                root
+            }
+            Some(bytes) => {
+                return Err(BulkAppendError::CorruptedData(format!(
+                    "persisted MMR root has {} bytes, expected 32",
+                    bytes.len()
+                )))
+            }
+            None => {
+                let root = self.bag_mmr_root_with_cost(grove_version).unwrap()?;
+                self.persist_mmr_root(&root)?;
+                root
+            }
+        };
+        self.last_mmr_root = Some(root);
+        Ok(())
     }
 
     /// The MMR root bagged from the peaks — the independent derivation, which
@@ -756,21 +836,7 @@ impl<'db, S: StorageContext<'db>> BulkAppendTree<S> {
         if accounting.fixed_model
             && let Some(root) = self.last_mmr_root
         {
-            let cost_info = Some(
-                grovedb_costs::storage_cost::key_value_cost::KeyValueStorageCost {
-                    key_storage_cost: Default::default(),
-                    value_storage_cost: Default::default(),
-                    new_node: false,
-                    needs_value_verification: false,
-                },
-            );
-            self.dense_tree
-                .storage
-                .put(MMR_ROOT_KEY, &root, None, cost_info)
-                .unwrap()
-                .map_err(|e| {
-                    BulkAppendError::StorageError(format!("MMR root put failed: {}", e))
-                })?;
+            self.persist_mmr_root(&root)?;
         }
         Ok(())
     }

--- a/grovedb-bulk-append-tree/src/tree/append.rs
+++ b/grovedb-bulk-append-tree/src/tree/append.rs
@@ -1,7 +1,7 @@
 //! Append and compaction logic for BulkAppendTree.
 
 use grovedb_costs::{CostResult, CostsExt, OperationCost};
-use grovedb_dense_fixed_sized_merkle_tree::{position_key, SlotWriteAccounting};
+use grovedb_dense_fixed_sized_merkle_tree::SlotWriteAccounting;
 use grovedb_merkle_mountain_range::{mmr_size_to_leaf_count, MmrKeySize, MmrNode, MmrStore, MMR};
 use grovedb_storage::StorageContext;
 use grovedb_version::version::GroveVersion;
@@ -33,7 +33,6 @@ impl<'db, S: StorageContext<'db>> BulkAppendTree<S> {
             mmr_overlay: Vec::new(),
             // Empty tree → empty MMR → zero root.
             last_mmr_root: Some([0u8; 32]),
-            committed_total_count: 0,
         })
     }
 
@@ -67,58 +66,19 @@ impl<'db, S: StorageContext<'db>> BulkAppendTree<S> {
             // Lazy: the restored MMR may not be readable until an append occurs,
             // so don't compute the root here. The first append fills the cache.
             last_mmr_root: None,
-            committed_total_count: total_count,
         })
     }
 
-    /// Whether buffer slot `position` holds a value in committed storage:
-    /// every slot once a chunk has ever been completed (the buffer was full
-    /// when it compacted), otherwise the slots below the committed buffer
-    /// count. Judged against the state at open — see `committed_total_count`.
-    pub(crate) fn slot_is_committed(&self, position: u16) -> bool {
-        let epoch_size = self.epoch_size();
-        self.committed_total_count / epoch_size > 0
-            || (position as u64) < self.committed_total_count % epoch_size
-    }
-
-    /// Decide how the next buffer-slot write is reported, reading the slot's
-    /// committed value when the accounting sizes rewrites against it.
-    ///
-    /// The read — one seek, the committed value's bytes — is billed into
-    /// `cost`. It goes to the underlying storage (committed state plus the
-    /// surrounding transaction), never to the session's write-through cache:
-    /// a `StorageBatch` keeps one put per key, so the put that is eventually
-    /// charged must describe the transition from the committed value. A
-    /// slot written for the first time, and a full buffer (the append
-    /// compacts and writes no slot), are not read. A committed slot that
-    /// storage does not hold — corruption, not a state this code produces —
-    /// is charged as new, the safe direction.
-    fn slot_write_accounting(
-        &self,
-        accounting: &AppendStorageAccounting,
-        cost: &mut OperationCost,
-    ) -> Result<SlotWriteAccounting, BulkAppendError> {
-        if accounting.slot_rewrite == SlotRewriteAccounting::AsNew {
-            return Ok(SlotWriteAccounting::AsNew);
-        }
-        let position = self.dense_tree.count();
-        if position >= self.dense_tree.capacity() || !self.slot_is_committed(position) {
-            return Ok(SlotWriteAccounting::AsNew);
-        }
-        match self
-            .dense_tree
-            .storage
-            .get(position_key(position))
-            .unwrap_add_cost(cost)
-        {
-            Ok(Some(previous)) => Ok(SlotWriteAccounting::Overwrite {
-                previous_value_len: previous.len() as u32,
-            }),
-            Ok(None) => Ok(SlotWriteAccounting::AsNew),
-            Err(e) => Err(BulkAppendError::StorageError(format!(
-                "committed slot {} read before rewrite failed: {}",
-                position, e
-            ))),
+    /// Decide how the next buffer-slot write — and the path record written
+    /// beside it — is reported to the storage cost layer, per the
+    /// accounting version: as new storage (the shipped accounting) or as
+    /// churn (GROVE_V4: an in-place replacement of its own size, nothing
+    /// added, nothing read to size it — the buffer is a rolling scratch area
+    /// and the entry's long-term bytes are its prepaid chunk-blob share).
+    fn slot_write_accounting(&self, accounting: &AppendStorageAccounting) -> SlotWriteAccounting {
+        match accounting.slot_rewrite {
+            SlotRewriteAccounting::AsNew => SlotWriteAccounting::AsNew,
+            SlotRewriteAccounting::Churn => SlotWriteAccounting::Churn,
         }
     }
 
@@ -170,22 +130,32 @@ impl<'db, S: StorageContext<'db>> BulkAppendTree<S> {
         let global_position = self.total_count;
         let accounting = append_storage_accounting(grove_version)?;
         let mut storage_accounting_cost = OperationCost::default();
-        let slot_write = self.slot_write_accounting(&accounting, &mut storage_accounting_cost)?;
+        let slot_write = self.slot_write_accounting(&accounting);
 
         // 1. Try to insert into the dense tree buffer.
         //
-        // The dense tree's own cost is dropped here except for its hash
-        // count: this path returns a plain `Result` and reports its work
-        // through `hash_count` (the figure CommitmentTree bills) and
-        // `storage_accounting_cost`. The reads the root maintenance performs
-        // — the full-buffer walk under GROVE_V1..V3, the ancestor-path record
-        // reads from GROVE_V4 — are not billed by it, as they never were; the
-        // record writes from GROVE_V4 are charged at commit like every other
-        // put. Callers that bill everything use `append_deferred_roots`.
+        // This path returns a plain `Result` and reports its work through
+        // `hash_count` (the figure CommitmentTree bills) and
+        // `storage_accounting_cost`. The dense tree's hash count is always
+        // forwarded; its reads — the full-buffer walk under GROVE_V1..V3,
+        // which the shipped accounting dropped, or the fixed root-maintenance
+        // model from GROVE_V4 — are forwarded only when the accounting
+        // version bills them (`bill_dense_io`). The slot and record writes
+        // are charged at commit like every other put. Callers that bill
+        // everything use `append_deferred_roots`.
         let insert_ctx =
             self.dense_tree
                 .try_insert_with_accounting(value, slot_write, grove_version);
-        let dense_hash_calls = insert_ctx.cost.hash_node_calls;
+        let dense_cost = insert_ctx.cost;
+        let dense_hash_calls = dense_cost.hash_node_calls;
+        if accounting.bill_dense_io {
+            storage_accounting_cost.seek_count = storage_accounting_cost
+                .seek_count
+                .saturating_add(dense_cost.seek_count);
+            storage_accounting_cost.storage_loaded_bytes = storage_accounting_cost
+                .storage_loaded_bytes
+                .saturating_add(dense_cost.storage_loaded_bytes);
+        }
         let try_result = insert_ctx.value.map_err(|e| {
             BulkAppendError::StorageError(format!("dense tree insert failed: {}", e))
         })?;
@@ -200,10 +170,10 @@ impl<'db, S: StorageContext<'db>> BulkAppendTree<S> {
                 // `compute_current_state_root` at the end of the batch, which
                 // populates the cache then.)
                 //
-                // The hashes the insert performed: two per filled position
+                // The hashes the insert reports: two per filled position
                 // (the whole buffer re-walked) under root-maintenance version
-                // 0 — the shipped `count * 2` — and two for the leaf plus one
-                // per ancestor level under version 1.
+                // 0 — the shipped `count * 2` — and the fixed model for the
+                // buffer's height under version 1.
                 hash_count += dense_hash_calls;
                 false
             }
@@ -265,15 +235,8 @@ impl<'db, S: StorageContext<'db>> BulkAppendTree<S> {
             Ok(a) => a,
             Err(e) => return Err(e).wrap_with_cost(cost),
         };
-        // The committed-slot read is billed here, in the returned cost, and
-        // mirrored (with the prepaid share) in the result for information.
         let mut storage_accounting_cost = OperationCost::default();
-        let slot_write = self.slot_write_accounting(&accounting, &mut storage_accounting_cost);
-        cost += storage_accounting_cost.clone();
-        let slot_write = match slot_write {
-            Ok(s) => s,
-            Err(e) => return Err(e).wrap_with_cost(cost),
-        };
+        let slot_write = self.slot_write_accounting(&accounting);
 
         let try_result = match self
             .dense_tree

--- a/grovedb-bulk-append-tree/src/tree/append.rs
+++ b/grovedb-bulk-append-tree/src/tree/append.rs
@@ -1,10 +1,11 @@
 //! Append and compaction logic for BulkAppendTree.
 
 use grovedb_costs::{CostResult, CostsExt, OperationCost};
-use grovedb_dense_fixed_sized_merkle_tree::SlotWriteAccounting;
+use grovedb_dense_fixed_sized_merkle_tree::{v1_insert_model_cost, SlotWriteAccounting};
 use grovedb_merkle_mountain_range::{mmr_size_to_leaf_count, MmrKeySize, MmrNode, MmrStore, MMR};
 use grovedb_storage::StorageContext;
 use grovedb_version::version::GroveVersion;
+use integer_encoding::VarInt;
 
 use super::{
     capacity_for_height, hash::compute_state_root, AppendNoStateRootResult, AppendResult,
@@ -14,10 +15,19 @@ use crate::{
     chunk::serialize_chunk_blob,
     cost::{
         append_storage_accounting, compaction_hash_count, AppendStorageAccounting,
-        SlotRewriteAccounting,
+        SlotRewriteAccounting, AMORTIZED_COMPACTION_HASHES,
     },
     BulkAppendError,
 };
+
+/// Storage key of the persisted chunk-MMR root (32 bytes), written by
+/// [`BulkAppendTree::commit_mmr`] under the fixed-model accounting so a
+/// reopened tree resolves its MMR root with one small read instead of
+/// bagging the peaks — which are leaf nodes carrying whole chunk blobs, so
+/// bagging reads every peak's blob back. A 1-byte key: the 2-byte slots,
+/// 3-byte records, 4-byte MMR nodes and the owners' named keys cannot
+/// collide with it.
+pub const MMR_ROOT_KEY: &[u8] = b"r";
 
 impl<'db, S: StorageContext<'db>> BulkAppendTree<S> {
     /// Create a new empty tree.
@@ -136,29 +146,52 @@ impl<'db, S: StorageContext<'db>> BulkAppendTree<S> {
         //
         // This path returns a plain `Result` and reports its work through
         // `hash_count` (the figure CommitmentTree bills) and
-        // `storage_accounting_cost`. The dense tree's hash count is always
-        // forwarded; its reads — the full-buffer walk under GROVE_V1..V3,
-        // which the shipped accounting dropped, or the fixed root-maintenance
-        // model from GROVE_V4 — are forwarded only when the accounting
-        // version bills them (`bill_dense_io`). The slot and record writes
-        // are charged at commit like every other put. Callers that bill
+        // `storage_accounting_cost`. Under the fixed model (GROVE_V4) every
+        // append — buffered or compacting — is charged the buffer's
+        // root-maintenance model for its height plus one amortized
+        // compaction blake3, and its reads go through
+        // `storage_accounting_cost`; under the shipped accounting the dense
+        // walk's hashes and the compaction's hashes are reported where they
+        // happen and the reads are dropped. The slot and record writes are
+        // charged at commit like every other put. Callers that bill
         // everything use `append_deferred_roots`.
         let insert_ctx =
             self.dense_tree
                 .try_insert_with_accounting(value, slot_write, grove_version);
         let dense_cost = insert_ctx.cost;
-        let dense_hash_calls = dense_cost.hash_node_calls;
-        if accounting.bill_dense_io {
-            storage_accounting_cost.seek_count = storage_accounting_cost
-                .seek_count
-                .saturating_add(dense_cost.seek_count);
-            storage_accounting_cost.storage_loaded_bytes = storage_accounting_cost
-                .storage_loaded_bytes
-                .saturating_add(dense_cost.storage_loaded_bytes);
-        }
         let try_result = insert_ctx.value.map_err(|e| {
             BulkAppendError::StorageError(format!("dense tree insert failed: {}", e))
         })?;
+        if accounting.fixed_model {
+            let model = v1_insert_model_cost(self.dense_tree.height());
+            hash_count += model.hash_node_calls + AMORTIZED_COMPACTION_HASHES;
+            storage_accounting_cost.seek_count = storage_accounting_cost
+                .seek_count
+                .saturating_add(model.seek_count);
+            storage_accounting_cost.storage_loaded_bytes = storage_accounting_cost
+                .storage_loaded_bytes
+                .saturating_add(model.storage_loaded_bytes);
+            // The entry's own bytes as its part of the blob rewrite the
+            // epoch's compaction will perform (the blob put itself is
+            // prepaid).
+            storage_accounting_cost.storage_cost.replaced_bytes = storage_accounting_cost
+                .storage_cost
+                .replaced_bytes
+                .saturating_add(u32::try_from(value.len()).unwrap_or(u32::MAX));
+            if try_result.is_none() {
+                // A compacting append writes no slot and no record; it is
+                // charged their churn all the same, so its storage figure is
+                // the fixed model's.
+                storage_accounting_cost.storage_cost.replaced_bytes = storage_accounting_cost
+                    .storage_cost
+                    .replaced_bytes
+                    .saturating_add(self.buffer_churn_replaced_bytes(value.len()));
+            }
+        } else {
+            // The hashes the insert reports: two per filled position (the
+            // whole buffer re-walked) — the shipped `count * 2`.
+            hash_count += dense_cost.hash_node_calls;
+        }
 
         let compacted = match try_result {
             Some((_dense_root, _position)) => {
@@ -169,12 +202,6 @@ impl<'db, S: StorageContext<'db>> BulkAppendTree<S> {
                 // the caller will recover the state root via
                 // `compute_current_state_root` at the end of the batch, which
                 // populates the cache then.)
-                //
-                // The hashes the insert reports: two per filled position
-                // (the whole buffer re-walked) under root-maintenance version
-                // 0 — the shipped `count * 2` — and the fixed model for the
-                // buffer's height under version 1.
-                hash_count += dense_hash_calls;
                 false
             }
             None => {
@@ -182,6 +209,8 @@ impl<'db, S: StorageContext<'db>> BulkAppendTree<S> {
                 // Must run before incrementing total_count so that
                 // self.mmr_size() reflects the pre-compaction state.
                 let (compact_hashes, mmr_root) = self.compact_with_value(value, grove_version)?;
+                // Nothing under the fixed model (amortized); the shipped
+                // figure otherwise.
                 hash_count += compact_hashes;
                 // MMR mutated by the compaction — refresh the cached root.
                 self.last_mmr_root = Some(mmr_root);
@@ -189,12 +218,14 @@ impl<'db, S: StorageContext<'db>> BulkAppendTree<S> {
             }
         };
 
+        let epoch_size = self.epoch_size();
         self.total_count += 1;
 
         storage_accounting_cost.storage_cost.added_bytes = storage_accounting_cost
             .storage_cost
             .added_bytes
-            .saturating_add(accounting.prepaid_chunk_bytes(value.len()));
+            .saturating_add(accounting.prepaid_chunk_bytes(value.len()))
+            .saturating_add(accounting.amortized_compaction_added_bytes(epoch_size));
 
         Ok(AppendNoStateRootResult {
             global_position,
@@ -238,13 +269,14 @@ impl<'db, S: StorageContext<'db>> BulkAppendTree<S> {
         let mut storage_accounting_cost = OperationCost::default();
         let slot_write = self.slot_write_accounting(&accounting);
 
-        let try_result = match self
-            .dense_tree
-            .try_insert_no_root_with_accounting(value, slot_write, grove_version)
-            .unwrap_add_cost(&mut cost)
-        {
+        let insert_ctx =
+            self.dense_tree
+                .try_insert_no_root_with_accounting(value, slot_write, grove_version);
+        let dense_cost = insert_ctx.cost;
+        let try_result = match insert_ctx.value {
             Ok(r) => r,
             Err(e) => {
+                cost += dense_cost;
                 return Err(BulkAppendError::StorageError(format!(
                     "dense tree insert failed: {}",
                     e
@@ -252,47 +284,67 @@ impl<'db, S: StorageContext<'db>> BulkAppendTree<S> {
                 .wrap_with_cost(cost);
             }
         };
+        if accounting.fixed_model {
+            // The fixed model, whatever the position: the buffer's
+            // root-maintenance model plus one amortized compaction blake3,
+            // the entry's own bytes as its part of the blob rewrite, and —
+            // on a compacting append, which writes no slot and no record —
+            // their churn all the same.
+            let mut model = v1_insert_model_cost(self.dense_tree.height());
+            model.hash_node_calls += AMORTIZED_COMPACTION_HASHES;
+            model.storage_cost.replaced_bytes = u32::try_from(value.len()).unwrap_or(u32::MAX);
+            if try_result.is_none() {
+                model.storage_cost.replaced_bytes = model
+                    .storage_cost
+                    .replaced_bytes
+                    .saturating_add(self.buffer_churn_replaced_bytes(value.len()));
+            }
+            cost += model.clone();
+            storage_accounting_cost += model;
+        } else {
+            cost += dense_cost;
+        }
 
         let compacted = match try_result {
-            // Inserted into the buffer; no root walk, so no hashes yet.
             Some(_position) => false,
             None => {
                 // Buffer full — compact existing entries plus this value.
                 // Must run before incrementing total_count so self.mmr_size()
-                // reflects the pre-compaction state.
-                // The model counter this returns is deliberately unused — see
-                // the `hash_count` derivation below.
-                let (_model_hash_count, mmr_root) = match self
-                    .compact_with_value_with_cost(value, grove_version)
-                    .unwrap_add_cost(&mut cost)
-                {
+                // reflects the pre-compaction state. Under the fixed model
+                // the compaction's own work (the read-back, the chunk-leaf
+                // hash, the MMR merges and bagging) is amortized into every
+                // append and billed nothing here; under the shipped
+                // accounting it is billed as performed.
+                let compaction = self.compact_with_value_with_cost(value, grove_version);
+                let (_model_hash_count, mmr_root) = match compaction.value {
                     Ok(r) => r,
-                    Err(e) => return Err(e).wrap_with_cost(cost),
+                    Err(e) => {
+                        cost += compaction.cost;
+                        return Err(e).wrap_with_cost(cost);
+                    }
                 };
+                if !accounting.fixed_model {
+                    cost += compaction.cost;
+                }
                 self.last_mmr_root = Some(mmr_root);
                 true
             }
         };
 
+        let epoch_size = self.epoch_size();
         self.total_count += 1;
 
-        // Derive the reported counter from what was actually billed rather
-        // than from `hash_count_for_push`. That helper covers the eager leaf
-        // hash and the merges `push` performs, but NOT the peak-bagging
-        // merges `get_root` performs during a compaction, so the model
-        // counter falls below the true figure as soon as the MMR has more
-        // than one peak. Everything accumulated in `cost` here is this
-        // append's own hashing, so the two cannot disagree.
-        //
-        // Scoped to this deferred path on purpose: `compact_with_value` and
-        // `append_no_state_root` keep returning the model counter, because
-        // the live CommitmentTree adds that value straight into its own
-        // `hash_node_calls` and changing it would move a released cost.
+        // The reported counter is what was billed, so the two cannot
+        // disagree (the shipped `hash_count_for_push` model omitted the
+        // peak-bagging merges `get_root` performs).
         let hash_count = cost.hash_node_calls;
 
-        // The entry's chunk-blob share is billed here, in the returned cost;
+        // The entry's chunk-blob share (and, under the fixed model, its share
+        // of the compaction overhead) is billed here, in the returned cost;
         // the mirror field is informational for this path (see its doc).
-        let prepaid_chunk_bytes = accounting.prepaid_chunk_bytes(value.len());
+        let prepaid_chunk_bytes = accounting
+            .prepaid_chunk_bytes(value.len())
+            .saturating_add(accounting.amortized_compaction_added_bytes(epoch_size));
         cost.storage_cost.added_bytes = cost
             .storage_cost
             .added_bytes
@@ -311,16 +363,28 @@ impl<'db, S: StorageContext<'db>> BulkAppendTree<S> {
         .wrap_with_cost(cost)
     }
 
+    /// The paid bytes of the slot and the path record a buffered append of a
+    /// `value_len`-byte value writes as churn — what a compacting append,
+    /// which writes neither, is charged all the same under the fixed model.
+    fn buffer_churn_replaced_bytes(&self, value_len: usize) -> u32 {
+        let paid = |len: u32| len.saturating_add(len.required_space() as u32);
+        let value_len = u32::try_from(value_len).unwrap_or(u32::MAX);
+        let record_len =
+            grovedb_dense_fixed_sized_merkle_tree::path_record_len(self.dense_tree.height()) as u32;
+        paid(value_len).saturating_add(paid(record_len))
+    }
+
     /// Compute the current state root without modifying the tree.
     ///
     /// Uses the cached MMR root when available, so this is O(1) on the
-    /// post-first-append fast path (no overlay clone). Falls back to a one-shot
-    /// `get_mmr_root` only when the cache is empty (e.g. immediately after a
-    /// lazy `from_state` with no appends yet).
+    /// post-first-append fast path (no overlay clone). Otherwise resolves the
+    /// MMR root through [`get_mmr_root_with_cost`](Self::get_mmr_root_with_cost)
+    /// — the persisted root under the fixed-model accounting, the peak
+    /// bagging before it.
     ///
     /// `grove_version` selects how the dense buffer's root is derived (the
     /// value is the same under every version): walked from every filled
-    /// position under GROVE_V1..V3, read from the position-0 hash record
+    /// position under GROVE_V1..V3, read from the last insert's path record
     /// from GROVE_V4.
     pub fn compute_current_state_root(
         &self,
@@ -328,7 +392,7 @@ impl<'db, S: StorageContext<'db>> BulkAppendTree<S> {
     ) -> Result<[u8; 32], BulkAppendError> {
         let mmr_root = match self.last_mmr_root {
             Some(r) => r,
-            None => self.get_mmr_root()?,
+            None => self.get_mmr_root_with_cost(grove_version).unwrap()?,
         };
         let dense_root = self
             .dense_tree
@@ -346,10 +410,11 @@ impl<'db, S: StorageContext<'db>> BulkAppendTree<S> {
     /// Identical to [`compute_current_state_root`](Self::compute_current_state_root)
     /// on a consistent tree; see `DenseFixedSizedMerkleTree::root_hash_from_values`.
     pub fn compute_current_state_root_from_values(&self) -> Result<[u8; 32], BulkAppendError> {
-        let mmr_root = match self.last_mmr_root {
-            Some(r) => r,
-            None => self.get_mmr_root()?,
-        };
+        // Bag the peaks: the persisted MMR root is derived state an audit
+        // must not trust either.
+        let mmr_root = self
+            .bag_mmr_root_with_cost(GroveVersion::first())
+            .unwrap()?;
         let dense_root = self
             .dense_tree
             .root_hash_from_values()
@@ -360,25 +425,19 @@ impl<'db, S: StorageContext<'db>> BulkAppendTree<S> {
         Ok(compute_state_root(&mmr_root, &dense_root))
     }
 
-    /// Audit the buffer's hash records (GROVE_V4 root maintenance) against
-    /// its values: `Some` when a current position-0 record
-    /// exists and disagrees with the root walked from the values, `None`
-    /// when they agree or no current record exists (a buffer filled under
-    /// GROVE_V1..V3 is caught up by its next append and is not an error).
-    pub fn buffer_record_mismatch(&self) -> Result<Option<BufferRecordMismatch>, BulkAppendError> {
-        let recorded = self.dense_tree.recorded_root().unwrap().map_err(|e| {
-            BulkAppendError::StorageError(format!("dense tree recorded root failed: {}", e))
-        })?;
-        let Some(recorded) = recorded else {
-            return Ok(None);
-        };
-        let walked = self
-            .dense_tree
-            .root_hash_from_values()
-            .unwrap()
-            .map_err(|e| {
-                BulkAppendError::StorageError(format!("dense tree root_hash failed: {}", e))
-            })?;
+    /// Audit the tree's derived state — the buffer's path records and the
+    /// persisted MMR root (GROVE_V4) — against its values: `Some` when the
+    /// state root a normal read under `grove_version` returns disagrees with
+    /// the state root walked from the values and bagged from the MMR peaks,
+    /// `None` when they agree (a buffer filled under GROVE_V1..V3 with no
+    /// records, or a tree without a persisted MMR root, reads through the
+    /// same walk and agrees).
+    pub fn buffer_record_mismatch(
+        &self,
+        grove_version: &GroveVersion,
+    ) -> Result<Option<BufferRecordMismatch>, BulkAppendError> {
+        let recorded = self.compute_current_state_root(grove_version)?;
+        let walked = self.compute_current_state_root_from_values()?;
         Ok((recorded != walked).then_some(BufferRecordMismatch { recorded, walked }))
     }
 
@@ -395,13 +454,23 @@ impl<'db, S: StorageContext<'db>> BulkAppendTree<S> {
         grove_version: &GroveVersion,
     ) -> CostResult<[u8; 32], BulkAppendError> {
         let mut cost = OperationCost::default();
+        let accounting = match append_storage_accounting(grove_version) {
+            Ok(a) => a,
+            Err(e) => return Err(e).wrap_with_cost(cost),
+        };
+        // Under the fixed model the two root reads — the persisted MMR root
+        // and the last insert's path record — are charged as the model
+        // (one seek each, their sizes) whether or not this particular state
+        // needs them (an in-session cache, an empty MMR, an empty buffer
+        // right after a compaction); otherwise as performed.
+        let mut work = OperationCost::default();
         let mmr_root = match self.last_mmr_root {
             Some(r) => r,
             // Lazy path: a reopened tree has no cached root, so this read is
-            // real I/O and must be billed.
+            // real I/O.
             None => match self
                 .get_mmr_root_with_cost(grove_version)
-                .unwrap_add_cost(&mut cost)
+                .unwrap_add_cost(&mut work)
             {
                 Ok(r) => r,
                 Err(e) => return Err(e).wrap_with_cost(cost),
@@ -410,7 +479,7 @@ impl<'db, S: StorageContext<'db>> BulkAppendTree<S> {
         let dense_root = match self
             .dense_tree
             .root_hash(grove_version)
-            .unwrap_add_cost(&mut cost)
+            .unwrap_add_cost(&mut work)
         {
             Ok(r) => r,
             Err(e) => {
@@ -421,12 +490,18 @@ impl<'db, S: StorageContext<'db>> BulkAppendTree<S> {
                 .wrap_with_cost(cost);
             }
         };
-        // `root_hash` already charged its own work — the walk over every
-        // filled position (a value hash and a node hash each) under
-        // root-maintenance version 0, the position-0 record read under
-        // version 1 — and that reached us through `unwrap_add_cost` above.
-        // Only the final blake3 combining the MMR and dense roots is still
-        // unbilled.
+        if accounting.fixed_model {
+            cost.seek_count += 2;
+            cost.storage_loaded_bytes += 32
+                + grovedb_dense_fixed_sized_merkle_tree::path_record_len(self.dense_tree.height())
+                    as u64;
+        } else {
+            // `root_hash` already charged its own work — the walk over every
+            // filled position (a value hash and a node hash each) — and the
+            // lazy MMR root read its bagging; both reached us through `work`.
+            cost += work;
+        }
+        // The final blake3 combining the MMR and dense roots.
         cost.hash_node_calls = cost.hash_node_calls.saturating_add(1);
         Ok(compute_state_root(&mmr_root, &dense_root)).wrap_with_cost(cost)
     }
@@ -562,10 +637,11 @@ impl<'db, S: StorageContext<'db>> BulkAppendTree<S> {
     }
 
     /// Get the MMR root hash, or `[0; 32]` if no chunks exist.
+    #[cfg(test)]
     pub(crate) fn get_mmr_root(&self) -> Result<[u8; 32], BulkAppendError> {
         // Cost discarded here, so the version is unobservable; pinned to the
-        // shipped accounting to match the released callers.
-        self.get_mmr_root_with_cost(GroveVersion::first()).unwrap()
+        // shipped accounting (bagging) to match the released callers.
+        self.bag_mmr_root_with_cost(GroveVersion::first()).unwrap()
     }
 
     /// Cost-propagating variant of [`get_mmr_root`](Self::get_mmr_root).
@@ -575,6 +651,49 @@ impl<'db, S: StorageContext<'db>> BulkAppendTree<S> {
     /// exactly the case proof binding and the integrity walk hit. Discarding
     /// the read cost there undercharges their storage I/O.
     pub(crate) fn get_mmr_root_with_cost(
+        &self,
+        grove_version: &GroveVersion,
+    ) -> CostResult<[u8; 32], BulkAppendError> {
+        let mut cost = OperationCost::default();
+        if self.mmr_size() == 0 {
+            return Ok([0u8; 32]).wrap_with_cost(cost);
+        }
+        // Under the fixed-model accounting the root written at the last
+        // `commit_mmr` is read back (one small read) instead of bagging the
+        // peaks, whose leaf nodes carry whole chunk blobs. Absent (a tree
+        // whose chunks were all committed before) → bag.
+        let accounting = match append_storage_accounting(grove_version) {
+            Ok(a) => a,
+            Err(e) => return Err(e).wrap_with_cost(cost),
+        };
+        if accounting.fixed_model {
+            match self
+                .dense_tree
+                .storage
+                .get(MMR_ROOT_KEY)
+                .unwrap_add_cost(&mut cost)
+            {
+                Ok(Some(bytes)) if bytes.len() == 32 => {
+                    let mut root = [0u8; 32];
+                    root.copy_from_slice(&bytes);
+                    return Ok(root).wrap_with_cost(cost);
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    return Err(BulkAppendError::StorageError(format!(
+                        "MMR root read failed: {}",
+                        e
+                    )))
+                    .wrap_with_cost(cost);
+                }
+            }
+        }
+        self.bag_mmr_root_with_cost(grove_version).add_cost(cost)
+    }
+
+    /// The MMR root bagged from the peaks — the independent derivation, which
+    /// never consults the persisted root. `[0; 32]` for an empty MMR.
+    pub(crate) fn bag_mmr_root_with_cost(
         &self,
         grove_version: &GroveVersion,
     ) -> CostResult<[u8; 32], BulkAppendError> {
@@ -628,6 +747,30 @@ impl<'db, S: StorageContext<'db>> BulkAppendTree<S> {
                 "MMR commit failed: {}",
                 e
             )));
+        }
+        // Under the fixed-model accounting, persist the MMR root the
+        // compaction derived (32 bytes) so the next open reads it instead of
+        // bagging the peaks' blobs. Prepaid like the MMR nodes: zero-byte
+        // cost information, so the compacting append's storage figure stays
+        // the fixed model's.
+        if accounting.fixed_model
+            && let Some(root) = self.last_mmr_root
+        {
+            let cost_info = Some(
+                grovedb_costs::storage_cost::key_value_cost::KeyValueStorageCost {
+                    key_storage_cost: Default::default(),
+                    value_storage_cost: Default::default(),
+                    new_node: false,
+                    needs_value_verification: false,
+                },
+            );
+            self.dense_tree
+                .storage
+                .put(MMR_ROOT_KEY, &root, None, cost_info)
+                .unwrap()
+                .map_err(|e| {
+                    BulkAppendError::StorageError(format!("MMR root put failed: {}", e))
+                })?;
         }
         Ok(())
     }

--- a/grovedb-bulk-append-tree/src/tree/mod.rs
+++ b/grovedb-bulk-append-tree/src/tree/mod.rs
@@ -10,6 +10,8 @@
 
 #[cfg(feature = "storage")]
 mod append;
+#[cfg(feature = "storage")]
+pub use append::MMR_ROOT_KEY;
 pub mod hash;
 
 #[cfg(feature = "storage")]
@@ -66,12 +68,16 @@ pub struct AppendNoStateRootResult {
     /// `Result`-returning appends cannot otherwise surface:
     ///
     /// - `storage_cost.added_bytes`: the entry's share of the chunk blob it
-    ///   will eventually be compacted into — its own bytes — charged at this
-    ///   append so that the blob written at compaction can be reported as a
-    ///   replacement of bytes already paid for (issue #822);
+    ///   will eventually be compacted into — its own bytes — plus its share
+    ///   of the blob framing and MMR nodes, charged at this append so that
+    ///   the compaction writes nothing that is not already paid for (issue
+    ///   #822);
+    /// - `storage_cost.replaced_bytes`: the entry's own bytes again, as its
+    ///   part of the blob rewrite the epoch's compaction performs;
     /// - `seek_count` / `storage_loaded_bytes`: the dense buffer's
     ///   root-maintenance reads — from GROVE_V4 the fixed model for the
-    ///   buffer's height (`v1_insert_model_cost`), whatever the position.
+    ///   buffer's height (`v1_insert_model_cost`), whatever the position,
+    ///   compacting appends included.
     ///
     /// Zero under the shipped accounting (GROVE_V1..V3), where the blob is
     /// charged in full at compaction and the buffer's reads are dropped.

--- a/grovedb-bulk-append-tree/src/tree/mod.rs
+++ b/grovedb-bulk-append-tree/src/tree/mod.rs
@@ -69,12 +69,12 @@ pub struct AppendNoStateRootResult {
     ///   will eventually be compacted into — its own bytes — charged at this
     ///   append so that the blob written at compaction can be reported as a
     ///   replacement of bytes already paid for (issue #822);
-    /// - `seek_count` / `storage_loaded_bytes`: the read of the committed
-    ///   value a buffer slot already holds (epoch 2 onward), performed to
-    ///   size the rewrite.
+    /// - `seek_count` / `storage_loaded_bytes`: the dense buffer's
+    ///   root-maintenance reads — from GROVE_V4 the fixed model for the
+    ///   buffer's height (`v1_insert_model_cost`), whatever the position.
     ///
     /// Zero under the shipped accounting (GROVE_V1..V3), where the blob is
-    /// charged in full at compaction and no slot is read.
+    /// charged in full at compaction and the buffer's reads are dropped.
     ///
     /// Like `hash_count`, this follows the "caller bills" convention of the
     /// `Result`-returning appends ([`append`](BulkAppendTree::append),
@@ -162,15 +162,6 @@ pub struct BulkAppendTree<S> {
     ///
     /// [`from_state`]: BulkAppendTree::from_state
     pub(crate) last_mmr_root: Option<[u8; 32]>,
-    /// `total_count` as of the open ([`new`] → 0, [`from_state`] → the
-    /// persisted count): what committed storage holds, which this session's
-    /// appends have not changed. Used to tell a buffer slot that holds a
-    /// committed value — whose rewrite is read and reported as a replacement
-    /// — from one written for the first time.
-    ///
-    /// [`new`]: BulkAppendTree::new
-    /// [`from_state`]: BulkAppendTree::from_state
-    pub(crate) committed_total_count: u64,
 }
 
 impl<S> BulkAppendTree<S> {

--- a/grovedb-bulk-append-tree/src/tree/mod.rs
+++ b/grovedb-bulk-append-tree/src/tree/mod.rs
@@ -168,6 +168,13 @@ pub struct BulkAppendTree<S> {
     ///
     /// [`from_state`]: BulkAppendTree::from_state
     pub(crate) last_mmr_root: Option<[u8; 32]>,
+    /// The one byte length every entry must have, when the owner declares it
+    /// (`with_fixed_entry_size`): appends of any other length are rejected
+    /// before anything is written, so every chunk blob takes the fixed
+    /// format and the fixed cost model charges no per-entry framing. `None`
+    /// — the default — admits any length and charges the variable format's
+    /// four-byte prefix on every entry (`VARIABLE_ENTRY_FRAMING_BYTES`).
+    pub(crate) fixed_entry_size: Option<u32>,
 }
 
 impl<S> BulkAppendTree<S> {

--- a/grovedb-bulk-append-tree/src/tree/storage_accounting_tests.rs
+++ b/grovedb-bulk-append-tree/src/tree/storage_accounting_tests.rs
@@ -147,10 +147,12 @@ fn v1_buffer_writes_are_churn_and_every_append_is_charged_the_fixed_model() {
     // 159 bytes of compaction overhead over an epoch of 4.
     let amortized: u32 = (159u32).div_ceil(4);
     for (i, (cost, value)) in run.accounting.iter().zip(VALUES.iter()).enumerate() {
+        // No declared entry size: the variable format's four-byte prefix is
+        // prepaid with every entry.
         assert_eq!(
             cost.storage_cost.added_bytes,
-            value.len() as u32 + amortized,
-            "append {i}: prepaid share + amortized compaction overhead"
+            value.len() as u32 + crate::VARIABLE_ENTRY_FRAMING_BYTES + amortized,
+            "append {i}: prepaid share + framing + amortized compaction overhead"
         );
         // Its part of the blob rewrite — and, for a compacting append,
         // which writes no slot and no record, their churn billed here
@@ -337,10 +339,11 @@ fn append_deferred_roots_bills_accounting_cost() {
     let mut tree = BulkAppendTree::new(2, MemStorageContext::new()).expect("new");
     let ctx = tree.append_deferred_roots(&[7u8; 20], &GROVE_V4);
     let r = ctx.value.expect("append");
-    // The share (20) plus the epoch's amortized compaction overhead
-    // (159 bytes over an epoch of 4 → 40), and the 20 bytes of blob rewrite.
-    assert_eq!(r.storage_accounting_cost.storage_cost.added_bytes, 60);
-    assert_eq!(ctx.cost.storage_cost.added_bytes, 60);
+    // The share (20) plus the variable format's prefix (4) plus the epoch's
+    // amortized compaction overhead (159 bytes over an epoch of 4 → 40), and
+    // the 20 bytes of blob rewrite.
+    assert_eq!(r.storage_accounting_cost.storage_cost.added_bytes, 64);
+    assert_eq!(ctx.cost.storage_cost.added_bytes, 64);
     assert_eq!(ctx.cost.storage_cost.replaced_bytes, 20);
     assert_eq!(r.storage_accounting_cost.storage_cost.replaced_bytes, 20);
 
@@ -515,4 +518,156 @@ fn wrong_length_persisted_mmr_root_is_corrupted_data() {
     ));
     // The shipped accounting never consults the key.
     assert!(tree.get_mmr_root_with_cost(&GROVE_V3).unwrap().is_ok());
+}
+
+/// The per-chunk compaction hash bound holds at every chunk index the
+/// 32-bit MMR keys admit, and the amortized charge — the bound spread over
+/// the epoch, rounded up — keeps every prefix of the tree's life prepaid at
+/// every height, the smallest included. (One hash per append would not: at
+/// `chunk_power` 1 the first six chunks perform 13 compaction hashes against
+/// 12 prepaid, and the bagging term keeps growing with the peak count.)
+#[test]
+fn amortized_compaction_hashes_prepay_every_prefix_at_every_height() {
+    // The blake3 calls chunk `i` (0-based) costs: the leaf hash, one merge
+    // per trailing one bit of `i`, and the root bagging over the peaks of
+    // the `i + 1`-leaf MMR.
+    fn actual(i: u64) -> u32 {
+        1 + i.trailing_ones() + (i + 1).count_ones().saturating_sub(1)
+    }
+    // The bound at the extremes and around every power of two.
+    for k in 0..31u32 {
+        let p = 1u64 << k;
+        for i in [p - 1, p, p + 1, 2 * p - 2, 2 * p - 1] {
+            assert!(
+                actual(i) <= crate::MAX_COMPACTION_HASHES_PER_CHUNK,
+                "chunk {i}: {}",
+                actual(i)
+            );
+        }
+    }
+    assert_eq!(actual((1u64 << 31) - 1), 1 + 31 + 0);
+    assert_eq!(actual((1u64 << 31) - 2), 1 + 0 + 30);
+    // Prefix sums at the smallest heights, exhaustively over many chunks.
+    for chunk_power in 1..=4u8 {
+        let epoch = 1u64 << chunk_power;
+        let per_chunk_charge = epoch * crate::amortized_compaction_hashes(chunk_power) as u64;
+        let (mut charged, mut performed) = (0u64, 0u64);
+        for i in 0..(1u64 << 16) {
+            charged += per_chunk_charge;
+            performed += actual(i) as u64;
+            assert!(
+                charged >= performed,
+                "chunk_power {chunk_power}, chunk {i}: charged {charged} < performed {performed}"
+            );
+        }
+    }
+    // The figures.
+    assert_eq!(crate::amortized_compaction_hashes(1), 33);
+    assert_eq!(crate::amortized_compaction_hashes(2), 17);
+    assert_eq!(crate::amortized_compaction_hashes(4), 5);
+    assert_eq!(crate::amortized_compaction_hashes(6), 2);
+    assert_eq!(crate::amortized_compaction_hashes(7), 1);
+    assert_eq!(crate::amortized_compaction_hashes(11), 1);
+    assert_eq!(crate::amortized_compaction_hashes(16), 1);
+    assert_eq!(
+        crate::max_amortized_compaction_hashes(),
+        crate::amortized_compaction_hashes(1)
+    );
+}
+
+/// A height-1 tree run for many epochs under the fixed model: every append
+/// reports the model plus the amortized bound, and the total reported never
+/// falls below the dense work plus the compaction work actually performed.
+#[test]
+fn height_one_tree_stays_prepaid_over_its_life() {
+    let mut tree = BulkAppendTree::new(1, MemStorageContext::new()).expect("new");
+    let model = grovedb_dense_fixed_sized_merkle_tree::V1InsertModel::for_height(1);
+    let amortized = crate::amortized_compaction_hashes(1);
+    let (mut reported, mut performed) = (0u64, 0u64);
+    for i in 0..4096u64 {
+        let r = tree
+            .append_no_state_root(&[i as u8; 4], &GROVE_V4)
+            .expect("append");
+        assert_eq!(
+            r.hash_count,
+            model.hash_node_calls + amortized,
+            "append {i}"
+        );
+        reported += r.hash_count as u64;
+        // Height 1: one leaf insert (2 hashes) per epoch, then a compaction
+        // per 2 appends.
+        if i % 2 == 0 {
+            performed += 2;
+        } else {
+            let chunk = i / 2;
+            performed += 1 + chunk.trailing_ones() as u64 + (chunk + 1).count_ones() as u64 - 1;
+        }
+        assert!(
+            reported >= performed,
+            "append {i}: {reported} < {performed}"
+        );
+    }
+}
+
+/// With a declared fixed entry size every append is charged exactly its own
+/// bytes (no per-entry framing) and any other length is rejected before a
+/// write; without it the variable format's four-byte prefix is prepaid on
+/// every entry, and a mixed-size epoch's added bytes cover the blob and MMR
+/// bytes the compaction persists.
+#[test]
+fn entry_framing_is_charged_unless_a_fixed_entry_size_is_declared() {
+    // Declared: exact, and enforced.
+    let mut fixed = BulkAppendTree::new(2, MemStorageContext::new())
+        .expect("new")
+        .with_fixed_entry_size(8);
+    let r = fixed
+        .append_no_state_root(&[1u8; 8], &GROVE_V4)
+        .expect("append");
+    assert_eq!(
+        r.storage_accounting_cost.storage_cost.added_bytes,
+        8 + (159u32).div_ceil(4)
+    );
+    assert!(matches!(
+        fixed.append_no_state_root(&[2u8; 9], &GROVE_V4),
+        Err(BulkAppendError::InvalidInput(_))
+    ));
+    assert!(matches!(
+        fixed.append_deferred_roots(&[2u8; 7], &GROVE_V4).unwrap(),
+        Err(BulkAppendError::InvalidInput(_))
+    ));
+    assert_eq!(fixed.total_count, 1, "a rejected append writes nothing");
+    assert_eq!(slot_puts(&fixed.dense_tree.storage).len(), 1);
+
+    // Undeclared: a full mixed-size epoch at chunk_power 4. The epoch's
+    // added bytes must cover everything the compaction persists — the blob
+    // (variable format: 1 + Σ(4 + len)) and the MMR nodes, keys and length
+    // varints included.
+    let mut tree = BulkAppendTree::new(4, MemStorageContext::new()).expect("new");
+    let mut added = 0u64;
+    for i in 0..16u32 {
+        let value = vec![i as u8; 1 + (i as usize % 5) * 3];
+        let r = tree
+            .append_no_state_root(&value, &GROVE_V4)
+            .expect("append");
+        assert_eq!(
+            r.storage_accounting_cost.storage_cost.added_bytes,
+            value.len() as u32 + crate::VARIABLE_ENTRY_FRAMING_BYTES + (159u32).div_ceil(16)
+        );
+        added += r.storage_accounting_cost.storage_cost.added_bytes as u64;
+    }
+    tree.commit_mmr(&GROVE_V4).expect("commit");
+    let persisted: u64 = tree
+        .dense_tree
+        .storage
+        .data
+        .borrow()
+        .iter()
+        .filter(|(k, _)| k.len() == 4 || k.as_slice() == crate::MMR_ROOT_KEY)
+        .map(|(k, v)| 32 + k.len() as u64 + paid(v.len() as u32) as u64)
+        .sum();
+    assert!(persisted > 0);
+    assert!(
+        added >= persisted,
+        "mixed-size epoch: added {added} < persisted {persisted}"
+    );
 }

--- a/grovedb-bulk-append-tree/src/tree/storage_accounting_tests.rs
+++ b/grovedb-bulk-append-tree/src/tree/storage_accounting_tests.rs
@@ -131,46 +131,54 @@ fn v0_issues_every_put_without_cost_info_and_bills_no_accounting() {
     }
 }
 
-/// v1 (GROVE_V4): the buffer is churn. Every slot write — epoch 1 included,
-/// growth and shrink alike — and every path record write is reported as an
-/// in-place replacement of its own size, nothing added and no key charged;
-/// nothing is read to size it. Every append prepays its own bytes (its
-/// chunk-blob share) as added storage, and bills the buffer's fixed
-/// root-maintenance model.
+/// v1 (GROVE_V4): the buffer is churn and the charge is fixed. Every slot
+/// write — epoch 1 included, growth and shrink alike — and every path record
+/// write is reported as an in-place replacement of its own size, nothing
+/// added and no key charged; nothing is read to size it. Every append —
+/// buffered or compacting — prepays its own bytes plus the epoch's share of
+/// the compaction overhead as added storage, its own bytes again as its part
+/// of the blob rewrite, and the buffer's fixed root-maintenance model.
 #[test]
-fn v1_buffer_writes_are_churn_and_every_append_prepays_its_bytes() {
+fn v1_buffer_writes_are_churn_and_every_append_is_charged_the_fixed_model() {
     use grovedb_dense_fixed_sized_merkle_tree::{path_record_len, V1InsertModel};
 
     let run = run(&GROVE_V4);
     let model = V1InsertModel::for_height(2);
+    // 159 bytes of compaction overhead over an epoch of 4.
+    let amortized: u32 = (159u32).div_ceil(4);
     for (i, (cost, value)) in run.accounting.iter().zip(VALUES.iter()).enumerate() {
         assert_eq!(
             cost.storage_cost.added_bytes,
-            value.len() as u32,
-            "append {i}: prepaid share"
+            value.len() as u32 + amortized,
+            "append {i}: prepaid share + amortized compaction overhead"
         );
-        assert_eq!(cost.storage_cost.replaced_bytes, 0, "append {i}");
+        // Its part of the blob rewrite — and, for a compacting append,
+        // which writes no slot and no record, their churn billed here
+        // instead of through the puts.
+        let churn = if i % 4 == 3 {
+            paid(value.len() as u32) + paid(path_record_len(2) as u32)
+        } else {
+            0
+        };
+        assert_eq!(
+            cost.storage_cost.replaced_bytes,
+            value.len() as u32 + churn,
+            "append {i}: its part of the blob rewrite (+ the compacting append's churn)"
+        );
         assert_eq!(
             cost.hash_node_calls, 0,
             "append {i}: hashes go through hash_count"
         );
-        let compacting = i % 4 == 3;
-        if compacting {
-            // The overflow value goes straight into the blob: no buffer
-            // work, no model.
-            assert_eq!(cost.seek_count, 0, "append {i}");
-            assert_eq!(cost.storage_loaded_bytes, 0, "append {i}");
-        } else {
-            assert_eq!(
-                cost.seek_count, model.record_reads,
-                "append {i}: model reads"
-            );
-            assert_eq!(
-                cost.storage_loaded_bytes,
-                model.record_reads as u64 * model.record_len as u64,
-                "append {i}: model bytes"
-            );
-        }
+        // The model, compacting appends included.
+        assert_eq!(
+            cost.seek_count, model.record_reads,
+            "append {i}: model reads"
+        );
+        assert_eq!(
+            cost.storage_loaded_bytes,
+            model.record_reads as u64 * model.record_len as u64,
+            "append {i}: model bytes"
+        );
     }
 
     let churn = |len: u32| KeyValueStorageCost {
@@ -185,9 +193,8 @@ fn v1_buffer_writes_are_churn_and_every_append_prepays_its_bytes() {
     };
     let slots = slot_puts(&run.ctx);
     assert_eq!(slots.len(), 9, "three slots per epoch, three epochs");
-    let buffered: Vec<&&[u8]> = VALUES.iter().filter(|v| v.len() != 0).collect();
     let mut expected = Vec::new();
-    for (i, v) in buffered.iter().enumerate() {
+    for (i, v) in VALUES.iter().enumerate() {
         if i % 4 != 3 {
             expected.push(Some(churn(v.len() as u32)));
         }
@@ -236,37 +243,24 @@ fn v1_never_reads_to_size_a_buffer_write() {
     );
 }
 
-/// v1: the compaction blob is reported as a replacement of the entry bytes
-/// it supersedes — all prepaid — with only its framing added; internal MMR
-/// nodes are new storage.
+/// v1: the compaction blob and the MMR internal nodes are prepaid — every
+/// append charged its share over the epoch — so their puts carry zero-byte
+/// cost information: nothing added, nothing replaced, no key.
 #[test]
-fn v1_commit_mmr_reports_blob_as_replacement_of_prepaid_entry_bytes() {
+fn v1_commit_mmr_writes_are_prepaid() {
     let run = run(&GROVE_V4);
     let nodes = mmr_puts(&run.ctx);
     assert_eq!(nodes.len(), 4, "{nodes:?}");
-
-    let leaf = |entry_bytes: u32, blob_len: u32| {
-        // MmrNode leaf envelope: flag (1) + hash (32) + length (4) + blob.
-        let node_len = 37 + blob_len;
-        KeyValueStorageCost {
-            key_storage_cost: Default::default(),
-            value_storage_cost: StorageCost {
-                added_bytes: paid(node_len) - entry_bytes,
-                replaced_bytes: entry_bytes,
-                removed_bytes: NoStorageRemoval,
-            },
-            new_node: true,
-            needs_value_verification: true,
-        }
+    let prepaid = KeyValueStorageCost {
+        key_storage_cost: Default::default(),
+        value_storage_cost: StorageCost::default(),
+        new_node: false,
+        needs_value_verification: false,
     };
-    // Blob 1: four 8-byte entries, fixed format: 9-byte header + 32.
-    assert_eq!(nodes[0], Some(leaf(32, 9 + 32)));
-    // Blob 2: 8, 16, 4, 8 -> variable format: 1 + sum(4 + len) = 53, 36 entry bytes.
-    assert_eq!(nodes[1], Some(leaf(36, 53)));
-    // The merge of leaves 1 and 2 is an internal node: new storage.
-    assert_eq!(nodes[2], None);
-    // Blob 3: fixed again.
-    assert_eq!(nodes[3], Some(leaf(32, 9 + 32)));
+    assert!(
+        nodes.iter().all(|n| *n == Some(prepaid.clone())),
+        "every MMR put — three chunk leaves and one merge — is prepaid: {nodes:?}"
+    );
 }
 
 /// The tree itself must not depend on the accounting version: the values,
@@ -278,26 +272,50 @@ fn stored_state_and_roots_are_identical_across_accounting_versions() {
     let r3 = run(&GROVE_V3);
     let r4 = run(&GROVE_V4);
     assert_eq!(r3.root, r4.root);
-    let without_records = |ctx: &MemStorageContext| -> std::collections::HashMap<Vec<u8>, Vec<u8>> {
+    // GROVE_V4 adds the path records (3-byte keys) and the persisted MMR
+    // root (the 1-byte key `r`); everything else is byte-identical.
+    let without_derived = |ctx: &MemStorageContext| -> std::collections::HashMap<Vec<u8>, Vec<u8>> {
         ctx.data
             .borrow()
             .iter()
-            .filter(|(k, _)| k.len() != 3)
+            .filter(|(k, _)| k.len() != 3 && k.len() != 1)
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect()
     };
     assert!(
-        r3.ctx.data.borrow().keys().all(|k| k.len() != 3),
-        "GROVE_V3 writes no hash records"
+        r3.ctx
+            .data
+            .borrow()
+            .keys()
+            .all(|k| k.len() != 3 && k.len() != 1),
+        "GROVE_V3 writes no records and no persisted MMR root"
     );
     assert!(
         r4.ctx.data.borrow().keys().any(|k| k.len() == 3),
-        "GROVE_V4 writes hash records"
+        "GROVE_V4 writes path records"
     );
+    let persisted_root = r4
+        .ctx
+        .data
+        .borrow()
+        .get(crate::MMR_ROOT_KEY)
+        .cloned()
+        .expect("GROVE_V4 persists the MMR root at commit");
+    let reopened = BulkAppendTree::from_state(12, 2, r4.ctx).expect("reopen");
     assert_eq!(
-        without_records(&r3.ctx),
-        without_records(&r4.ctx),
-        "byte-identical storage apart from the hash records"
+        persisted_root.as_slice(),
+        reopened
+            .bag_mmr_root_with_cost(&GROVE_V4)
+            .unwrap()
+            .expect("bag")
+            .as_slice(),
+        "the persisted MMR root is the bagged root"
+    );
+    let r4_ctx = reopened.dense_tree.storage;
+    assert_eq!(
+        without_derived(&r3.ctx),
+        without_derived(&r4_ctx),
+        "byte-identical storage apart from the records and the persisted MMR root"
     );
 }
 
@@ -309,9 +327,12 @@ fn append_deferred_roots_bills_accounting_cost() {
     let mut tree = BulkAppendTree::new(2, MemStorageContext::new()).expect("new");
     let ctx = tree.append_deferred_roots(&[7u8; 20], &GROVE_V4);
     let r = ctx.value.expect("append");
-    assert_eq!(r.storage_accounting_cost.storage_cost.added_bytes, 20);
-    assert_eq!(ctx.cost.storage_cost.added_bytes, 20);
-    assert_eq!(ctx.cost.storage_cost.replaced_bytes, 0);
+    // The share (20) plus the epoch's amortized compaction overhead
+    // (159 bytes over an epoch of 4 → 40), and the 20 bytes of blob rewrite.
+    assert_eq!(r.storage_accounting_cost.storage_cost.added_bytes, 60);
+    assert_eq!(ctx.cost.storage_cost.added_bytes, 60);
+    assert_eq!(ctx.cost.storage_cost.replaced_bytes, 20);
+    assert_eq!(r.storage_accounting_cost.storage_cost.replaced_bytes, 20);
 
     let mut legacy = BulkAppendTree::new(2, MemStorageContext::new()).expect("new");
     let ctx = legacy.append_deferred_roots(&[7u8; 20], &GROVE_V3);

--- a/grovedb-bulk-append-tree/src/tree/storage_accounting_tests.rs
+++ b/grovedb-bulk-append-tree/src/tree/storage_accounting_tests.rs
@@ -2,11 +2,9 @@
 //! the level of the cost information each put carries.
 //!
 //! The in-memory context records every `put` with its `cost_info`, which is
-//! exactly what a real storage context hands the commit path to bill. A
-//! buffer slot counts as holding a committed value by the `total_count` the
-//! tree was opened with, so each epoch here is run on a tree re-opened with
-//! `from_state` over the previous epoch's storage — the way every GroveDB
-//! operation opens it.
+//! exactly what a real storage context hands the commit path to bill. Each
+//! epoch here is run on a tree re-opened with `from_state` over the previous
+//! epoch's storage — the way every GroveDB operation opens it.
 
 use grovedb_costs::{
     storage_cost::{
@@ -41,6 +39,16 @@ fn slot_puts(ctx: &MemStorageContext) -> Vec<Option<KeyValueStorageCost>> {
         .borrow()
         .iter()
         .filter(|(k, _)| k.len() == 2)
+        .map(|(_, c)| c.clone())
+        .collect()
+}
+
+/// Path record puts (3-byte keys), in order.
+fn record_puts(ctx: &MemStorageContext) -> Vec<Option<KeyValueStorageCost>> {
+    ctx.puts
+        .borrow()
+        .iter()
+        .filter(|(k, _)| k.len() == 3)
         .map(|(_, c)| c.clone())
         .collect()
 }
@@ -123,102 +131,109 @@ fn v0_issues_every_put_without_cost_info_and_bills_no_accounting() {
     }
 }
 
-/// v1 (GROVE_V4): a slot written for the first time is new storage; a slot
-/// that already holds a committed value is a replacement — growth added,
-/// shrink not credited, key not charged; every append prepays its own bytes.
+/// v1 (GROVE_V4): the buffer is churn. Every slot write — epoch 1 included,
+/// growth and shrink alike — and every path record write is reported as an
+/// in-place replacement of its own size, nothing added and no key charged;
+/// nothing is read to size it. Every append prepays its own bytes (its
+/// chunk-blob share) as added storage, and bills the buffer's fixed
+/// root-maintenance model.
 #[test]
-fn v1_slot_rewrites_are_replacements_and_every_append_prepays_its_bytes() {
+fn v1_buffer_writes_are_churn_and_every_append_prepays_its_bytes() {
+    use grovedb_dense_fixed_sized_merkle_tree::{path_record_len, V1InsertModel};
+
     let run = run(&GROVE_V4);
-    // The in-memory context reports no cost for its reads, so the
-    // accounting cost carries the prepaid share only; the read's seek and
-    // bytes are pinned against RocksDB by the GroveDB-level tests.
-    let prepaid: Vec<u32> = run
-        .accounting
-        .iter()
-        .map(|c| c.storage_cost.added_bytes)
-        .collect();
-    let expected_prepaid: Vec<u32> = VALUES.iter().map(|v| v.len() as u32).collect();
-    assert_eq!(prepaid, expected_prepaid);
-    assert!(run
-        .accounting
-        .iter()
-        .all(|c| c.storage_cost.replaced_bytes == 0 && c.hash_node_calls == 0));
+    let model = V1InsertModel::for_height(2);
+    for (i, (cost, value)) in run.accounting.iter().zip(VALUES.iter()).enumerate() {
+        assert_eq!(
+            cost.storage_cost.added_bytes,
+            value.len() as u32,
+            "append {i}: prepaid share"
+        );
+        assert_eq!(cost.storage_cost.replaced_bytes, 0, "append {i}");
+        assert_eq!(
+            cost.hash_node_calls, 0,
+            "append {i}: hashes go through hash_count"
+        );
+        let compacting = i % 4 == 3;
+        if compacting {
+            // The overflow value goes straight into the blob: no buffer
+            // work, no model.
+            assert_eq!(cost.seek_count, 0, "append {i}");
+            assert_eq!(cost.storage_loaded_bytes, 0, "append {i}");
+        } else {
+            assert_eq!(
+                cost.seek_count, model.record_reads,
+                "append {i}: model reads"
+            );
+            assert_eq!(
+                cost.storage_loaded_bytes,
+                model.record_reads as u64 * model.record_len as u64,
+                "append {i}: model bytes"
+            );
+        }
+    }
 
-    let slots = slot_puts(&run.ctx);
-    assert_eq!(slots.len(), 9);
-    // Epoch 1: fresh slots.
-    assert!(slots[..3].iter().all(Option::is_none), "{slots:?}");
-
-    let rewrite = |previous: u32, new: u32| KeyValueStorageCost {
+    let churn = |len: u32| KeyValueStorageCost {
         key_storage_cost: Default::default(),
         value_storage_cost: StorageCost {
-            added_bytes: paid(new).saturating_sub(paid(previous)),
-            replaced_bytes: paid(new).min(paid(previous)),
+            added_bytes: 0,
+            replaced_bytes: paid(len),
             removed_bytes: NoStorageRemoval,
         },
         new_node: false,
         needs_value_verification: true,
     };
-    // Epoch 2 over epoch 1's 8-byte values.
-    assert_eq!(slots[3], Some(rewrite(8, 8)), "same size: fully replaced");
-    assert_eq!(
-        slots[4],
-        Some(rewrite(8, 16)),
-        "growth: 9 replaced, 8 added"
+    let slots = slot_puts(&run.ctx);
+    assert_eq!(slots.len(), 9, "three slots per epoch, three epochs");
+    let buffered: Vec<&&[u8]> = VALUES.iter().filter(|v| v.len() != 0).collect();
+    let mut expected = Vec::new();
+    for (i, v) in buffered.iter().enumerate() {
+        if i % 4 != 3 {
+            expected.push(Some(churn(v.len() as u32)));
+        }
+    }
+    assert_eq!(slots, expected, "every slot write is churn of its own size");
+
+    let records = record_puts(&run.ctx);
+    assert_eq!(records.len(), 9, "one path record per buffered append");
+    let record_len = path_record_len(2) as u32;
+    assert!(
+        records.iter().all(|c| *c == Some(churn(record_len))),
+        "every record write is churn of the fixed record size: {records:?}"
     );
-    assert_eq!(
-        slots[5],
-        Some(rewrite(8, 4)),
-        "shrink: 5 replaced, nothing credited"
-    );
-    assert_eq!(slots[4].as_ref().unwrap().value_storage_cost.added_bytes, 8);
-    assert_eq!(slots[5].as_ref().unwrap().value_storage_cost.added_bytes, 0);
-    // Epoch 3 over epoch 2's values.
-    assert_eq!(slots[6], Some(rewrite(8, 8)));
-    assert_eq!(slots[7], Some(rewrite(16, 8)));
-    assert_eq!(slots[8], Some(rewrite(4, 8)));
 }
 
-/// Whether a slot is rewritten is judged against the state at open: inside
-/// one session a slot written for the first time and rewritten after an
-/// in-session compaction is still new storage (nothing is committed), so
-/// it is never read and never reported as a replacement — a `StorageBatch`
-/// will charge its last put, which must describe the transition from
-/// committed storage. A slot the open count says is committed but storage
-/// does not hold is charged as new, the safe direction.
+/// The churn accounting never reads a slot to size a rewrite — a broken
+/// reader for slot keys does not stop an append — and the same slot written
+/// twice in one session is churn both times.
 #[test]
-fn v1_judges_committed_slots_by_the_count_at_open() {
-    // Two epochs on a tree created in this session: no slot is committed.
+fn v1_never_reads_to_size_a_buffer_write() {
+    let ctx = MemStorageContext::new();
+    ctx.fail_reads();
+    // Opened after a completed chunk: under the old accounting every slot
+    // counted as committed and was read first.
+    let mut tree = BulkAppendTree::from_state(4, 2, ctx).expect("open");
+    tree.append_no_state_root(&[1; 8], &GROVE_V4)
+        .expect("no read under the churn accounting");
+    // (The dense tree's own reads go to records the broken reader also
+    // fails; at buffer position 0 there are none.)
+    assert_eq!(slot_puts(&tree.dense_tree.storage).len(), 1);
+    assert!(slot_puts(&tree.dense_tree.storage)[0]
+        .as_ref()
+        .is_some_and(|c| !c.new_node && c.value_storage_cost.added_bytes == 0));
+
     let mut tree = BulkAppendTree::new(2, MemStorageContext::new()).expect("new");
     for v in &VALUES[..8] {
         tree.append_no_state_root(v, &GROVE_V4).expect("append");
     }
     let slots = slot_puts(&tree.dense_tree.storage);
     assert_eq!(slots.len(), 6);
-    assert!(slots.iter().all(Option::is_none), "{slots:?}");
-
-    // Opened with two committed buffer entries and no chunk: slots 0 and 1
-    // are committed, slot 2 is not and is written without a read.
-    let mut seeded = BulkAppendTree::new(2, MemStorageContext::new()).expect("new");
-    for v in &VALUES[..2] {
-        seeded.append_no_state_root(v, &GROVE_V4).expect("seed");
-    }
-    let mut tree = BulkAppendTree::from_state(2, 2, seeded.dense_tree.storage).expect("open");
-    assert!(tree.slot_is_committed(0) && tree.slot_is_committed(1));
-    assert!(!tree.slot_is_committed(2));
-    tree.append_no_state_root(&[1; 8], &GROVE_V4)
-        .expect("slot 2");
-    let slots = slot_puts(&tree.dense_tree.storage);
-    assert_eq!(slots, vec![None, None, None]);
-
-    // Opened after a completed chunk: every slot is committed — and one
-    // that storage does not hold (corruption, not a state this code
-    // produces) is charged as new rather than as a rewrite of nothing.
-    let mut tree = BulkAppendTree::from_state(4, 2, MemStorageContext::new()).expect("open");
-    assert!((0..3).all(|p| tree.slot_is_committed(p)));
-    tree.append_no_state_root(&[1; 8], &GROVE_V4)
-        .expect("slot 0");
-    assert_eq!(slot_puts(&tree.dense_tree.storage), vec![None]);
+    assert!(
+        slots.iter().all(|c| c
+            .as_ref()
+            .is_some_and(|c| c.value_storage_cost.added_bytes == 0)),
+        "{slots:?}"
+    );
 }
 
 /// v1: the compaction blob is reported as a replacement of the entry bytes
@@ -305,32 +320,6 @@ fn append_deferred_roots_bills_accounting_cost() {
         OperationCost::default()
     );
     assert_eq!(ctx.cost.storage_cost.added_bytes, 0);
-}
-
-/// A storage fault on the committed-slot read surfaces as an error and
-/// nothing is written; the shipped accounting never performs that read.
-#[test]
-fn committed_slot_read_failure_surfaces() {
-    let ctx = MemStorageContext::new();
-    ctx.fail_reads();
-    let mut tree = BulkAppendTree::from_state(4, 2, ctx).expect("open");
-    let err = tree
-        .append_no_state_root(&[1; 8], &GROVE_V4)
-        .expect_err("read failed");
-    assert!(
-        matches!(&err, BulkAppendError::StorageError(m) if m.contains("committed slot")),
-        "{err:?}"
-    );
-    let err = tree
-        .append_deferred_roots(&[1; 8], &GROVE_V4)
-        .value
-        .expect_err("read failed");
-    assert!(matches!(err, BulkAppendError::StorageError(_)));
-    assert!(tree.dense_tree.storage.puts.borrow().is_empty());
-
-    // v0 reads nothing, so it writes straight through the broken reader.
-    tree.append_no_state_root(&[1; 8], &GROVE_V3)
-        .expect("no read under the shipped accounting");
 }
 
 /// An unknown accounting version is rejected at every entry that consults

--- a/grovedb-bulk-append-tree/src/tree/storage_accounting_tests.rs
+++ b/grovedb-bulk-append-tree/src/tree/storage_accounting_tests.rs
@@ -215,15 +215,25 @@ fn v1_buffer_writes_are_churn_and_every_append_is_charged_the_fixed_model() {
 /// twice in one session is churn both times.
 #[test]
 fn v1_never_reads_to_size_a_buffer_write() {
-    let ctx = MemStorageContext::new();
-    ctx.fail_reads();
     // Opened after a completed chunk: under the old accounting every slot
     // counted as committed and was read first.
-    let mut tree = BulkAppendTree::from_state(4, 2, ctx).expect("open");
+    let mut tree = BulkAppendTree::new(2, MemStorageContext::new()).expect("new");
+    for v in &VALUES[..4] {
+        tree.append_no_state_root(v, &GROVE_V4).expect("append");
+    }
+    tree.commit_mmr(&GROVE_V4).expect("commit");
+    let mut tree = BulkAppendTree::from_state(4, 2, tree.dense_tree.storage).expect("open");
+    tree.dense_tree.storage.gets.borrow_mut().clear();
+    tree.dense_tree.storage.puts.borrow_mut().clear();
     tree.append_no_state_root(&[1; 8], &GROVE_V4)
-        .expect("no read under the churn accounting");
-    // (The dense tree's own reads go to records the broken reader also
-    // fails; at buffer position 0 there are none.)
+        .expect("append");
+    // The only read is the persisted MMR root — one of the two root reads
+    // the model charges on every state-root derivation; no slot, and at
+    // buffer position 0 no record either.
+    assert_eq!(
+        tree.dense_tree.storage.gets.borrow().clone(),
+        vec![crate::MMR_ROOT_KEY.to_vec()]
+    );
     assert_eq!(slot_puts(&tree.dense_tree.storage).len(), 1);
     assert!(slot_puts(&tree.dense_tree.storage)[0]
         .as_ref()
@@ -371,4 +381,138 @@ fn unknown_storage_accounting_version_is_rejected() {
     tree.commit_mmr(&GROVE_V4)
         .expect("flush with a known version");
     assert_eq!(mmr_puts(&tree.dense_tree.storage).len(), 1);
+}
+
+/// A tree whose last compaction predates the fixed model has no persisted
+/// MMR root. Its first GROVE_V4 append bags the peaks ONCE, backfills the
+/// key — prepaid, so the append's figure is the fixed model's — and from
+/// then on every reopen reads the key instead of the peaks' blobs.
+#[test]
+fn legacy_mmr_root_is_backfilled_once_on_the_first_v4_append() {
+    let prepaid = KeyValueStorageCost {
+        key_storage_cost: Default::default(),
+        value_storage_cost: StorageCost::default(),
+        new_node: false,
+        needs_value_verification: false,
+    };
+    // Epoch 1 under the shipped accounting: chunk committed, no root key.
+    let mut tree = BulkAppendTree::new(2, MemStorageContext::new()).expect("new");
+    for v in &VALUES[..4] {
+        tree.append_no_state_root(v, &GROVE_V3).expect("append");
+    }
+    tree.commit_mmr(&GROVE_V3).expect("commit");
+    assert!(!tree
+        .dense_tree
+        .storage
+        .data
+        .borrow()
+        .contains_key(crate::MMR_ROOT_KEY));
+    let bagged = tree
+        .bag_mmr_root_with_cost(&GROVE_V4)
+        .unwrap()
+        .expect("bag");
+
+    // First V4 append on the reopened tree: backfill.
+    let mut tree = BulkAppendTree::from_state(4, 2, tree.dense_tree.storage).expect("open");
+    tree.dense_tree.storage.puts.borrow_mut().clear();
+    let first = tree
+        .append_no_state_root(VALUES[4], &GROVE_V4)
+        .expect("append");
+    let root_puts: Vec<_> = tree
+        .dense_tree
+        .storage
+        .puts
+        .borrow()
+        .iter()
+        .filter(|(k, _)| k == crate::MMR_ROOT_KEY)
+        .map(|(_, c)| c.clone())
+        .collect();
+    assert_eq!(root_puts, vec![Some(prepaid)], "one prepaid backfill put");
+    assert_eq!(
+        tree.dense_tree.storage.data.borrow()[crate::MMR_ROOT_KEY],
+        bagged.to_vec()
+    );
+    // Charged the fixed model, exactly like the same append on a tree that
+    // ran under V4 from the start.
+    let v4 = run(&GROVE_V4);
+    assert_eq!(first.storage_accounting_cost, v4.accounting[4]);
+    assert_eq!(first.hash_count, {
+        let mut t = BulkAppendTree::new(2, MemStorageContext::new()).expect("new");
+        for v in &VALUES[..4] {
+            t.append_no_state_root(v, &GROVE_V4).expect("append");
+        }
+        t.append_no_state_root(VALUES[4], &GROVE_V4)
+            .expect("append")
+            .hash_count
+    });
+    tree.commit_mmr(&GROVE_V4).expect("commit");
+
+    // Every later reopen reads the key and never the peaks.
+    let mut tree = BulkAppendTree::from_state(5, 2, tree.dense_tree.storage).expect("open");
+    tree.dense_tree.storage.gets.borrow_mut().clear();
+    tree.dense_tree.storage.puts.borrow_mut().clear();
+    tree.append_no_state_root(VALUES[5], &GROVE_V4)
+        .expect("append");
+    let state_root = tree.compute_current_state_root(&GROVE_V4).expect("root");
+    let gets = tree.dense_tree.storage.gets.borrow().clone();
+    assert!(gets.contains(&crate::MMR_ROOT_KEY.to_vec()), "{gets:?}");
+    assert!(
+        gets.iter().all(|k| k.len() != 4),
+        "no MMR node read after the backfill: {gets:?}"
+    );
+    assert!(
+        !tree
+            .dense_tree
+            .storage
+            .puts
+            .borrow()
+            .iter()
+            .any(|(k, _)| k == crate::MMR_ROOT_KEY),
+        "no second backfill"
+    );
+    // And the state is the one a V4-only tree reaches.
+    let mut v4_tree = BulkAppendTree::new(2, MemStorageContext::new()).expect("new");
+    for v in &VALUES[..6] {
+        v4_tree.append_no_state_root(v, &GROVE_V4).expect("append");
+    }
+    assert_eq!(
+        state_root,
+        v4_tree.compute_current_state_root(&GROVE_V4).expect("root")
+    );
+    assert_eq!(
+        state_root,
+        tree.compute_current_state_root_from_values().expect("root")
+    );
+}
+
+/// A persisted MMR root of any length but 32 is corruption (or the key
+/// collision the layout rules out), never a legacy tree: reported, not
+/// silently bagged over.
+#[test]
+fn wrong_length_persisted_mmr_root_is_corrupted_data() {
+    let mut tree = BulkAppendTree::new(2, MemStorageContext::new()).expect("new");
+    for v in &VALUES[..4] {
+        tree.append_no_state_root(v, &GROVE_V4).expect("append");
+    }
+    tree.commit_mmr(&GROVE_V4).expect("commit");
+    tree.dense_tree
+        .storage
+        .data
+        .borrow_mut()
+        .insert(crate::MMR_ROOT_KEY.to_vec(), vec![7u8; 5]);
+    let mut tree = BulkAppendTree::from_state(4, 2, tree.dense_tree.storage).expect("open");
+    assert!(matches!(
+        tree.get_mmr_root_with_cost(&GROVE_V4).unwrap(),
+        Err(BulkAppendError::CorruptedData(_))
+    ));
+    assert!(matches!(
+        tree.append_no_state_root(VALUES[4], &GROVE_V4),
+        Err(BulkAppendError::CorruptedData(_))
+    ));
+    assert!(matches!(
+        tree.append_deferred_roots(VALUES[4], &GROVE_V4).unwrap(),
+        Err(BulkAppendError::CorruptedData(_))
+    ));
+    // The shipped accounting never consults the key.
+    assert!(tree.get_mmr_root_with_cost(&GROVE_V3).unwrap().is_ok());
 }

--- a/grovedb-bulk-append-tree/src/tree/tests.rs
+++ b/grovedb-bulk-append-tree/src/tree/tests.rs
@@ -635,12 +635,15 @@ fn get_range_wrong_chunk_entry_count_is_corruption() {
 
 /// The hash count a buffered append reports is the dense tree's own figure
 /// under every version — the shipped `2 * count` full-buffer walk under
-/// GROVE_V3, the ancestor path (`2 + depth`) under GROVE_V4 — and the state
-/// roots are identical under both: the records change the work, not the
-/// root.
+/// GROVE_V3, the fixed model for the buffer's height under GROVE_V4 — and
+/// the state roots are identical under both: the records change the work
+/// and the charge, not the root.
 #[test]
 fn buffered_append_hash_count_follows_the_root_maintenance_version() {
+    use grovedb_dense_fixed_sized_merkle_tree::V1InsertModel;
     use grovedb_version::version::{v3::GROVE_V3, v4::GROVE_V4};
+
+    let model = V1InsertModel::for_height(4);
 
     // capacity 15, epoch 16: one full epoch of buffered appends plus the
     // compaction, then a few of the next epoch (slot rewrites).
@@ -659,7 +662,6 @@ fn buffered_append_hash_count_follows_the_root_maintenance_version() {
             assert!(r3.hash_count >= 2, "v3 compaction: {}", r3.hash_count);
         } else {
             let filled = buffer_position + 1;
-            let depth = (buffer_position + 1).ilog2();
             assert_eq!(
                 r3.hash_count,
                 2 * filled + 1,
@@ -667,8 +669,8 @@ fn buffered_append_hash_count_follows_the_root_maintenance_version() {
             );
             assert_eq!(
                 r4.hash_count,
-                2 + depth + 1,
-                "position {i}: v4 hashes the leaf and its {depth} ancestors (+1 state root)"
+                model.hash_node_calls + 1,
+                "position {i}: v4 charges the height-4 model (+1 state root), whatever the position"
             );
         }
     }

--- a/grovedb-bulk-append-tree/src/tree/tests.rs
+++ b/grovedb-bulk-append-tree/src/tree/tests.rs
@@ -655,12 +655,12 @@ fn buffered_append_hash_count_follows_the_root_maintenance_version() {
         assert_eq!(r3.state_root, r4.state_root, "position {i}: state root");
         assert_eq!(r3.compacted, r4.compacted);
         let buffer_position = (i % 16) as u32;
-        // v4: the height-4 model + the amortized compaction blake3 + the
-        // state root — the same on every append, the compacting one
-        // included.
+        // v4: the height-4 model + the amortized compaction bound (5 at
+        // height 4) + the state root — the same on every append, the
+        // compacting one included.
         assert_eq!(
             r4.hash_count,
-            model.hash_node_calls + 1 + 1,
+            model.hash_node_calls + crate::amortized_compaction_hashes(4) + 1,
             "position {i}: v4 charges the fixed model whatever the position"
         );
         if r3.compacted {

--- a/grovedb-bulk-append-tree/src/tree/tests.rs
+++ b/grovedb-bulk-append-tree/src/tree/tests.rs
@@ -655,10 +655,17 @@ fn buffered_append_hash_count_follows_the_root_maintenance_version() {
         assert_eq!(r3.state_root, r4.state_root, "position {i}: state root");
         assert_eq!(r3.compacted, r4.compacted);
         let buffer_position = (i % 16) as u32;
+        // v4: the height-4 model + the amortized compaction blake3 + the
+        // state root — the same on every append, the compacting one
+        // included.
+        assert_eq!(
+            r4.hash_count,
+            model.hash_node_calls + 1 + 1,
+            "position {i}: v4 charges the fixed model whatever the position"
+        );
         if r3.compacted {
-            // No buffer work on a compacting append: the chunk-leaf hash, the
-            // MMR push, and the state root — and v4 adds the root bagging
-            // the v3 figure omits (`compaction_hash_count`), here nothing.
+            // v3: no buffer work on a compacting append — the chunk-leaf
+            // hash, the MMR push, and the state root.
             assert!(r3.hash_count >= 2, "v3 compaction: {}", r3.hash_count);
         } else {
             let filled = buffer_position + 1;
@@ -666,11 +673,6 @@ fn buffered_append_hash_count_follows_the_root_maintenance_version() {
                 r3.hash_count,
                 2 * filled + 1,
                 "position {i}: v3 walks the {filled} filled positions (+1 state root)"
-            );
-            assert_eq!(
-                r4.hash_count,
-                model.hash_node_calls + 1,
-                "position {i}: v4 charges the height-4 model (+1 state root), whatever the position"
             );
         }
     }

--- a/grovedb-commitment-tree/src/commitment_tree/cost/mod.rs
+++ b/grovedb-commitment-tree/src/commitment_tree/cost/mod.rs
@@ -10,6 +10,13 @@
 //!   information, so the key and the whole frontier are charged as new
 //!   storage on every append. v1 reports it as a replacement of the bytes
 //!   loaded at open, with only growth added.
+//! - `frontier_cost_model` — whether the frontier's per-append cost is the
+//!   actual work of the position (v0: `32 + trailing_ones(position)`
+//!   Sinsemilla hashes, the frontier's actual size loaded and saved) or a
+//!   fixed model derived from the depth (v1: `depth + 1` hashes, a
+//!   `42 + 32 · depth/2`-byte frontier), so every append costs the same.
+//!   When set it also decides the save's storage accounting — a replacement
+//!   of the model size — taking precedence over the gate above.
 //!
 //! [`CommitmentTree::save`]: super::CommitmentTree::save
 
@@ -21,31 +28,75 @@ use grovedb_version::{error::GroveVersionError, version::GroveVersion};
 
 use crate::CommitmentTreeError;
 
-/// Cost information to attach to the frontier put.
-///
-/// `persisted_len` is the serialized size of the frontier as loaded at open
-/// (`None` when the key did not exist), `new_len` the size being written.
-pub(crate) fn frontier_save_cost_info(
-    persisted_len: Option<u32>,
-    new_len: u32,
+/// Whether `grove_version` charges the frontier at its fixed model.
+pub(crate) fn frontier_cost_model(
     grove_version: &GroveVersion,
-) -> Result<Option<KeyValueStorageCost>, CommitmentTreeError> {
+) -> Result<bool, CommitmentTreeError> {
     match grove_version
         .commitment_tree_versions
         .cost
-        .frontier_save_storage_accounting
+        .frontier_cost_model
     {
-        0 => Ok(v0::frontier_save_cost_info()),
-        1 => Ok(v1::frontier_save_cost_info(persisted_len, new_len)),
+        0 => Ok(false),
+        1 => Ok(true),
         version => Err(CommitmentTreeError::VersionError(
             GroveVersionError::UnknownVersionMismatch {
-                method: "CommitmentTree frontier save storage accounting".to_string(),
+                method: "CommitmentTree frontier cost model".to_string(),
                 known_versions: vec![0, 1],
                 received: version,
             }
             .to_string(),
         )),
     }
+}
+
+/// Cost information to attach to the frontier put.
+///
+/// `persisted_len` is the serialized size of the frontier as loaded at open
+/// (`None` when the key did not exist), `new_len` the size being written.
+/// Under the fixed frontier cost model the put is a replacement of the model
+/// size whatever was there; otherwise the save accounting gate decides.
+pub(crate) fn frontier_save_cost_info(
+    persisted_len: Option<u32>,
+    new_len: u32,
+    grove_version: &GroveVersion,
+) -> Result<Option<KeyValueStorageCost>, CommitmentTreeError> {
+    let actual = match grove_version
+        .commitment_tree_versions
+        .cost
+        .frontier_save_storage_accounting
+    {
+        0 => v0::frontier_save_cost_info(),
+        1 => v1::frontier_save_cost_info(persisted_len, new_len),
+        version => {
+            return Err(CommitmentTreeError::VersionError(
+                GroveVersionError::UnknownVersionMismatch {
+                    method: "CommitmentTree frontier save storage accounting".to_string(),
+                    known_versions: vec![0, 1],
+                    received: version,
+                }
+                .to_string(),
+            ))
+        }
+    };
+    if frontier_cost_model(grove_version)? {
+        // A replacement of the model size, whatever the bytes written — so
+        // the commit path must not verify the figure against them.
+        // 554 bytes: a two-byte length varint.
+        let paid = crate::MODEL_FRONTIER_SERIALIZED_LEN + 2;
+        return Ok(Some(KeyValueStorageCost {
+            key_storage_cost: grovedb_costs::storage_cost::StorageCost::default(),
+            value_storage_cost: grovedb_costs::storage_cost::StorageCost {
+                added_bytes: 0,
+                replaced_bytes: paid,
+                removed_bytes:
+                    grovedb_costs::storage_cost::removal::StorageRemovedBytes::NoStorageRemoval,
+            },
+            new_node: false,
+            needs_value_verification: false,
+        }));
+    }
+    Ok(actual)
 }
 
 #[cfg(test)]
@@ -66,21 +117,30 @@ mod tests {
         }
     }
 
+    /// GROVE_V4 with the fixed frontier cost model switched off: the
+    /// save-accounting gate alone.
+    fn v4_actual_frontier() -> GroveVersion {
+        let mut version = GROVE_V4.clone();
+        version.commitment_tree_versions.cost.frontier_cost_model = 0;
+        version
+    }
+
     #[test]
-    fn v1_first_save_is_new_storage_and_rewrites_replace_with_growth_added() {
+    fn save_accounting_v1_first_save_is_new_storage_and_rewrites_replace_with_growth_added() {
+        let version = v4_actual_frontier();
         // No committed frontier: the key is created, everything is added.
-        assert!(frontier_save_cost_info(None, 74, &GROVE_V4)
+        assert!(frontier_save_cost_info(None, 74, &version)
             .unwrap()
             .is_none());
         // 74 -> 106 bytes (one more ommer): paid 75 replaced, 32 added.
-        let c = frontier_save_cost_info(Some(74), 106, &GROVE_V4)
+        let c = frontier_save_cost_info(Some(74), 106, &version)
             .unwrap()
             .unwrap();
         assert_eq!(c.value_storage_cost.replaced_bytes, 75);
         assert_eq!(c.value_storage_cost.added_bytes, 32);
         assert!(!c.new_node);
         // 1066 -> 74 bytes (position 2^k): replaced at the new size, nothing credited.
-        let c = frontier_save_cost_info(Some(1066), 74, &GROVE_V4)
+        let c = frontier_save_cost_info(Some(1066), 74, &version)
             .unwrap()
             .unwrap();
         assert_eq!(c.value_storage_cost.replaced_bytes, 75);
@@ -91,14 +151,42 @@ mod tests {
         );
     }
 
+    /// GROVE_V4: the fixed frontier cost model — every save, the first
+    /// included, is a replacement of the model size, whatever was loaded and
+    /// whatever is written.
+    #[test]
+    fn v4_saves_replace_the_model_size() {
+        let paid = crate::MODEL_FRONTIER_SERIALIZED_LEN + 2;
+        for (persisted, new_len) in [(None, 74), (Some(74), 106), (Some(1066), 74)] {
+            let c = frontier_save_cost_info(persisted, new_len, &GROVE_V4)
+                .unwrap()
+                .unwrap();
+            assert_eq!(c.value_storage_cost.replaced_bytes, paid);
+            assert_eq!(c.value_storage_cost.added_bytes, 0);
+            assert!(!c.new_node);
+        }
+        assert_eq!(crate::MODEL_FRONTIER_SERIALIZED_LEN, 554);
+        assert_eq!(crate::MODEL_FRONTIER_APPEND_SINSEMILLA_HASHES, 33);
+    }
+
     #[test]
     fn unknown_version_is_rejected() {
-        let mut bad = GROVE_V4.clone();
+        let mut bad = v4_actual_frontier();
         bad.commitment_tree_versions
             .cost
             .frontier_save_storage_accounting = 99;
         assert!(matches!(
             frontier_save_cost_info(Some(74), 74, &bad),
+            Err(CommitmentTreeError::VersionError(_))
+        ));
+        let mut bad = GROVE_V4.clone();
+        bad.commitment_tree_versions.cost.frontier_cost_model = 99;
+        assert!(matches!(
+            frontier_save_cost_info(Some(74), 74, &bad),
+            Err(CommitmentTreeError::VersionError(_))
+        ));
+        assert!(matches!(
+            frontier_cost_model(&bad),
             Err(CommitmentTreeError::VersionError(_))
         ));
     }

--- a/grovedb-commitment-tree/src/commitment_tree/mod.rs
+++ b/grovedb-commitment-tree/src/commitment_tree/mod.rs
@@ -175,13 +175,23 @@ impl<'db, S: StorageContext<'db>, M: MemoSize> CommitmentTree<S, M> {
     /// `BulkAppendTree` (height parameter).
     pub fn new(chunk_power: u8, storage: S) -> Result<Self, CommitmentTreeError> {
         let bulk_tree = BulkAppendTree::new(chunk_power, storage)
-            .map_err(|e| CommitmentTreeError::InvalidData(format!("bulk tree new: {}", e)))?;
+            .map_err(|e| CommitmentTreeError::InvalidData(format!("bulk tree new: {}", e)))?
+            .with_fixed_entry_size(Self::entry_size());
         Ok(Self {
             frontier: CommitmentFrontier::new(),
             bulk_tree,
             persisted_frontier_len: None,
             _memo: PhantomData,
         })
+    }
+
+    /// The one size every bulk-tree entry of this memo type has:
+    /// `cmx || rho || cv_net || payload` — 96 bytes plus the fixed
+    /// ciphertext payload. `append_raw` / `append_many_raw` reject any other
+    /// payload length, so the bulk tree is told the size and charges no
+    /// per-entry blob framing under the fixed cost model.
+    pub fn entry_size() -> u32 {
+        (96 + ciphertext_payload_size::<M>()) as u32
     }
 
     /// Load a commitment tree from storage, or start with an empty frontier if
@@ -198,7 +208,7 @@ impl<'db, S: StorageContext<'db>, M: MemoSize> CommitmentTree<S, M> {
         let mut cost = OperationCost::default();
 
         let bulk_tree = match BulkAppendTree::from_state(total_count, chunk_power, storage) {
-            Ok(t) => t,
+            Ok(t) => t.with_fixed_entry_size(Self::entry_size()),
             Err(e) => {
                 return Err(CommitmentTreeError::InvalidData(format!(
                     "bulk tree from_state: {}",
@@ -334,6 +344,14 @@ impl<'db, S: StorageContext<'db>, M: MemoSize> CommitmentTree<S, M> {
             .wrap_with_cost(cost);
         }
 
+        // Every version gate this append consults is resolved BEFORE the
+        // first write, so an unknown version rejects a pristine tree rather
+        // than one whose bulk tree has moved while its frontier has not.
+        let fixed_model = match cost::frontier_cost_model(grove_version) {
+            Ok(f) => f,
+            Err(e) => return Err(e).wrap_with_cost(cost),
+        };
+
         // 1. Build cmx||rho||cv_net||payload and append to BulkAppendTree
         let mut item_value = Vec::with_capacity(96 + payload.len());
         item_value.extend_from_slice(&cmx);
@@ -367,10 +385,6 @@ impl<'db, S: StorageContext<'db>, M: MemoSize> CommitmentTree<S, M> {
         //    charged as performed (`32 + trailing_ones(position)`) or, under
         //    the fixed frontier cost model, at the depth-derived model so the
         //    charge does not depend on the position.
-        let fixed_model = match cost::frontier_cost_model(grove_version) {
-            Ok(f) => f,
-            Err(e) => return Err(e).wrap_with_cost(cost),
-        };
         let sinsemilla_root = match self.frontier.append(cmx) {
             grovedb_costs::CostContext {
                 value: Ok(root),

--- a/grovedb-commitment-tree/src/commitment_tree/mod.rs
+++ b/grovedb-commitment-tree/src/commitment_tree/mod.rs
@@ -193,6 +193,7 @@ impl<'db, S: StorageContext<'db>, M: MemoSize> CommitmentTree<S, M> {
         total_count: u64,
         chunk_power: u8,
         storage: S,
+        grove_version: &GroveVersion,
     ) -> CostResult<Self, CommitmentTreeError> {
         let mut cost = OperationCost::default();
 
@@ -207,12 +208,21 @@ impl<'db, S: StorageContext<'db>, M: MemoSize> CommitmentTree<S, M> {
             }
         };
 
-        // Read frontier from the bulk tree's storage
-        let data = bulk_tree
-            .dense_tree
-            .storage
-            .get(COMMITMENT_TREE_DATA_KEY)
-            .unwrap_add_cost(&mut cost);
+        // Read frontier from the bulk tree's storage. Under the fixed
+        // frontier cost model the read is charged at the model size
+        // whatever the position's actual serialized size.
+        let fixed_model = match cost::frontier_cost_model(grove_version) {
+            Ok(f) => f,
+            Err(e) => return Err(e).wrap_with_cost(cost),
+        };
+        let read = bulk_tree.dense_tree.storage.get(COMMITMENT_TREE_DATA_KEY);
+        if fixed_model {
+            cost.seek_count += 1;
+            cost.storage_loaded_bytes += crate::MODEL_FRONTIER_SERIALIZED_LEN as u64;
+        } else {
+            cost += read.cost;
+        }
+        let data = read.value;
 
         let (frontier, persisted_frontier_len) = match data {
             Ok(Some(bytes)) => match CommitmentFrontier::deserialize(&bytes) {
@@ -353,13 +363,24 @@ impl<'db, S: StorageContext<'db>, M: MemoSize> CommitmentTree<S, M> {
         // accounting (GROVE_V1..V3). See `BulkAppendTree` issue #822.
         cost += bulk_result.storage_accounting_cost;
 
-        // 2. Append cmx to Sinsemilla frontier (tracks sinsemilla_hash_calls)
+        // 2. Append cmx to Sinsemilla frontier. The Sinsemilla hashes are
+        //    charged as performed (`32 + trailing_ones(position)`) or, under
+        //    the fixed frontier cost model, at the depth-derived model so the
+        //    charge does not depend on the position.
+        let fixed_model = match cost::frontier_cost_model(grove_version) {
+            Ok(f) => f,
+            Err(e) => return Err(e).wrap_with_cost(cost),
+        };
         let sinsemilla_root = match self.frontier.append(cmx) {
             grovedb_costs::CostContext {
                 value: Ok(root),
                 cost: frontier_cost,
             } => {
-                cost += frontier_cost;
+                if fixed_model {
+                    cost.sinsemilla_hash_calls += crate::MODEL_FRONTIER_APPEND_SINSEMILLA_HASHES;
+                } else {
+                    cost += frontier_cost;
+                }
                 root
             }
             // codecov:ignore — CommitmentFrontier::append can only fail with InvalidFieldElement
@@ -448,6 +469,10 @@ impl<'db, S: StorageContext<'db>, M: MemoSize> CommitmentTree<S, M> {
     {
         let mut cost = OperationCost::default();
         let expected_payload = ciphertext_payload_size::<M>();
+        let fixed_model = match cost::frontier_cost_model(grove_version) {
+            Ok(f) => f,
+            Err(e) => return Err(e).wrap_with_cost(cost),
+        };
 
         let mut appended: u64 = 0;
         let mut hash_count: u32 = 0;
@@ -514,8 +539,16 @@ impl<'db, S: StorageContext<'db>, M: MemoSize> CommitmentTree<S, M> {
 
             // 2. Append cmx to the Sinsemilla frontier, deferring the depth-32
             //    root walk. Validation here is now redundant with the pre-check
-            //    above but is cheap and keeps the cost accounting correct.
-            if let Err(e) = self.frontier.append_no_root(cmx).unwrap_add_cost(&mut cost) {
+            //    above but is cheap and keeps the cost accounting correct. The
+            //    carry-chain hashes are charged as performed, or — under the
+            //    fixed frontier cost model — at their average (one per leaf).
+            let no_root = self.frontier.append_no_root(cmx);
+            if fixed_model {
+                cost.sinsemilla_hash_calls += 1;
+            } else {
+                cost += no_root.cost;
+            }
+            if let Err(e) = no_root.value {
                 // codecov:ignore — `append_no_root` can only error on
                 // `InvalidFieldElement` (already filtered by the pre-validation
                 // above) or `TreeFull` (2^32 leaves, unreachable).
@@ -690,9 +723,10 @@ impl<'db, S: StorageContext<'db>, M: MemoSize> CommitmentTree<S, M> {
     /// `BulkAppendTree::buffer_record_mismatch`.
     pub fn buffer_record_mismatch(
         &self,
+        grove_version: &GroveVersion,
     ) -> Result<Option<grovedb_bulk_append_tree::BufferRecordMismatch>, CommitmentTreeError> {
         self.bulk_tree
-            .buffer_record_mismatch()
+            .buffer_record_mismatch(grove_version)
             .map_err(|e| CommitmentTreeError::InvalidData(format!("record audit: {}", e)))
     }
 

--- a/grovedb-commitment-tree/src/commitment_tree/tests.rs
+++ b/grovedb-commitment-tree/src/commitment_tree/tests.rs
@@ -487,7 +487,8 @@ mod storage_tests {
     #[test]
     fn test_open_empty_store() {
         let ctx = MockDataStorageContext::new();
-        let result = CommitmentTree::<_, DashMemo>::open(0, TEST_CHUNK_POWER, ctx);
+        let result =
+            CommitmentTree::<_, DashMemo>::open(0, TEST_CHUNK_POWER, ctx, GroveVersion::latest());
         let ct = result.value.expect("open should succeed on empty store");
 
         assert_eq!(
@@ -508,7 +509,8 @@ mod storage_tests {
         let ctx = MockDataStorageContext::new();
 
         // Build a frontier with several leaves, save, then re-open
-        let result = CommitmentTree::<_, DashMemo>::open(0, TEST_CHUNK_POWER, ctx);
+        let result =
+            CommitmentTree::<_, DashMemo>::open(0, TEST_CHUNK_POWER, ctx, GroveVersion::latest());
         let mut ct = result.value.expect("open should succeed");
         for i in 0..20u64 {
             ct.append(
@@ -536,8 +538,12 @@ mod storage_tests {
 
         // Re-open from the same storage (extract from bulk tree)
         let storage = ct.bulk_tree.dense_tree.storage;
-        let load_result =
-            CommitmentTree::<_, DashMemo>::open(expected_total_count, TEST_CHUNK_POWER, storage);
+        let load_result = CommitmentTree::<_, DashMemo>::open(
+            expected_total_count,
+            TEST_CHUNK_POWER,
+            storage,
+            GroveVersion::latest(),
+        );
         let loaded = load_result.value.expect("open should succeed");
 
         assert_eq!(loaded.root_hash(), expected_root, "root hash should match");
@@ -556,9 +562,10 @@ mod storage_tests {
     #[test]
     fn test_save_overwrite_and_load() {
         let ctx = MockDataStorageContext::new();
-        let mut ct = CommitmentTree::<_, DashMemo>::open(0, TEST_CHUNK_POWER, ctx)
-            .value
-            .expect("open should succeed");
+        let mut ct =
+            CommitmentTree::<_, DashMemo>::open(0, TEST_CHUNK_POWER, ctx, GroveVersion::latest())
+                .value
+                .expect("open should succeed");
 
         // Save empty
         ct.save(GroveVersion::latest())
@@ -583,9 +590,14 @@ mod storage_tests {
 
         // Re-open should return the latest (non-empty) frontier
         let storage = ct.bulk_tree.dense_tree.storage;
-        let loaded = CommitmentTree::<_, DashMemo>::open(total_count, TEST_CHUNK_POWER, storage)
-            .value
-            .expect("open should succeed");
+        let loaded = CommitmentTree::<_, DashMemo>::open(
+            total_count,
+            TEST_CHUNK_POWER,
+            storage,
+            GroveVersion::latest(),
+        )
+        .value
+        .expect("open should succeed");
         assert_eq!(
             loaded.root_hash(),
             expected_root,
@@ -597,7 +609,8 @@ mod storage_tests {
     fn test_open_corrupted_data_returns_error() {
         let ctx =
             MockDataStorageContext::with_raw_data(COMMITMENT_TREE_DATA_KEY, vec![0x01, 0x02, 0x03]);
-        let result = CommitmentTree::<_, DashMemo>::open(0, TEST_CHUNK_POWER, ctx);
+        let result =
+            CommitmentTree::<_, DashMemo>::open(0, TEST_CHUNK_POWER, ctx, GroveVersion::latest());
         assert!(
             result.value.is_err(),
             "should return error for corrupted data"
@@ -607,7 +620,8 @@ mod storage_tests {
     #[test]
     fn test_open_storage_error_surfaces() {
         let ctx = FailingDataStorageContext;
-        let result = CommitmentTree::<_, DashMemo>::open(0, TEST_CHUNK_POWER, ctx);
+        let result =
+            CommitmentTree::<_, DashMemo>::open(0, TEST_CHUNK_POWER, ctx, GroveVersion::latest());
         assert!(result.value.is_err(), "should surface storage get error");
         let err_msg = format!("{}", result.value.expect_err("should be storage error"));
         assert!(
@@ -666,18 +680,24 @@ mod storage_tests {
     #[test]
     fn test_save_empty_and_reopen() {
         let ctx = MockDataStorageContext::new();
-        let ct = CommitmentTree::<_, DashMemo>::open(0, TEST_CHUNK_POWER, ctx)
-            .value
-            .expect("open should succeed");
+        let ct =
+            CommitmentTree::<_, DashMemo>::open(0, TEST_CHUNK_POWER, ctx, GroveVersion::latest())
+                .value
+                .expect("open should succeed");
 
         ct.save(GroveVersion::latest())
             .value
             .expect("save empty should succeed");
 
         let storage = ct.bulk_tree.dense_tree.storage;
-        let loaded = CommitmentTree::<_, DashMemo>::open(0, TEST_CHUNK_POWER, storage)
-            .value
-            .expect("open should succeed");
+        let loaded = CommitmentTree::<_, DashMemo>::open(
+            0,
+            TEST_CHUNK_POWER,
+            storage,
+            GroveVersion::latest(),
+        )
+        .value
+        .expect("open should succeed");
         assert_eq!(
             loaded.position(),
             None,
@@ -693,9 +713,10 @@ mod storage_tests {
     #[test]
     fn test_roundtrip_with_many_leaves() {
         let ctx = MockDataStorageContext::new();
-        let mut ct = CommitmentTree::<_, DashMemo>::open(0, TEST_CHUNK_POWER, ctx)
-            .value
-            .expect("open should succeed");
+        let mut ct =
+            CommitmentTree::<_, DashMemo>::open(0, TEST_CHUNK_POWER, ctx, GroveVersion::latest())
+                .value
+                .expect("open should succeed");
 
         for i in 0..500u64 {
             ct.append(
@@ -715,9 +736,14 @@ mod storage_tests {
             .expect("save should succeed");
 
         let storage = ct.bulk_tree.dense_tree.storage;
-        let loaded = CommitmentTree::<_, DashMemo>::open(total_count, TEST_CHUNK_POWER, storage)
-            .value
-            .expect("open should succeed");
+        let loaded = CommitmentTree::<_, DashMemo>::open(
+            total_count,
+            TEST_CHUNK_POWER,
+            storage,
+            GroveVersion::latest(),
+        )
+        .value
+        .expect("open should succeed");
 
         // Build an identical frontier to compare root hashes
         let mut expected = CommitmentFrontier::new();
@@ -735,9 +761,10 @@ mod storage_tests {
     #[test]
     fn test_append_returns_result_with_position() {
         let ctx = MockDataStorageContext::new();
-        let mut ct = CommitmentTree::<_, DashMemo>::open(0, TEST_CHUNK_POWER, ctx)
-            .value
-            .expect("open should succeed");
+        let mut ct =
+            CommitmentTree::<_, DashMemo>::open(0, TEST_CHUNK_POWER, ctx, GroveVersion::latest())
+                .value
+                .expect("open should succeed");
 
         let r0 = ct
             .append(
@@ -787,9 +814,10 @@ mod storage_tests {
     #[test]
     fn test_append_raw_rejects_wrong_payload_size() {
         let ctx = MockDataStorageContext::new();
-        let mut ct = CommitmentTree::<_, DashMemo>::open(0, TEST_CHUNK_POWER, ctx)
-            .value
-            .expect("open should succeed");
+        let mut ct =
+            CommitmentTree::<_, DashMemo>::open(0, TEST_CHUNK_POWER, ctx, GroveVersion::latest())
+                .value
+                .expect("open should succeed");
 
         // Too small
         let result = ct.append_raw(
@@ -883,9 +911,10 @@ mod storage_tests {
     #[test]
     fn test_get_buffer_value_empty_tree() {
         let ctx = MockDataStorageContext::new();
-        let ct = CommitmentTree::<_, DashMemo>::open(0, TEST_CHUNK_POWER, ctx)
-            .value
-            .expect("open should succeed");
+        let ct =
+            CommitmentTree::<_, DashMemo>::open(0, TEST_CHUNK_POWER, ctx, GroveVersion::latest())
+                .value
+                .expect("open should succeed");
 
         let result = ct
             .get_buffer_value(0)
@@ -896,9 +925,10 @@ mod storage_tests {
     #[test]
     fn test_get_buffer_value_after_appends() {
         let ctx = MockDataStorageContext::new();
-        let mut ct = CommitmentTree::<_, DashMemo>::open(0, TEST_CHUNK_POWER, ctx)
-            .value
-            .expect("open should succeed");
+        let mut ct =
+            CommitmentTree::<_, DashMemo>::open(0, TEST_CHUNK_POWER, ctx, GroveVersion::latest())
+                .value
+                .expect("open should succeed");
 
         // Append one item (goes into buffer since epoch_size = 2 for chunk_power=1)
         ct.append(
@@ -926,9 +956,10 @@ mod storage_tests {
     #[test]
     fn test_get_chunk_value_empty_tree() {
         let ctx = MockDataStorageContext::new();
-        let ct = CommitmentTree::<_, DashMemo>::open(0, TEST_CHUNK_POWER, ctx)
-            .value
-            .expect("open should succeed");
+        let ct =
+            CommitmentTree::<_, DashMemo>::open(0, TEST_CHUNK_POWER, ctx, GroveVersion::latest())
+                .value
+                .expect("open should succeed");
 
         let result = ct
             .get_chunk_value(0)
@@ -939,9 +970,10 @@ mod storage_tests {
     #[test]
     fn test_get_chunk_value_after_compaction() {
         let ctx = MockDataStorageContext::new();
-        let mut ct = CommitmentTree::<_, DashMemo>::open(0, TEST_CHUNK_POWER, ctx)
-            .value
-            .expect("open should succeed");
+        let mut ct =
+            CommitmentTree::<_, DashMemo>::open(0, TEST_CHUNK_POWER, ctx, GroveVersion::latest())
+                .value
+                .expect("open should succeed");
 
         // chunk_power=1 → epoch_size=2. Append 2 items to trigger compaction.
         ct.append(
@@ -979,9 +1011,10 @@ mod storage_tests {
     #[test]
     fn test_compute_current_state_root_empty() {
         let ctx = MockDataStorageContext::new();
-        let ct = CommitmentTree::<_, DashMemo>::open(0, TEST_CHUNK_POWER, ctx)
-            .value
-            .expect("open should succeed");
+        let ct =
+            CommitmentTree::<_, DashMemo>::open(0, TEST_CHUNK_POWER, ctx, GroveVersion::latest())
+                .value
+                .expect("open should succeed");
 
         let root = ct
             .compute_current_state_root(GroveVersion::latest())
@@ -993,9 +1026,10 @@ mod storage_tests {
     #[test]
     fn test_compute_current_state_root_matches_append_result() {
         let ctx = MockDataStorageContext::new();
-        let mut ct = CommitmentTree::<_, DashMemo>::open(0, TEST_CHUNK_POWER, ctx)
-            .value
-            .expect("open should succeed");
+        let mut ct =
+            CommitmentTree::<_, DashMemo>::open(0, TEST_CHUNK_POWER, ctx, GroveVersion::latest())
+                .value
+                .expect("open should succeed");
 
         let r = ct
             .append(
@@ -1022,9 +1056,10 @@ mod storage_tests {
     #[test]
     fn test_epoch_size_and_chunk_count() {
         let ctx = MockDataStorageContext::new();
-        let mut ct = CommitmentTree::<_, DashMemo>::open(0, TEST_CHUNK_POWER, ctx)
-            .value
-            .expect("open should succeed");
+        let mut ct =
+            CommitmentTree::<_, DashMemo>::open(0, TEST_CHUNK_POWER, ctx, GroveVersion::latest())
+                .value
+                .expect("open should succeed");
 
         assert_eq!(ct.epoch_size(), 2, "chunk_power=1 → epoch_size=2");
         assert_eq!(ct.chunk_count(), 0, "no chunks initially");
@@ -1077,9 +1112,10 @@ mod storage_tests {
     #[test]
     fn test_anchor_on_commitment_tree() {
         let ctx = MockDataStorageContext::new();
-        let mut ct = CommitmentTree::<_, DashMemo>::open(0, TEST_CHUNK_POWER, ctx)
-            .value
-            .expect("open should succeed");
+        let mut ct =
+            CommitmentTree::<_, DashMemo>::open(0, TEST_CHUNK_POWER, ctx, GroveVersion::latest())
+                .value
+                .expect("open should succeed");
 
         let empty_anchor = ct.anchor();
         assert_eq!(
@@ -1109,9 +1145,10 @@ mod storage_tests {
     #[test]
     fn test_debug_fmt() {
         let ctx = MockDataStorageContext::new();
-        let mut ct = CommitmentTree::<_, DashMemo>::open(0, TEST_CHUNK_POWER, ctx)
-            .value
-            .expect("open should succeed");
+        let mut ct =
+            CommitmentTree::<_, DashMemo>::open(0, TEST_CHUNK_POWER, ctx, GroveVersion::latest())
+                .value
+                .expect("open should succeed");
 
         // Debug on empty tree
         let s = format!("{:?}", ct);
@@ -1143,7 +1180,7 @@ mod storage_tests {
     fn test_open_from_state_error_invalid_chunk_power() {
         let ctx = MockDataStorageContext::new();
         // chunk_power=0 is invalid (must be 1..=16), causing from_state to fail
-        let result = CommitmentTree::<_, DashMemo>::open(0, 0, ctx);
+        let result = CommitmentTree::<_, DashMemo>::open(0, 0, ctx, GroveVersion::latest());
         let err = result
             .value
             .expect_err("should fail with invalid chunk_power");
@@ -1159,9 +1196,10 @@ mod storage_tests {
     fn test_open_frontier_total_count_mismatch() {
         // 1. Create a tree, append 1 item, save
         let ctx = MockDataStorageContext::new();
-        let mut ct = CommitmentTree::<_, DashMemo>::open(0, TEST_CHUNK_POWER, ctx)
-            .value
-            .expect("open should succeed");
+        let mut ct =
+            CommitmentTree::<_, DashMemo>::open(0, TEST_CHUNK_POWER, ctx, GroveVersion::latest())
+                .value
+                .expect("open should succeed");
         ct.append(
             test_leaf(0),
             test_rho(0),
@@ -1177,7 +1215,12 @@ mod storage_tests {
 
         // 2. Re-open with total_count=0 but the frontier has tree_size=1
         let storage = ct.bulk_tree.dense_tree.storage;
-        let result = CommitmentTree::<_, DashMemo>::open(0, TEST_CHUNK_POWER, storage);
+        let result = CommitmentTree::<_, DashMemo>::open(
+            0,
+            TEST_CHUNK_POWER,
+            storage,
+            GroveVersion::latest(),
+        );
         let err = result
             .value
             .expect_err("should fail with frontier/total_count mismatch");
@@ -1192,9 +1235,10 @@ mod storage_tests {
     #[test]
     fn test_append_raw_rejects_invalid_cmx() {
         let ctx = MockDataStorageContext::new();
-        let mut ct = CommitmentTree::<_, DashMemo>::open(0, TEST_CHUNK_POWER, ctx)
-            .value
-            .expect("open should succeed");
+        let mut ct =
+            CommitmentTree::<_, DashMemo>::open(0, TEST_CHUNK_POWER, ctx, GroveVersion::latest())
+                .value
+                .expect("open should succeed");
 
         // All 0xFF is not a valid Pallas field element
         let payload = vec![0u8; ciphertext_payload_size::<DashMemo>()];

--- a/grovedb-commitment-tree/src/commitment_tree/tests.rs
+++ b/grovedb-commitment-tree/src/commitment_tree/tests.rs
@@ -811,6 +811,68 @@ mod storage_tests {
         assert_eq!(ct.total_count(), 0);
     }
 
+    /// Every version gate an append consults is resolved before its first
+    /// write: an unknown frontier cost model rejects the append with the
+    /// tree untouched — bulk count, anchor and frontier all as before — so a
+    /// retry under a known version does not append a duplicate.
+    #[test]
+    fn test_append_rejects_unknown_frontier_cost_model_before_mutating() {
+        let ctx = MockDataStorageContext::new();
+        let mut ct =
+            CommitmentTree::<_, DashMemo>::open(0, TEST_CHUNK_POWER, ctx, GroveVersion::latest())
+                .value
+                .expect("open should succeed");
+        ct.append(
+            test_leaf(0),
+            test_rho(0),
+            test_cv_net(0),
+            &test_ciphertext(0),
+            GroveVersion::latest(),
+        )
+        .value
+        .expect("append should succeed");
+        let anchor_before = ct.anchor();
+        let count_before = ct.total_count();
+        let bulk_root_before = ct
+            .bulk_tree
+            .compute_current_state_root(GroveVersion::latest())
+            .expect("root");
+
+        let mut bad = GroveVersion::latest().clone();
+        bad.commitment_tree_versions.cost.frontier_cost_model = 99;
+        let result = ct.append(
+            test_leaf(1),
+            test_rho(1),
+            test_cv_net(1),
+            &test_ciphertext(1),
+            &bad,
+        );
+        assert!(
+            matches!(result.value, Err(CommitmentTreeError::VersionError(_))),
+            "unknown version must be rejected: {:?}",
+            result.value
+        );
+        assert_eq!(ct.total_count(), count_before, "bulk tree untouched");
+        assert_eq!(ct.anchor(), anchor_before, "frontier untouched");
+        assert_eq!(
+            ct.bulk_tree
+                .compute_current_state_root(GroveVersion::latest())
+                .expect("root"),
+            bulk_root_before
+        );
+        // And a retry under a known version appends exactly once.
+        ct.append(
+            test_leaf(1),
+            test_rho(1),
+            test_cv_net(1),
+            &test_ciphertext(1),
+            GroveVersion::latest(),
+        )
+        .value
+        .expect("retry should succeed");
+        assert_eq!(ct.total_count(), count_before + 1);
+    }
+
     #[test]
     fn test_append_raw_rejects_wrong_payload_size() {
         let ctx = MockDataStorageContext::new();

--- a/grovedb-commitment-tree/src/lib.rs
+++ b/grovedb-commitment-tree/src/lib.rs
@@ -31,6 +31,18 @@ pub(crate) mod test_utils;
 pub use client::ClientPersistentCommitmentTree;
 #[cfg(feature = "sqlite")]
 pub use client::{SqliteShardStore, SqliteShardStoreError};
+/// The fixed per-append Sinsemilla charge of the frontier under the
+/// `frontier_cost_model` gate (GROVE_V4): the depth-deep root walk plus the
+/// average ommer merge — `trailing_ones(position)` averages to one over the
+/// position space.
+pub const MODEL_FRONTIER_APPEND_SINSEMILLA_HASHES: u32 = NOTE_COMMITMENT_TREE_DEPTH as u32 + 1;
+
+/// The fixed serialized frontier size charged under the `frontier_cost_model`
+/// gate (GROVE_V4), loaded at open and replaced at save: the 42-byte fixed
+/// part plus 32 bytes per ommer at the average ommer count over the position
+/// space (`depth / 2`).
+pub const MODEL_FRONTIER_SERIALIZED_LEN: u32 = 42 + 32 * (NOTE_COMMITMENT_TREE_DEPTH as u32 / 2);
+
 pub use commitment_frontier::*;
 
 /// Pre-computed state root for an empty CommitmentTree.

--- a/grovedb-dense-fixed-sized-merkle-tree/src/lib.rs
+++ b/grovedb-dense-fixed-sized-merkle-tree/src/lib.rs
@@ -33,5 +33,10 @@ mod tests;
 pub use error::DenseMerkleError;
 pub use proof::DenseTreeProof;
 #[cfg(feature = "storage")]
+pub use tree::root_maintenance::{v1_insert_model_cost, V1InsertModel};
+#[cfg(feature = "storage")]
 pub use tree::SlotWriteAccounting;
-pub use tree::{position_key, record_key, DenseFixedSizedMerkleTree, HashRecord, HASH_RECORD_LEN};
+pub use tree::{
+    depth_of, last_filled_in_subtree, path_record_len, position_key, record_key,
+    DenseFixedSizedMerkleTree, PathRecord, HASH_RECORD_KEY_PREFIX, PATH_RECORD_HEADER_LEN,
+};

--- a/grovedb-dense-fixed-sized-merkle-tree/src/root_maintenance_tests.rs
+++ b/grovedb-dense-fixed-sized-merkle-tree/src/root_maintenance_tests.rs
@@ -1,15 +1,17 @@
-//! Tests for the versioned root maintenance: version 1 (per-position hash
-//! records, GROVE_V4+) must produce exactly the roots version 0 (recompute
+//! Tests for the versioned root maintenance: version 1 (one path record per
+//! insert, GROVE_V4+) must produce exactly the roots version 0 (recompute
 //! from every filled position, GROVE_V1..V3) produces, under every fill
 //! level, across sessions, after a buffer filled under version 0, and over
-//! records left by an earlier epoch — while doing O(height) work per insert.
+//! records left by an earlier epoch — while doing O(height) work per insert
+//! and charging a fixed, height-derived figure for it.
 
 use grovedb_costs::storage_cost::key_value_cost::KeyValueStorageCost;
 use grovedb_version::version::GroveVersion;
 
 use crate::{
-    position_key, record_key, test_utils::MemStorageContext, DenseFixedSizedMerkleTree,
-    DenseMerkleError, HashRecord, SlotWriteAccounting, HASH_RECORD_LEN,
+    depth_of, last_filled_in_subtree, path_record_len, position_key, record_key,
+    test_utils::MemStorageContext, v1_insert_model_cost, DenseFixedSizedMerkleTree,
+    DenseMerkleError, PathRecord, SlotWriteAccounting, V1InsertModel,
 };
 
 /// GROVE_V1: root-maintenance version 0.
@@ -33,11 +35,6 @@ fn value(pos: u16, salt: u8) -> Vec<u8> {
     v
 }
 
-/// Depth of a BFS position (root = 0).
-fn depth(pos: u16) -> u32 {
-    (pos as u32 + 1).ilog2()
-}
-
 /// Record puts (3-byte keys) made on `ctx`, in order.
 fn record_puts(ctx: &MemStorageContext) -> Vec<(u16, Option<KeyValueStorageCost>)> {
     ctx.puts
@@ -48,7 +45,7 @@ fn record_puts(ctx: &MemStorageContext) -> Vec<(u16, Option<KeyValueStorageCost>
         .collect()
 }
 
-/// Storage gets of hash records (3-byte keys) made on `ctx`, in order.
+/// Storage gets of path records (3-byte keys) made on `ctx`, in order.
 fn record_gets(ctx: &MemStorageContext) -> Vec<u16> {
     ctx.gets
         .borrow()
@@ -73,12 +70,12 @@ fn clear_logs(ctx: &MemStorageContext) {
     ctx.gets.borrow_mut().clear();
 }
 
-/// The stored record for `pos`, if any.
-fn stored_record(ctx: &MemStorageContext, pos: u16) -> Option<HashRecord> {
+/// The stored record for the insert at `pos`, if any, for a tree of `height`.
+fn stored_record(ctx: &MemStorageContext, pos: u16, height: u8) -> Option<PathRecord> {
     ctx.data
         .borrow()
         .get(record_key(pos).as_slice())
-        .and_then(|b| HashRecord::from_bytes(b))
+        .and_then(|b| PathRecord::from_bytes(b, height))
 }
 
 // ── Equivalence ────────────────────────────────────────────────────────
@@ -98,8 +95,8 @@ fn v1_roots_equal_v0_roots_at_every_fill_level_and_across_sessions() {
             let v = value(pos, 7);
             let (legacy_root, _) = legacy.insert(&v, v0()).unwrap().unwrap();
 
-            // A fresh session per insert: the ancestor records must be found
-            // in storage, not in a cache.
+            // A fresh session per insert: the path records must be found in
+            // storage, not in a cache.
             let mut tree = DenseFixedSizedMerkleTree::from_state(height, pos, ctx).unwrap();
             let (root, at) = tree.insert(&v, v1()).unwrap().unwrap();
             assert_eq!(at, pos);
@@ -113,6 +110,11 @@ fn v1_roots_equal_v0_roots_at_every_fill_level_and_across_sessions() {
                 tree.root_hash(v0()).unwrap().unwrap(),
                 legacy_root,
                 "height {height} pos {pos}: value walk over v1 storage"
+            );
+            assert_eq!(
+                tree.recorded_root().unwrap().unwrap(),
+                Some(legacy_root),
+                "height {height} pos {pos}: recorded root"
             );
             ctx = tree.storage;
 
@@ -153,7 +155,7 @@ fn v1_roots_equal_v0_roots_within_one_session() {
     }
 }
 
-/// `try_insert_no_root` under version 1 maintains the records exactly as
+/// `try_insert_no_root` under version 1 writes the path record exactly as
 /// `insert` does — a later root read finds the record and does not walk.
 #[test]
 fn try_insert_no_root_maintains_records_under_v1() {
@@ -173,12 +175,32 @@ fn try_insert_no_root_maintains_records_under_v1() {
     assert_eq!(ctx.value.unwrap(), legacy.root_hash(v0()).unwrap().unwrap());
 }
 
+/// `last_filled_in_subtree` locates the insert whose record holds a
+/// subtree's current hash: the largest filled position below it.
+#[test]
+fn last_filled_in_subtree_is_the_largest_filled_descendant() {
+    // Height 4, 11 filled (positions 0..=10).
+    assert_eq!(last_filled_in_subtree(0, 11, 4), Some(10));
+    assert_eq!(last_filled_in_subtree(1, 11, 4), Some(10)); // subtree of 1: 3,4,7..10
+    assert_eq!(last_filled_in_subtree(2, 11, 4), Some(6)); // subtree of 2: 5,6,11..14
+    assert_eq!(last_filled_in_subtree(5, 11, 4), Some(5)); // children 11,12 not filled
+    assert_eq!(last_filled_in_subtree(3, 11, 4), Some(8)); // children 7,8
+    assert_eq!(last_filled_in_subtree(4, 11, 4), Some(10)); // children 9,10
+    assert_eq!(last_filled_in_subtree(10, 11, 4), Some(10));
+    assert_eq!(last_filled_in_subtree(11, 11, 4), None);
+    assert_eq!(depth_of(0), 0);
+    assert_eq!(depth_of(2), 1);
+    assert_eq!(depth_of(6), 2);
+    assert_eq!(depth_of(7), 3);
+}
+
 // ── Legacy buffers ─────────────────────────────────────────────────────
 
 /// A buffer filled under version 0 has no records. The first version-1
-/// insert derives what it needs from the values (costing no more than the
-/// version-0 walk), records it, and every later insert is O(height) again;
-/// the roots match version 0 throughout.
+/// insert derives what it needs from the values (the walk) and records it;
+/// every later insert is O(height) again and reads no value back; the roots
+/// match version 0 throughout — and every insert is charged the same fixed
+/// model.
 #[test]
 fn buffer_filled_under_v0_is_caught_up_by_the_first_v1_insert() {
     const HEIGHT: u8 = 5;
@@ -191,7 +213,7 @@ fn buffer_filled_under_v0_is_caught_up_by_the_first_v1_insert() {
     }
     let ctx = under_test.storage;
     assert!(
-        (0..LEGACY_FILL).all(|p| stored_record(&ctx, p).is_none()),
+        (0..LEGACY_FILL).all(|p| stored_record(&ctx, p, HEIGHT).is_none()),
         "version 0 writes no records"
     );
     // A version-1 root read of the legacy buffer falls back to the walk.
@@ -202,9 +224,11 @@ fn buffer_filled_under_v0_is_caught_up_by_the_first_v1_insert() {
         read.value.unwrap(),
         legacy.root_hash(v0()).unwrap().unwrap()
     );
+    assert_eq!(reopened.recorded_root().unwrap().unwrap(), None);
     let ctx = reopened.storage;
 
-    // First version-1 insert: catch-up.
+    // First version-1 insert: catch-up — reads legacy values, writes only
+    // its own record, and is charged the model.
     let mut tree = DenseFixedSizedMerkleTree::from_state(HEIGHT, LEGACY_FILL, ctx).unwrap();
     clear_logs(&tree.storage);
     let v = value(LEGACY_FILL, 9);
@@ -212,21 +236,20 @@ fn buffer_filled_under_v0_is_caught_up_by_the_first_v1_insert() {
     let first = tree.insert(&v, v1());
     let (root, _) = first.value.unwrap();
     assert_eq!(root, legacy_root);
-    // No more hashing than the version-0 walk over the now-filled buffer.
+    assert_eq!(first.cost, v1_insert_model_cost(HEIGHT), "billed the model");
     assert!(
-        first.cost.hash_node_calls <= 2 * (LEGACY_FILL as u32 + 1),
-        "catch-up must not exceed the version-0 walk: {:?}",
-        first.cost
+        !value_gets(&tree.storage).is_empty(),
+        "the catch-up walks values"
     );
-    // Every position on the path and every off-path sibling subtree root now
-    // has a current record; later inserts need nothing else.
-    let touched: Vec<u16> = record_puts(&tree.storage)
-        .into_iter()
-        .map(|(p, _)| p)
-        .collect();
-    assert!(touched.contains(&0) && touched.contains(&LEGACY_FILL));
+    assert_eq!(
+        record_puts(&tree.storage).len(),
+        1,
+        "the catch-up writes nothing but the insert's own record"
+    );
 
-    // Second version-1 insert: O(height).
+    // Second version-1 insert: one record put, the model, and only legacy
+    // values read back (its parent 9 and the sibling subtrees that have no
+    // version-1 insert yet).
     clear_logs(&tree.storage);
     let pos = LEGACY_FILL + 1;
     let v = value(pos, 9);
@@ -234,25 +257,40 @@ fn buffer_filled_under_v0_is_caught_up_by_the_first_v1_insert() {
     let second = tree.insert(&v, v1());
     let (root, _) = second.value.unwrap();
     assert_eq!(root, legacy_root);
+    assert_eq!(second.cost, v1_insert_model_cost(HEIGHT));
     assert_eq!(
-        second.cost.hash_node_calls,
-        2 + depth(pos),
-        "after catch-up an insert hashes the leaf twice and once per ancestor"
+        record_puts(&tree.storage).len(),
+        1,
+        "one path record per insert"
     );
     assert!(
-        value_gets(&tree.storage).is_empty(),
-        "after catch-up no value is read back: {:?}",
+        value_gets(&tree.storage).iter().all(|p| *p < LEGACY_FILL),
+        "only legacy values are read back: {:?}",
         value_gets(&tree.storage)
     );
 
-    // And the rest of the buffer, in fresh sessions, keeps agreeing.
+    // And the rest of the buffer, in fresh sessions, keeps agreeing. Only
+    // legacy (V0-inserted) values are ever read back — a legacy parent's
+    // value hash, or a walk of a legacy sibling subtree no version-1 insert
+    // has landed in yet — every insert writes exactly one record and is
+    // charged the model.
     let mut ctx = tree.storage;
     for pos in (LEGACY_FILL + 2)..((1u16 << HEIGHT) - 1) {
         let v = value(pos, 9);
         let (legacy_root, _) = legacy.insert(&v, v0()).unwrap().unwrap();
         let mut t = DenseFixedSizedMerkleTree::from_state(HEIGHT, pos, ctx).unwrap();
-        let (root, _) = t.insert(&v, v1()).unwrap().unwrap();
+        clear_logs(&t.storage);
+        let out = t.insert(&v, v1());
+        assert_eq!(out.cost, v1_insert_model_cost(HEIGHT), "pos {pos}: model");
+        let (root, _) = out.value.unwrap();
         assert_eq!(root, legacy_root, "pos {pos}");
+        assert_eq!(record_puts(&t.storage).len(), 1, "pos {pos}: one record");
+        for read in value_gets(&t.storage) {
+            assert!(
+                read < LEGACY_FILL,
+                "pos {pos}: read a V4-inserted value {read}"
+            );
+        }
         ctx = t.storage;
     }
 }
@@ -274,27 +312,22 @@ fn records_from_an_earlier_epoch_are_never_trusted() {
     tree.reset();
     assert_eq!(tree.generation(), 1);
     assert_eq!(tree.count(), 0);
-    // Stale records for every position, tagged generation 0.
-    assert!((0..7u16).all(|p| stored_record(&tree.storage, p).map(|r| r.generation) == Some(0)));
+    assert!(
+        (0..7u16).all(|p| stored_record(&tree.storage, p, HEIGHT).map(|r| r.generation) == Some(0))
+    );
 
     let mut legacy = DenseFixedSizedMerkleTree::new(HEIGHT, MemStorageContext::new()).unwrap();
     for pos in 0..7u16 {
         let v = value(pos, 0xBB);
         let (legacy_root, _) = legacy.insert(&v, v0()).unwrap().unwrap();
         let (root, _) = tree
-            .try_insert_with_accounting(
-                &v,
-                SlotWriteAccounting::Overwrite {
-                    previous_value_len: value(pos, 0xAA).len() as u32,
-                },
-                v1(),
-            )
+            .try_insert_with_accounting(&v, SlotWriteAccounting::Churn, v1())
             .unwrap()
             .unwrap()
             .unwrap();
         assert_eq!(root, legacy_root, "epoch 2 pos {pos}");
         assert_eq!(
-            stored_record(&tree.storage, pos).map(|r| r.generation),
+            stored_record(&tree.storage, pos, HEIGHT).map(|r| r.generation),
             Some(1)
         );
     }
@@ -320,11 +353,13 @@ fn records_from_an_earlier_epoch_are_never_trusted() {
     for pos in 0..5u16 {
         legacy.insert(&value(pos, 0xCC), v0()).unwrap().unwrap();
     }
-    // Root read: the generation-0 record at 0 is not current → walk.
+    // Root read: the generation-0 record of the last insert is not current
+    // → walk.
     assert_eq!(
         reopened.root_hash(v1()).unwrap().unwrap(),
         legacy.root_hash(v0()).unwrap().unwrap()
     );
+    assert_eq!(reopened.recorded_root().unwrap().unwrap(), None);
     // Insert at 5: siblings 3 and 4 / parent 2 / root 0 have only stale
     // records → recomputed from the new values.
     let v = value(5, 0xCC);
@@ -336,35 +371,57 @@ fn records_from_an_earlier_epoch_are_never_trusted() {
         .storage
         .data
         .borrow_mut()
-        .insert(record_key(0).to_vec(), vec![1, 2, 3]);
+        .insert(record_key(5).to_vec(), vec![1, 2, 3]);
     let fresh = DenseFixedSizedMerkleTree::from_state(HEIGHT, 6, reopened.storage).unwrap();
     assert_eq!(fresh.root_hash(v1()).unwrap().unwrap(), legacy_root);
+    assert_eq!(fresh.recorded_root().unwrap().unwrap(), None);
 }
 
-// ── Cost shape ─────────────────────────────────────────────────────────
+// ── Cost: fixed model, bounded work ────────────────────────────────────
 
-/// Under version 1 an insert at depth `d` hashes `2 + d` times, writes `d +
-/// 1` records, reads at most `2d` records and never reads a value back —
-/// whatever the fill level. (Storage reads are counted from the storage
-/// log: this in-memory context does not charge seeks itself.)
+/// Under version 1 every insert into a tree of a given height is charged
+/// the same figure — the height's model — whatever its position and
+/// whatever the session has cached; and the work it actually performs is
+/// bounded by depth: exactly one record put, at most `2 · depth` record
+/// reads, no value read back. (Storage I/O is counted from the storage log:
+/// this in-memory context charges reads like a real store.)
 #[test]
-fn v1_insert_work_is_bounded_by_depth_not_by_count() {
+fn v1_insert_is_charged_the_fixed_model_and_works_within_depth() {
     const HEIGHT: u8 = 8;
+    let model = v1_insert_model_cost(HEIGHT);
     let mut ctx = MemStorageContext::new();
+    let mut single = DenseFixedSizedMerkleTree::new(HEIGHT, MemStorageContext::new()).unwrap();
     let capacity = (1u16 << HEIGHT) - 1;
     for pos in 0..capacity {
         // Fresh session each time: every record read goes to storage.
         let mut tree = DenseFixedSizedMerkleTree::from_state(HEIGHT, pos, ctx).unwrap();
         clear_logs(&tree.storage);
         let out = tree.insert(&value(pos, 5), v1());
-        out.value.unwrap();
-        let d = depth(pos);
-        assert_eq!(out.cost.hash_node_calls, 2 + d, "pos {pos}: hashes");
+        let in_session = single.insert(&value(pos, 5), v1());
+        assert_eq!(out.value.unwrap(), in_session.value.unwrap());
+        assert_eq!(
+            out.cost, model,
+            "pos {pos}: cold session is charged the model"
+        );
+        assert_eq!(
+            in_session.cost, model,
+            "pos {pos}: warm session is charged the model"
+        );
+
+        let d = depth_of(pos) as usize;
         let puts = record_puts(&tree.storage);
-        assert_eq!(puts.len() as u32, d + 1, "pos {pos}: record writes");
+        assert_eq!(puts.len(), 1, "pos {pos}: exactly one record put");
+        assert_eq!(
+            puts[0].0, pos,
+            "pos {pos}: under the inserting position's key"
+        );
+        assert!(
+            puts[0].1.is_none(),
+            "pos {pos}: a never-written key is new storage for an AsNew owner"
+        );
         let reads = record_gets(&tree.storage);
         assert!(
-            reads.len() as u32 <= 2 * d,
+            reads.len() <= 2 * d,
             "pos {pos}: {} record reads > 2 * depth {d}",
             reads.len()
         );
@@ -373,61 +430,104 @@ fn v1_insert_work_is_bounded_by_depth_not_by_count() {
             "pos {pos}: values read back: {:?}",
             value_gets(&tree.storage)
         );
-        // The leaf's record is new storage (the slot was never written);
-        // the ancestors' records were written by earlier sessions and are
-        // rewritten in place.
-        for (p, cost_info) in &puts {
-            if *p == pos {
-                assert!(cost_info.is_none(), "pos {pos}: own record is new");
-            } else {
-                let c = cost_info.as_ref().expect("ancestor record is a rewrite");
-                assert!(!c.new_node);
-                assert_eq!(
-                    c.value_storage_cost.replaced_bytes,
-                    HASH_RECORD_LEN as u32 + 1
-                );
-                assert_eq!(c.value_storage_cost.added_bytes, 0);
-            }
-        }
+        // The record is the fixed size for the height.
+        let stored = tree.storage.data.borrow();
+        assert_eq!(
+            stored.get(record_key(pos).as_slice()).map(|b| b.len()),
+            Some(path_record_len(HEIGHT))
+        );
+        drop(stored);
         ctx = tree.storage;
     }
 }
 
-/// Within one session the cost is the same as across sessions (cache hits
-/// are charged like the reads they stand in for), and the record writes of
-/// positions first written in this session stay reported as new storage
-/// however often the session rewrites them — the batch keeps one put per
-/// key and the key did not exist before the session.
+/// The model's figures: the epoch averages, rounded up, for the heights the
+/// append-only family uses.
 #[test]
-fn v1_costs_are_session_independent_and_new_keys_stay_new_within_a_session() {
-    const HEIGHT: u8 = 4;
-    let mut sessions = MemStorageContext::new();
-    let mut single = DenseFixedSizedMerkleTree::new(HEIGHT, MemStorageContext::new()).unwrap();
-    for pos in 0..((1u16 << HEIGHT) - 1) {
-        let mut tree = DenseFixedSizedMerkleTree::from_state(HEIGHT, pos, sessions).unwrap();
-        let per_session = tree.insert(&value(pos, 2), v1());
-        let in_session = single.insert(&value(pos, 2), v1());
-        assert_eq!(
-            per_session.cost, in_session.cost,
-            "pos {pos}: cost must not depend on what the session has cached"
-        );
-        assert_eq!(per_session.value.unwrap(), in_session.value.unwrap());
-        sessions = tree.storage;
-    }
-    assert!(
-        record_puts(&single.storage)
-            .iter()
-            .all(|(_, c)| c.is_none()),
-        "every record key was created in this session: no put may claim a rewrite"
+fn v1_model_is_the_rounded_up_epoch_average() {
+    // Height 1: one position at depth 0 — two hashes, no reads.
+    let m = V1InsertModel::for_height(1);
+    assert_eq!((m.hash_node_calls, m.record_reads), (2, 0));
+    // Height 2: depths 0,1,1 → average 2/3 → 3 hashes; reads 2·2 − 1 = 3 over
+    // 3 positions → 1.
+    let m = V1InsertModel::for_height(2);
+    assert_eq!((m.hash_node_calls, m.record_reads), (3, 1));
+    // Height 11 (the shielded pool): Σdepth = 9·2048 + 2 = 18434 over 2047
+    // positions → 9.005 → 12 hashes; reads (2·18434 − 1023) / 2047 = 17.5 →
+    // 18; a record is 42 + 32·11 = 394 bytes.
+    let m = V1InsertModel::for_height(11);
+    assert_eq!(
+        (m.hash_node_calls, m.record_reads, m.record_len),
+        (12, 18, 394)
     );
+    assert_eq!(
+        m.cost().storage_loaded_bytes,
+        18 * 394,
+        "loaded bytes are the reads times the record size"
+    );
+    // Height 16 (the ceiling): 14·65536 + 2 over 65535 → 14.0002 → 17
+    // hashes; reads (2·917506 − 32767)/65535 = 27.5 → 28.
+    let m = V1InsertModel::for_height(16);
+    assert_eq!((m.hash_node_calls, m.record_reads), (17, 28));
+    // Monotone in height, and never below the true epoch average.
+    for height in 2..=8u8 {
+        let model = V1InsertModel::for_height(height);
+        let prev = V1InsertModel::for_height(height - 1);
+        assert!(model.hash_node_calls >= prev.hash_node_calls);
+        assert!(model.record_reads >= prev.record_reads);
+        let capacity = (1u32 << height) - 1;
+        let total_depth: u32 = (0..capacity as u16).map(|p| depth_of(p) as u32).sum();
+        assert!(
+            model.hash_node_calls as u64 * capacity as u64 >= (2 * capacity + total_depth) as u64
+        );
+    }
 }
 
-/// A slot the owner reports as a committed rewrite may carry a record from
-/// an earlier epoch: the record write is then sized as a rewrite, and the
-/// key is read once to find out. A slot reported new is not read.
+/// Record writes follow the owner's slot accounting: `Churn` reports an
+/// in-place replacement of the fixed record size and never reads to size
+/// it; `Overwrite` reads the key and reports a rewrite only if it exists;
+/// `AsNew` is new storage.
 #[test]
-fn overwrite_slots_read_their_record_to_size_the_write() {
-    let mut tree = DenseFixedSizedMerkleTree::new(2, MemStorageContext::new()).unwrap();
+fn record_put_sizing_follows_the_slot_accounting() {
+    const HEIGHT: u8 = 2;
+    let len = path_record_len(HEIGHT) as u32;
+    let paid = len + 1;
+
+    // Churn on a fresh tree: replaced = paid size, nothing added, no key.
+    let mut churn = DenseFixedSizedMerkleTree::new(HEIGHT, MemStorageContext::new()).unwrap();
+    churn
+        .try_insert_with_accounting(&value(0, 2), SlotWriteAccounting::Churn, v1())
+        .unwrap()
+        .unwrap();
+    let puts = record_puts(&churn.storage);
+    let c = puts[0].1.as_ref().expect("churn carries cost info");
+    assert!(!c.new_node);
+    assert_eq!(c.value_storage_cost.replaced_bytes, paid);
+    assert_eq!(c.value_storage_cost.added_bytes, 0);
+    assert_eq!(c.key_storage_cost, Default::default());
+    assert!(
+        record_gets(&churn.storage).is_empty(),
+        "churn never reads to size"
+    );
+    // The slot put is churn too.
+    let slot = churn
+        .storage
+        .puts
+        .borrow()
+        .iter()
+        .find(|(k, _)| k.len() == 2)
+        .map(|(_, c)| c.clone())
+        .expect("slot put");
+    let slot = slot.expect("churn slot carries cost info");
+    assert_eq!(slot.value_storage_cost.added_bytes, 0);
+    assert_eq!(
+        slot.value_storage_cost.replaced_bytes,
+        value(0, 2).len() as u32 + 1
+    );
+
+    // Overwrite after a reset: the key exists from the earlier epoch → a
+    // rewrite, sized after one read.
+    let mut tree = DenseFixedSizedMerkleTree::new(HEIGHT, MemStorageContext::new()).unwrap();
     for pos in 0..3u16 {
         tree.insert(&value(pos, 1), v1()).unwrap().unwrap();
     }
@@ -447,8 +547,8 @@ fn overwrite_slots_read_their_record_to_size_the_write() {
     assert_eq!(puts.len(), 1);
     assert!(puts[0].1.as_ref().is_some_and(|c| !c.new_node));
 
-    // The same slot reported new: no record read, record written as new.
-    let mut fresh = DenseFixedSizedMerkleTree::new(2, MemStorageContext::new()).unwrap();
+    // AsNew: no read, new storage.
+    let mut fresh = DenseFixedSizedMerkleTree::new(HEIGHT, MemStorageContext::new()).unwrap();
     fresh
         .try_insert_with_accounting(&value(0, 2), SlotWriteAccounting::AsNew, v1())
         .unwrap()
@@ -468,26 +568,31 @@ fn v1_root_read_costs_one_record_read() {
 
     let mut tree = tree;
     tree.insert(&value(0, 1), v1()).unwrap().unwrap();
+    tree.insert(&value(1, 1), v1()).unwrap().unwrap();
     let same_session = tree.root_hash(v1());
     assert_eq!(same_session.cost.hash_node_calls, 0);
     assert_eq!(same_session.cost.seek_count, 1);
     assert_eq!(
         same_session.cost.storage_loaded_bytes,
-        HASH_RECORD_LEN as u64
+        path_record_len(3) as u64
     );
-    let reopened = DenseFixedSizedMerkleTree::from_state(3, 1, tree.storage).unwrap();
+    let reopened = DenseFixedSizedMerkleTree::from_state(3, 2, tree.storage).unwrap();
     clear_logs(&reopened.storage);
     let cold = reopened.root_hash(v1());
     assert_eq!(cold.value.unwrap(), same_session.value.unwrap());
     assert_eq!(cold.cost.hash_node_calls, 0);
-    assert_eq!(record_gets(&reopened.storage), vec![0]);
+    assert_eq!(
+        record_gets(&reopened.storage),
+        vec![1],
+        "the last insert's record"
+    );
 }
 
 // ── Failure and version handling ───────────────────────────────────────
 
-/// A storage fault while rewriting the ancestor path rolls the in-memory
-/// tree back (count, cached value, cached records) so the session can go on
-/// — or be discarded — consistently.
+/// A storage fault while writing the path record rolls the in-memory tree
+/// back (count, cached value, cached records) so the session can go on — or
+/// be discarded — consistently.
 #[test]
 fn v1_insert_failure_rolls_back_the_in_memory_state() {
     let mut tree = DenseFixedSizedMerkleTree::new(3, MemStorageContext::new()).unwrap();
@@ -501,10 +606,7 @@ fn v1_insert_failure_rolls_back_the_in_memory_state() {
     assert_eq!(tree.count(), 3, "count rolled back");
     assert_eq!(tree.get(3).unwrap().unwrap(), None, "value not visible");
     tree.storage.fail_record_puts.set(false);
-    // The records were cleared from memory; the root is re-read from storage
-    // and still describes the three committed positions.
     assert_eq!(tree.root_hash(v1()).unwrap().unwrap(), root_before);
-    // And the session can continue.
     let mut legacy = DenseFixedSizedMerkleTree::new(3, MemStorageContext::new()).unwrap();
     for pos in 0..4u16 {
         legacy.insert(&value(pos, 1), v0()).unwrap().unwrap();
@@ -512,6 +614,55 @@ fn v1_insert_failure_rolls_back_the_in_memory_state() {
     let (root, pos) = tree.insert(&value(3, 1), v1()).unwrap().unwrap();
     assert_eq!(pos, 3);
     assert_eq!(root, legacy.root_hash(v0()).unwrap().unwrap());
+}
+
+/// A storage fault on a record READ surfaces as a store error from every
+/// path that reads records — the lookups of an insert, the sizing read of
+/// an `Overwrite` slot, the root read — and the insert rolls back.
+#[test]
+fn v1_record_read_faults_surface_and_roll_back() {
+    let mut tree = DenseFixedSizedMerkleTree::new(3, MemStorageContext::new()).unwrap();
+    for pos in 0..3u16 {
+        tree.insert(&value(pos, 1), v1()).unwrap().unwrap();
+    }
+    let mut tree = DenseFixedSizedMerkleTree::from_state(3, 3, tree.storage).unwrap();
+    tree.storage.fail_record_gets.set(true);
+    assert!(matches!(
+        tree.root_hash(v1()).value,
+        Err(DenseMerkleError::StoreError(_))
+    ));
+    let failed = tree.insert(&value(3, 1), v1());
+    assert!(matches!(failed.value, Err(DenseMerkleError::StoreError(_))));
+    assert_eq!(tree.count(), 3);
+    tree.reset();
+    let failed = tree.try_insert_with_accounting(
+        &value(0, 2),
+        SlotWriteAccounting::Overwrite {
+            previous_value_len: 4,
+        },
+        v1(),
+    );
+    assert!(matches!(failed.value, Err(DenseMerkleError::StoreError(_))));
+    assert_eq!(tree.count(), 0);
+    tree.storage.fail_record_gets.set(false);
+    let (_, pos) = tree.insert(&value(0, 2), v1()).unwrap().unwrap();
+    assert_eq!(pos, 0);
+}
+
+/// A parent whose record is missing AND whose value is missing is store
+/// corruption, reported as such rather than hashed over nothing.
+#[test]
+fn v1_missing_parent_value_is_a_store_error() {
+    let mut tree = DenseFixedSizedMerkleTree::new(2, MemStorageContext::new()).unwrap();
+    tree.insert(&value(0, 1), v0()).unwrap().unwrap();
+    tree.storage
+        .data
+        .borrow_mut()
+        .remove(position_key(0).as_slice());
+    let mut cold = DenseFixedSizedMerkleTree::from_state(2, 1, tree.storage).unwrap();
+    let failed = cold.insert(&value(1, 1), v1());
+    assert!(matches!(failed.value, Err(DenseMerkleError::StoreError(_))));
+    assert_eq!(cold.count(), 1);
 }
 
 /// Every versioned entry point rejects a root-maintenance version this
@@ -541,73 +692,23 @@ fn unknown_root_maintenance_version_is_rejected() {
     assert!(tree.storage.puts.borrow().is_empty());
 }
 
-/// The record encoding round-trips and rejects other lengths.
+/// The record encoding round-trips, is fixed-size per height, and rejects
+/// other lengths.
 #[test]
-fn hash_record_encoding_round_trips() {
-    let record = HashRecord {
-        generation: 0x0102_0304_0506_0708,
-        value_hash: [0xAB; 32],
-        node_hash: [0xCD; 32],
-    };
+fn path_record_encoding_round_trips() {
+    let mut record = PathRecord::new(0x0102_0304_0506_0708, [0xAB; 32], 4);
+    record.set_entry(0, [1; 32]);
+    record.set_entry(2, [3; 32]);
+    assert_eq!(record.entry(0), Some([1; 32]));
+    assert_eq!(record.entry(1), None);
+    assert_eq!(record.entry(2), Some([3; 32]));
+    assert_eq!(record.entry(3), None);
     let bytes = record.to_bytes();
-    assert_eq!(bytes.len(), HASH_RECORD_LEN);
+    assert_eq!(bytes.len(), path_record_len(4));
     assert_eq!(&bytes[..8], &[1, 2, 3, 4, 5, 6, 7, 8]);
-    assert_eq!(HashRecord::from_bytes(&bytes), Some(record));
-    assert_eq!(HashRecord::from_bytes(&bytes[..71]), None);
-    assert_eq!(HashRecord::from_bytes(&[0u8; 73]), None);
+    assert_eq!(PathRecord::from_bytes(&bytes, 4), Some(record));
+    assert_eq!(PathRecord::from_bytes(&bytes, 5), None);
+    assert_eq!(PathRecord::from_bytes(&bytes[..bytes.len() - 1], 4), None);
     assert_eq!(record_key(0x0102), [b'h', 1, 2]);
-}
-
-/// A storage fault on a record READ surfaces as a store error from every
-/// path that reads records — the sibling / parent lookups of an insert, the
-/// sizing read of an `Overwrite` slot, and the root read — and the insert
-/// rolls back exactly as on a write fault.
-#[test]
-fn v1_record_read_faults_surface_and_roll_back() {
-    let mut tree = DenseFixedSizedMerkleTree::new(3, MemStorageContext::new()).unwrap();
-    for pos in 0..3u16 {
-        tree.insert(&value(pos, 1), v1()).unwrap().unwrap();
-    }
-    // A cold session so the reads go to storage.
-    let mut tree = DenseFixedSizedMerkleTree::from_state(3, 3, tree.storage).unwrap();
-    tree.storage.fail_record_gets.set(true);
-    assert!(matches!(
-        tree.root_hash(v1()).value,
-        Err(DenseMerkleError::StoreError(_))
-    ));
-    let failed = tree.insert(&value(3, 1), v1());
-    assert!(matches!(failed.value, Err(DenseMerkleError::StoreError(_))));
-    assert_eq!(tree.count(), 3);
-    // An `Overwrite` slot reads its own record to size the write.
-    tree.reset();
-    let failed = tree.try_insert_with_accounting(
-        &value(0, 2),
-        SlotWriteAccounting::Overwrite {
-            previous_value_len: 4,
-        },
-        v1(),
-    );
-    assert!(matches!(failed.value, Err(DenseMerkleError::StoreError(_))));
-    assert_eq!(tree.count(), 0);
-    tree.storage.fail_record_gets.set(false);
-    // Healthy again: the session continues from the rolled-back state.
-    let (_, pos) = tree.insert(&value(0, 2), v1()).unwrap().unwrap();
-    assert_eq!(pos, 0);
-}
-
-/// A parent whose record is missing AND whose value is missing is store
-/// corruption, reported as such rather than hashed over nothing.
-#[test]
-fn v1_missing_parent_value_is_a_store_error() {
-    let mut tree = DenseFixedSizedMerkleTree::new(2, MemStorageContext::new()).unwrap();
-    tree.insert(&value(0, 1), v0()).unwrap().unwrap();
-    // Drop the root's value behind the tree's back (no record exists: v0).
-    tree.storage
-        .data
-        .borrow_mut()
-        .remove(position_key(0).as_slice());
-    let mut cold = DenseFixedSizedMerkleTree::from_state(2, 1, tree.storage).unwrap();
-    let failed = cold.insert(&value(1, 1), v1());
-    assert!(matches!(failed.value, Err(DenseMerkleError::StoreError(_))));
-    assert_eq!(cold.count(), 1);
+    assert_eq!(path_record_len(11), 394);
 }

--- a/grovedb-dense-fixed-sized-merkle-tree/src/tree/mod.rs
+++ b/grovedb-dense-fixed-sized-merkle-tree/src/tree/mod.rs
@@ -151,14 +151,7 @@ impl PathRecord {
         let present = u16::from_be_bytes([bytes[8], bytes[9]]);
         let mut value_hash = [0u8; 32];
         value_hash.copy_from_slice(&bytes[10..42]);
-        let entries = bytes[42..]
-            .chunks_exact(32)
-            .map(|c| {
-                let mut h = [0u8; 32];
-                h.copy_from_slice(c);
-                h
-            })
-            .collect();
+        let entries = bytes[42..].as_chunks::<32>().0.to_vec();
         Some(Self {
             generation: u64::from_be_bytes(generation),
             present,
@@ -318,7 +311,7 @@ impl<S> DenseFixedSizedMerkleTree<S> {
     }
 
     /// The epoch tag hash records are written with and checked against. See
-    /// [`HashRecord::generation`].
+    /// [`PathRecord::generation`].
     pub fn generation(&self) -> u64 {
         self.generation
     }
@@ -453,9 +446,15 @@ impl<'db, S: StorageContext<'db>> DenseFixedSizedMerkleTree<S> {
     /// Reset the tree to empty state.
     ///
     /// Sets count to 0, clears the write-through caches and advances the
-    /// generation. Old values and hash records remain in the underlying
+    /// generation. Old values and path records remain in the underlying
     /// storage; positions are overwritten on the next cycle, and records
     /// from this cycle are recognised as stale by their generation.
+    ///
+    /// An owner that resets reuses keys that hold committed bytes, so its
+    /// later inserts must size their writes accordingly —
+    /// [`SlotWriteAccounting::Churn`] (the bulk-append tree) or
+    /// [`SlotWriteAccounting::Overwrite`]; the plain `AsNew` inserts would
+    /// report the reused keys as new storage.
     pub fn reset(&mut self) {
         self.count = 0;
         self.generation = self.generation.wrapping_add(1);

--- a/grovedb-dense-fixed-sized-merkle-tree/src/tree/mod.rs
+++ b/grovedb-dense-fixed-sized-merkle-tree/src/tree/mod.rs
@@ -47,65 +47,152 @@ pub fn position_key(pos: u16) -> [u8; 2] {
 /// the named keys the owning trees put beside them.
 pub const HASH_RECORD_KEY_PREFIX: u8 = b'h';
 
-/// Encode the key of the hash record for `pos`: `b'h' || position (BE u16)`.
+/// Encode the key of the path record written by the insert at `pos`:
+/// `b'h' || position (BE u16)`.
 pub fn record_key(pos: u16) -> [u8; 3] {
     let [hi, lo] = pos.to_be_bytes();
     [HASH_RECORD_KEY_PREFIX, hi, lo]
 }
 
-/// Serialized length of a [`HashRecord`]: generation (8) + value hash (32) +
-/// node hash (32).
-pub const HASH_RECORD_LEN: usize = 8 + 32 + 32;
+/// Fixed part of a serialized [`PathRecord`]: generation (8) + present mask
+/// (2) + value hash (32). The node-hash entries add 32 bytes per level of
+/// the tree.
+pub const PATH_RECORD_HEADER_LEN: usize = 8 + 2 + 32;
 
-/// The per-position hash record version 1 of `root_maintenance` keeps beside
-/// each value.
+/// Serialized length of a [`PathRecord`] for a tree of `height`: fixed per
+/// tree, whatever the depth of the inserting position, so every insert
+/// writes the same number of bytes.
+pub fn path_record_len(height: u8) -> usize {
+    PATH_RECORD_HEADER_LEN + 32 * height as usize
+}
+
+/// The record root-maintenance version 1 writes for each insert — one per
+/// inserted position, under that position's key, never rewritten by later
+/// inserts (only filled in further by a catch-up, see below).
+///
+/// It carries the inserted position's own `value_hash` (`blake3(value)`) and
+/// the `node_hash` of every position on its ancestor path — `entry[depth]`
+/// for depths `0..=depth(position)` — as of this insert. Because positions
+/// fill in BFS order, the record of the LAST insert into a subtree holds
+/// that subtree's current hash (no later insert touched it), and every
+/// position's own record holds its value hash for good; both are located
+/// arithmetically from `count`, so no record is ever rewritten by normal
+/// inserts.
 ///
 /// `generation` tags the epoch the record belongs to. The bulk-append tree
 /// reuses the same position keys every epoch (see
 /// [`DenseFixedSizedMerkleTree::reset`]); a record left over from an earlier
-/// epoch describes a value that is no longer there, so a reader that finds a
-/// record with a different generation treats it as absent rather than
-/// trusting it. `value_hash` is `blake3(value)` — kept so that re-hashing an
-/// ancestor does not need its (possibly large) value read back —
-/// and `node_hash` is `blake3(value_hash || H(left) || H(right))` over the
-/// subtree as of the last insert into it.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct HashRecord {
+/// epoch describes values that are no longer there, so a reader that finds
+/// a record with a different generation treats it as absent rather than
+/// trusting it. `present` says which entries hold a hash: every depth up to
+/// the inserting position's for a record written by an insert; a subset for
+/// a record synthesized by a catch-up (a buffer filled without records).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PathRecord {
     /// Epoch tag; see the type doc.
     pub generation: u64,
-    /// `blake3(value)` of the position's own value.
+    /// Bit `d` set when `entries[d]` holds the node hash of the path position
+    /// at depth `d`.
+    pub present: u16,
+    /// `blake3(value)` of the position this record belongs to.
     pub value_hash: [u8; 32],
-    /// The position's subtree hash as of the last insert into it.
-    pub node_hash: [u8; 32],
+    /// Node hashes by depth (index 0 = root); `height` entries, zero when not
+    /// present.
+    pub entries: Vec<[u8; 32]>,
 }
 
-impl HashRecord {
-    /// Serialize as `generation (BE u64) || value_hash || node_hash`.
-    pub fn to_bytes(&self) -> [u8; HASH_RECORD_LEN] {
-        let mut out = [0u8; HASH_RECORD_LEN];
-        out[..8].copy_from_slice(&self.generation.to_be_bytes());
-        out[8..40].copy_from_slice(&self.value_hash);
-        out[40..].copy_from_slice(&self.node_hash);
+impl PathRecord {
+    /// An empty record for a tree of `height`: no entries present.
+    pub fn new(generation: u64, value_hash: [u8; 32], height: u8) -> Self {
+        Self {
+            generation,
+            present: 0,
+            value_hash,
+            entries: vec![[0u8; 32]; height as usize],
+        }
+    }
+
+    /// The node hash recorded for depth `depth`, if present.
+    pub fn entry(&self, depth: u8) -> Option<[u8; 32]> {
+        ((self.present >> depth) & 1 == 1)
+            .then(|| self.entries.get(depth as usize).copied())
+            .flatten()
+    }
+
+    /// Record the node hash for depth `depth`.
+    pub fn set_entry(&mut self, depth: u8, hash: [u8; 32]) {
+        if let Some(slot) = self.entries.get_mut(depth as usize) {
+            *slot = hash;
+            self.present |= 1 << depth;
+        }
+    }
+
+    /// Serialize as `generation (BE u64) || present (BE u16) || value_hash ||
+    /// entries`.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(PATH_RECORD_HEADER_LEN + 32 * self.entries.len());
+        out.extend_from_slice(&self.generation.to_be_bytes());
+        out.extend_from_slice(&self.present.to_be_bytes());
+        out.extend_from_slice(&self.value_hash);
+        for e in &self.entries {
+            out.extend_from_slice(e);
+        }
         out
     }
 
-    /// Parse a record; `None` if the bytes are not a record (wrong length).
-    pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
-        if bytes.len() != HASH_RECORD_LEN {
+    /// Parse a record for a tree of `height`; `None` if the bytes are not a
+    /// record of that shape.
+    pub fn from_bytes(bytes: &[u8], height: u8) -> Option<Self> {
+        if bytes.len() != path_record_len(height) {
             return None;
         }
         let mut generation = [0u8; 8];
         generation.copy_from_slice(&bytes[..8]);
+        let present = u16::from_be_bytes([bytes[8], bytes[9]]);
         let mut value_hash = [0u8; 32];
-        value_hash.copy_from_slice(&bytes[8..40]);
-        let mut node_hash = [0u8; 32];
-        node_hash.copy_from_slice(&bytes[40..]);
+        value_hash.copy_from_slice(&bytes[10..42]);
+        let entries = bytes[42..]
+            .chunks_exact(32)
+            .map(|c| {
+                let mut h = [0u8; 32];
+                h.copy_from_slice(c);
+                h
+            })
+            .collect();
         Some(Self {
             generation: u64::from_be_bytes(generation),
+            present,
             value_hash,
-            node_hash,
+            entries,
         })
     }
+}
+
+/// Depth of a BFS position (root = 0).
+pub fn depth_of(position: u16) -> u8 {
+    (position as u32 + 1).ilog2() as u8
+}
+
+/// The last filled position inside the subtree rooted at `position`, given
+/// `count` filled positions in BFS order — the insert whose path record holds
+/// that subtree's current hash. `None` when `position >= count`.
+pub fn last_filled_in_subtree(position: u16, count: u16, height: u8) -> Option<u16> {
+    if position >= count {
+        return None;
+    }
+    let depth = depth_of(position);
+    // Descendants at distance k span `(position + 1) * 2^k - 1 ..=
+    // (position + 2) * 2^k - 2`; take the deepest level that has any filled
+    // position — its last filled one is the last insert into the subtree.
+    let max_k = (height - 1).saturating_sub(depth);
+    for k in (0..=max_k as u32).rev() {
+        let lo = ((position as u64 + 1) << k) - 1;
+        if lo < count as u64 {
+            let hi = ((position as u64 + 2) << k) - 2;
+            return Some(hi.min(count as u64 - 1) as u16);
+        }
+    }
+    Some(position)
 }
 
 /// How a slot write is reported to the storage cost layer.
@@ -141,14 +228,23 @@ pub enum SlotWriteAccounting {
         /// Length of the value the slot holds in committed storage.
         previous_value_len: u32,
     },
+    /// The slot is a position of a transient buffer: the bytes it holds are
+    /// churn, not the tree's long-term storage (the bulk-append tree rewrites
+    /// every slot each epoch and the values live on in the chunk blob, whose
+    /// bytes each append prepays). The write — and the path record written
+    /// beside it — is reported as an in-place replacement of its own size,
+    /// whether or not the key exists yet: `replaced_bytes` = the paid size,
+    /// nothing added, no key charged, and nothing is read to size it.
+    Churn,
 }
 
-/// A hash record as this session knows it, together with whether its key
-/// exists in committed storage — what a rewrite of it must be sized against.
+/// A path record as this session knows it, together with whether its key
+/// exists in committed storage — what a rewrite of it must be sized against
+/// for an owner whose records are long-term storage.
 #[cfg(feature = "storage")]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub(crate) struct CachedRecord {
-    pub record: HashRecord,
+    pub record: PathRecord,
     /// Whether the record's key held a value in committed storage (the
     /// underlying context, outside this session's batch) when this session
     /// first looked. A `StorageBatch` keeps one put per key, so the put that
@@ -189,9 +285,10 @@ pub struct DenseFixedSizedMerkleTree<S> {
     /// Only compiled when storage-dependent operations are available.
     #[cfg(feature = "storage")]
     cache: Vec<Option<Vec<u8>>>,
-    /// Write-through cache of hash records touched in this session — written,
-    /// or read from storage and found current. Absent means "not looked at in
-    /// this session" (fall back to storage).
+    /// Write-through cache of path records touched in this session —
+    /// written, or read from storage and found current — keyed by the
+    /// inserting position. Absent means "not looked at in this session" (fall
+    /// back to storage).
     #[cfg(feature = "storage")]
     record_cache: HashMap<u16, CachedRecord>,
 }
@@ -328,11 +425,12 @@ impl<'db, S: StorageContext<'db>> DenseFixedSizedMerkleTree<S> {
         self.compute_root_hash()
     }
 
-    /// The root the hash records claim, if a record with the current
-    /// generation exists at position 0 (this session's, or stored): what a
-    /// root-maintenance-version-1 root read returns. `None` when the tree is
-    /// empty or holds no current record there (a buffer filled under version
-    /// 0, or an earlier epoch's leftover). Does not walk.
+    /// The root the path records claim — what a root-maintenance-version-1
+    /// root read returns: entry 0 of the last insert's record, if that record
+    /// is current and holds it. `None` when the tree is empty or no such
+    /// record exists (a buffer filled under version 0, an earlier epoch's
+    /// leftover, or a catch-up-synthesized record without the root). Does
+    /// not walk.
     ///
     /// Audits compare it with [`root_hash_from_values`](Self::root_hash_from_values):
     /// a difference means the records and the values disagree — a payload
@@ -342,11 +440,12 @@ impl<'db, S: StorageContext<'db>> DenseFixedSizedMerkleTree<S> {
         if self.count == 0 {
             return Ok(None).wrap_with_cost(cost);
         }
-        if let Some(cached) = self.cached_record(0) {
-            return Ok(Some(cached.record.node_hash)).wrap_with_cost(cost);
+        let last = self.count - 1;
+        if let Some(cached) = self.cached_record(last) {
+            return Ok(cached.record.entry(0)).wrap_with_cost(cost);
         }
-        match cost_return_on_error!(cost, self.read_record_from_storage(0)) {
-            Some((Some(record), true)) => Ok(Some(record.node_hash)).wrap_with_cost(cost),
+        match cost_return_on_error!(cost, self.read_record_from_storage(last)) {
+            Some((Some(record), true)) => Ok(record.entry(0)).wrap_with_cost(cost),
             _ => Ok(None).wrap_with_cost(cost),
         }
     }
@@ -425,6 +524,11 @@ impl<'db, S: StorageContext<'db>> DenseFixedSizedMerkleTree<S> {
                     value.len() as u32,
                 ))
             }
+            // Churn: the paid size replaced, nothing added, key not charged.
+            SlotWriteAccounting::Churn => Some(KeyValueStorageCost::for_in_place_value_rewrite(
+                value.len() as u32,
+                value.len() as u32,
+            )),
         };
 
         let result = self
@@ -460,22 +564,22 @@ impl<'db, S: StorageContext<'db>> DenseFixedSizedMerkleTree<S> {
         self.count = count;
     }
 
-    // ── Hash-record storage helpers (root-maintenance version 1) ──────
+    // ── Path-record storage helpers (root-maintenance version 1) ──────
 
-    /// The hash record this session knows for `position`, if it has been
-    /// written or read-and-found-current in this session.
-    pub(crate) fn cached_record(&self, position: u16) -> Option<CachedRecord> {
-        self.record_cache.get(&position).copied()
+    /// The path record this session knows for the insert at `position`, if
+    /// it has been written or read-and-found-current in this session.
+    pub(crate) fn cached_record(&self, position: u16) -> Option<&CachedRecord> {
+        self.record_cache.get(&position)
     }
 
     /// Drop every cached record (after a failed insert left the in-memory
-    /// view of the ancestor path in doubt; storage is re-read next time).
+    /// view in doubt; storage is re-read next time).
     pub(crate) fn clear_record_cache(&mut self) {
         self.record_cache.clear();
     }
 
-    /// Read the hash record for `position` from the underlying storage —
-    /// committed state plus the surrounding transaction, never this
+    /// Read the path record of the insert at `position` from the underlying
+    /// storage — committed state plus the surrounding transaction, never this
     /// session's batch.
     ///
     /// Returns what the key holds: `None` when absent, otherwise the record
@@ -489,7 +593,7 @@ impl<'db, S: StorageContext<'db>> DenseFixedSizedMerkleTree<S> {
     pub(crate) fn read_record_from_storage(
         &self,
         position: u16,
-    ) -> CostResult<Option<(Option<HashRecord>, bool)>, DenseMerkleError> {
+    ) -> CostResult<Option<(Option<PathRecord>, bool)>, DenseMerkleError> {
         let mut cost = OperationCost::default();
         let result = self
             .storage
@@ -498,78 +602,87 @@ impl<'db, S: StorageContext<'db>> DenseFixedSizedMerkleTree<S> {
         match result {
             Ok(None) => Ok(None).wrap_with_cost(cost),
             Ok(Some(bytes)) => {
-                let parsed = HashRecord::from_bytes(&bytes);
-                let current = parsed.is_some_and(|r| r.generation == self.generation);
+                let parsed = PathRecord::from_bytes(&bytes, self.height);
+                let current = parsed
+                    .as_ref()
+                    .is_some_and(|r| r.generation == self.generation);
                 Ok(Some((parsed, current))).wrap_with_cost(cost)
             }
             Err(e) => Err(DenseMerkleError::StoreError(format!(
-                "hash record get at pos {}: {}",
+                "path record get at pos {}: {}",
                 position, e
             )))
             .wrap_with_cost(cost),
         }
     }
 
-    /// Resolve the hash record for `position` for this session: the cached
-    /// one if present, otherwise the stored one, cached when current.
+    /// Resolve the current path record of the insert at `position` for this
+    /// session: the cached one if present, otherwise the stored one, cached
+    /// when current.
     ///
     /// Returns `(record_if_current, key_exists_in_committed_storage)`.
     ///
     /// Cache hits are charged like a storage read (one seek, the record
-    /// bytes) so that the same append costs the same whether it runs in the
-    /// session that wrote the record or a later one.
+    /// bytes) so the same work costs the same in the session that wrote the
+    /// record and in a later one. (Root-maintenance version 1 bills a fixed
+    /// model per insert anyway; this keeps the crate-level figures honest.)
     pub(crate) fn resolve_record(
         &mut self,
         position: u16,
-    ) -> CostResult<(Option<HashRecord>, bool), DenseMerkleError> {
+    ) -> CostResult<(Option<PathRecord>, bool), DenseMerkleError> {
         if let Some(cached) = self.cached_record(position) {
-            return Ok((Some(cached.record), cached.committed)).wrap_with_cost(OperationCost {
-                seek_count: 1,
-                storage_loaded_bytes: HASH_RECORD_LEN as u64,
-                ..Default::default()
-            });
+            return Ok((Some(cached.record.clone()), cached.committed)).wrap_with_cost(
+                OperationCost {
+                    seek_count: 1,
+                    storage_loaded_bytes: path_record_len(self.height) as u64,
+                    ..Default::default()
+                },
+            );
         }
         let mut cost = OperationCost::default();
         let stored = cost_return_on_error!(cost, self.read_record_from_storage(position));
         match stored {
             None => Ok((None, false)).wrap_with_cost(cost),
-            Some((parsed, true)) => {
-                // `current` implies `parsed` is `Some`.
-                if let Some(record) = parsed {
-                    self.record_cache.insert(
-                        position,
-                        CachedRecord {
-                            record,
-                            committed: true,
-                        },
-                    );
-                }
-                Ok((parsed, true)).wrap_with_cost(cost)
+            Some((Some(record), true)) => {
+                self.record_cache.insert(
+                    position,
+                    CachedRecord {
+                        record: record.clone(),
+                        committed: true,
+                    },
+                );
+                Ok((Some(record), true)).wrap_with_cost(cost)
             }
-            Some((_, false)) => Ok((None, true)).wrap_with_cost(cost),
+            Some(_) => Ok((None, true)).wrap_with_cost(cost),
         }
     }
 
-    /// Write the hash record for `position` to storage and cache it.
+    /// Write the path record of the insert at `position` to storage and
+    /// cache it.
     ///
-    /// `committed` says whether the record's key already holds a value in
-    /// committed storage (see [`CachedRecord::committed`]): a rewrite is
-    /// reported as an in-place replacement of the same-size record, a first
-    /// write as new storage.
+    /// How the write is sized follows the owner's slot accounting: under
+    /// [`SlotWriteAccounting::Churn`] it is an in-place replacement of its own
+    /// (fixed) size; otherwise `committed` says whether the key already holds
+    /// a value in committed storage (see [`CachedRecord::committed`]) — a
+    /// rewrite is a replacement, a first write new storage.
     pub(crate) fn put_record(
         &mut self,
         position: u16,
-        record: HashRecord,
+        record: PathRecord,
         committed: bool,
+        accounting: SlotWriteAccounting,
     ) -> CostResult<(), DenseMerkleError> {
         let mut cost = OperationCost::default();
         let bytes = record.to_bytes();
-        let cost_info = committed.then(|| {
-            KeyValueStorageCost::for_in_place_value_rewrite(
-                HASH_RECORD_LEN as u32,
-                HASH_RECORD_LEN as u32,
-            )
-        });
+        let len = bytes.len() as u32;
+        let cost_info = match accounting {
+            SlotWriteAccounting::Churn => {
+                Some(KeyValueStorageCost::for_in_place_value_rewrite(len, len))
+            }
+            SlotWriteAccounting::AsNew | SlotWriteAccounting::Overwrite { .. } => {
+                committed.then(|| KeyValueStorageCost::for_in_place_value_rewrite(len, len))
+            }
+        };
         let result = self
             .storage
             .put(record_key(position), &bytes, None, cost_info)
@@ -581,7 +694,7 @@ impl<'db, S: StorageContext<'db>> DenseFixedSizedMerkleTree<S> {
                 Ok(()).wrap_with_cost(cost)
             }
             Err(e) => Err(DenseMerkleError::StoreError(format!(
-                "hash record put at pos {}: {}",
+                "path record put at pos {}: {}",
                 position, e
             )))
             .wrap_with_cost(cost),

--- a/grovedb-dense-fixed-sized-merkle-tree/src/tree/root_maintenance/mod.rs
+++ b/grovedb-dense-fixed-sized-merkle-tree/src/tree/root_maintenance/mod.rs
@@ -11,21 +11,26 @@
 //!   calls each), and so does every root read. This is what GROVE_V1..V3
 //!   shipped; it is locked — those versions are live and a replayed block
 //!   must be charged what it was admitted under.
-//! - [`v1`] keeps a per-position [`HashRecord`] beside each value and
-//!   updates only the inserted position's ancestor path: O(height) record
-//!   reads, one blake3 per level (two for the leaf) and one record write per
-//!   level. The root is the record at position 0. Records that are absent
-//!   (a buffer filled under `v0`) or tagged with an earlier generation (an
-//!   earlier epoch over the same slot keys) are never trusted: the subtree
-//!   is recomputed from its values, exactly as `v0` would, and the record is
-//!   written so the next insert is O(height) again.
+//! - [`v1`] writes one [`PathRecord`] per insert (the inserted position's
+//!   value hash and the node hash of every position on its ancestor path)
+//!   and derives an insert's ancestor hashes from the records of earlier
+//!   inserts: O(height) record reads, one blake3 per level (two for the
+//!   leaf) and ONE record write. The root is the last insert's record. Every
+//!   insert is charged a fixed figure for the tree's height
+//!   ([`v1_insert_model_cost`]), not the work of its particular position.
+//!   Records that are absent (a buffer filled under `v0`) or tagged with an
+//!   earlier generation (an earlier epoch over the same slot keys) are never
+//!   trusted: the subtree is recomputed from its values, exactly as `v0`
+//!   would, and recorded so the next insert is O(height) again.
 //!
 //! Selected by `grove_version.dense_tree_versions.root_maintenance`.
 //!
-//! [`HashRecord`]: super::HashRecord
+//! [`PathRecord`]: super::PathRecord
 
 mod v0;
 mod v1;
+
+pub use v1::{v1_insert_model_cost, V1InsertModel};
 
 use grovedb_costs::{CostResult, CostsExt, OperationCost};
 use grovedb_storage::StorageContext;
@@ -148,10 +153,10 @@ impl<'db, S: StorageContext<'db>> DenseFixedSizedMerkleTree<S> {
     ///
     /// Under root-maintenance version 0 this skips the O(count) root walk
     /// [`try_insert`](Self::try_insert) performs, so a run of n inserts is
-    /// O(n) instead of O(n²) in hash calls. Under version 1 the ancestor-path
-    /// records are maintained exactly as [`try_insert`](Self::try_insert)
-    /// does — the records are the tree's state, not a cache that may be
-    /// skipped — so the two cost the same and differ only in what is
+    /// O(n) instead of O(n²) in hash calls. Under version 1 the path record
+    /// is written exactly as [`try_insert`](Self::try_insert) does — the
+    /// records are the tree's state, not a cache that may be skipped — so
+    /// the two cost the same (the fixed model) and differ only in what is
     /// returned.
     pub fn try_insert_no_root(
         &mut self,
@@ -191,8 +196,8 @@ impl<'db, S: StorageContext<'db>> DenseFixedSizedMerkleTree<S> {
     ///
     /// Returns `[0u8; 32]` if the tree is empty. Under root-maintenance
     /// version 0 this walks every filled position; under version 1 it reads
-    /// the record at position 0 (falling back to the walk for a buffer that
-    /// has no current record there).
+    /// the last insert's path record (falling back to the walk for a buffer
+    /// that has no current record there).
     pub fn root_hash(
         &self,
         grove_version: &GroveVersion,

--- a/grovedb-dense-fixed-sized-merkle-tree/src/tree/root_maintenance/mod.rs
+++ b/grovedb-dense-fixed-sized-merkle-tree/src/tree/root_maintenance/mod.rs
@@ -45,8 +45,10 @@ pub(crate) enum RootMaintenance {
     /// Version 0: no intermediate hashes; the root is recomputed from every
     /// filled position on each insert and each root read.
     RecomputeFromValues,
-    /// Version 1: a hash record per position; an insert updates its ancestor
-    /// path and the root is the record at position 0.
+    /// Version 1: one path record per insert, holding the inserted position's
+    /// value hash and the node hashes of its ancestor path; the root is
+    /// `entry[0]` of the last insert's record, and every insert is charged
+    /// the height's fixed model.
     PerPositionRecords,
 }
 

--- a/grovedb-dense-fixed-sized-merkle-tree/src/tree/root_maintenance/v1.rs
+++ b/grovedb-dense-fixed-sized-merkle-tree/src/tree/root_maintenance/v1.rs
@@ -1,26 +1,39 @@
-//! Root-maintenance version 1: a hash record per position, updated along the
-//! inserted position's ancestor path. Used from GROVE_V4.
+//! Root-maintenance version 1: one path record per insert, and a fixed
+//! per-insert cost derived from the tree's height. Used from GROVE_V4.
 //!
 //! # What an insert at position `p` does
 //!
 //! 1. Writes the slot (as version 0 does).
 //! 2. Hashes the new leaf: `value_hash = blake3(value)`,
 //!    `node_hash = blake3(value_hash || 0 || 0)` — both children of `p` are
-//!    beyond `count`, hence empty. Writes `p`'s record.
+//!    beyond `count`, hence empty.
 //! 3. Walks up: for each ancestor `a`, the child on the path has the hash
 //!    just computed; the other child (`sibling`) is either beyond `count`
-//!    (empty, `[0; 32]`, no read) or filled, in which case its record's
-//!    `node_hash` is the hash of its subtree as of the last insert into it —
-//!    every insert into a subtree rewrites the records of all its ancestors,
-//!    so a filled sibling's record is always current. `a`'s own record
-//!    supplies its `value_hash` (so its value is not read back).
-//!    `node_hash(a) = blake3(value_hash(a) || H(left) || H(right))`, one
-//!    blake3; `a`'s record is rewritten.
-//! 4. The last ancestor is position 0; its hash is the root.
+//!    (empty, `[0; 32]`, no read) or filled, in which case its current
+//!    subtree hash sits in the path record of the LAST insert into its
+//!    subtree (located arithmetically from `count`, see
+//!    [`last_filled_in_subtree`]); `a`'s own value hash sits in `a`'s own
+//!    record. `node_hash(a) = blake3(value_hash(a) || H(left) || H(right))`,
+//!    one blake3 per level.
+//! 4. Writes ONE record under `p`'s key: `p`'s value hash and the node hash
+//!    of every position on its path (`entry[depth]`, depths `0..=depth(p)`),
+//!    fixed size for the tree's height. Nothing else is written: an earlier
+//!    record is never rewritten by a normal insert, because the record of
+//!    the last insert into a subtree IS that subtree's current hash.
+//! 5. The root is `entry[0]` of the last insert's record.
 //!
-//! Per insert at depth `d` (root depth 0): `2 + d` blake3 calls, at most
-//! `2d` record reads (`d` parent records, at most `d` sibling records), and
-//! `d + 1` record writes — O(height), independent of how full the tree is.
+//! # What an insert is charged
+//!
+//! A FIXED figure for the tree's height, not the work this particular insert
+//! did — [`v1_insert_model_cost`]: the blake3 calls and record reads an
+//! insert performs, averaged over every position of a full buffer (the
+//! average depth is `((h - 2) · 2^h + 2) / (2^h - 1)`, ≈ `h - 2` for the
+//! heights that matter), rounded up, plus the two puts (slot, record) the
+//! insert really issues, each of a size that does not depend on the
+//! position. So every append to a tree of a given height costs the same,
+//! whatever its position — the property the fee layer wants — and an
+//! estimator can charge exactly it. The real reads are still performed and
+//! still deterministic; only the figure returned is the model.
 //!
 //! # Records that cannot be trusted
 //!
@@ -29,33 +42,38 @@
 //! an earlier generation (left by an earlier epoch over the same slot keys,
 //! see [`DenseFixedSizedMerkleTree::reset`]) is treated as missing: the
 //! subtree is recomputed from its values — the version-0 walk, restricted to
-//! that subtree — and the record is written. For a parent only its value
-//! hash is needed, so only its value is read and hashed. This catch-up costs
-//! at most one version-0 walk per buffer, once, after which every position
-//! below `count` has a current record.
+//! that subtree — and for a parent only its value is read and hashed. This
+//! catch-up is READ-ONLY: an insert writes exactly its own path record
+//! whatever the buffer's history, so neither its storage writes nor its
+//! billed cost (the model) depend on it. The walks repeat while a legacy
+//! subtree is needed as a sibling and no version-1 insert has landed in it
+//! (which records it); for the append-only family's rolling buffer that
+//! ends with the epoch the switch happened in, and the work is no more than
+//! version 0 did on every insert.
 //!
 //! # Why a stale record cannot be read as current
 //!
 //! Positions fill sequentially and are written once per generation; every
-//! insert under this version writes the record of the position it fills and
-//! of every ancestor, and `reset` advances the generation. So a record with
-//! the current generation at a position below `count` was written by an
-//! insert of this epoch into that position's subtree — later than any value
-//! it hashes over. Grove versions are monotonic for a tree, so a version-0
-//! insert can never follow a version-1 one into the same epoch.
+//! insert under this version writes the record of the position it fills,
+//! and `reset` advances the generation. A record with the current generation
+//! under position `q` was therefore written by the insert at `q` (or
+//! synthesized from the values as of a later insert), and the hashes it
+//! holds for its path were computed over every value of this epoch below
+//! them at that time — the latest state of those subtrees if `q` is the last
+//! insert into them, which is exactly when a reader consults it. Grove
+//! versions are monotonic for a tree, so a version-0 insert can never follow
+//! a version-1 one into the same epoch.
 //!
 //! # Cost sizing of record writes
 //!
-//! A record's key either already holds a value in committed storage (an
-//! earlier epoch's record, or this epoch's record written in an earlier
-//! session) — then the write is reported as an in-place replacement — or it
-//! does not, and the write is new storage. The session learns which from the
-//! storage read that resolving the record performs anyway
-//! ([`CachedRecord::committed`]); the new leaf's record can pre-exist only
-//! when its slot does (the owner says so through
-//! [`SlotWriteAccounting::Overwrite`]), in which case it is read once.
+//! Under [`SlotWriteAccounting::Churn`] (the bulk-append tree's buffer) a
+//! record write is an in-place replacement of its fixed size, whatever the
+//! key held. Otherwise (a tree whose buffer is its long-term storage) a
+//! first write is new storage and a rewrite a replacement, learned from the
+//! read that resolving the record performs anyway ([`CachedRecord::committed`]).
 //!
 //! [`CachedRecord::committed`]: crate::tree::CachedRecord::committed
+//! [`last_filled_in_subtree`]: crate::tree::last_filled_in_subtree
 
 use grovedb_costs::{CostResult, CostsExt, OperationCost};
 use grovedb_storage::StorageContext;
@@ -63,34 +81,105 @@ use grovedb_storage::StorageContext;
 use crate::{
     hash::node_hash,
     tree::{
-        cost_return_on_error, DenseFixedSizedMerkleTree, HashRecord, SlotWriteAccounting,
-        HASH_RECORD_LEN,
+        cost_return_on_error, depth_of, last_filled_in_subtree, path_record_len,
+        DenseFixedSizedMerkleTree, PathRecord, SlotWriteAccounting,
     },
     DenseMerkleError,
 };
 
 const ZERO_HASH: [u8; 32] = [0u8; 32];
 
-/// Write `value` at the next position and bring the records on its ancestor
-/// path up to date. Returns the new root and the position. The caller has
-/// checked the tree is not full.
+/// The fixed per-insert figures root-maintenance version 1 charges for a
+/// tree of a given height. See [`v1_insert_model_cost`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct V1InsertModel {
+    /// blake3 calls: two for the leaf plus one per ancestor level, averaged
+    /// over a full buffer and rounded up.
+    pub hash_node_calls: u32,
+    /// Record reads: one for each ancestor's value hash and one for each
+    /// filled sibling's subtree hash, averaged over a full buffer and
+    /// rounded up.
+    pub record_reads: u32,
+    /// Bytes of one path record for this height — what each record read
+    /// loads and what the insert's record put writes.
+    pub record_len: u32,
+}
+
+impl V1InsertModel {
+    /// The model for a tree of `height` (1..=16).
+    pub fn for_height(height: u8) -> Self {
+        let h = height.clamp(1, 16) as u64;
+        // Positions of a full buffer and the sum of their depths:
+        // Σ_{p < 2^h - 1} depth(p) = Σ_{d < h} d · 2^d = (h - 2) · 2^h + 2.
+        let positions = (1u64 << h) - 1;
+        let total_depth = (h as i64 - 2) * (1i64 << h) + 2;
+        let total_depth = total_depth.max(0) as u64;
+        // Reads per insert at depth d: d ancestor value hashes, and a
+        // sibling subtree hash at every level where the sibling is filled —
+        // every ancestor level, and the leaf's own level only when the leaf
+        // is a right child (its left sibling is filled). So 2d minus one for
+        // every left child, of which a full buffer has 2^(h-1) - 1.
+        let left_children = (1u64 << (h - 1)) - 1;
+        let total_reads = 2 * total_depth - left_children;
+        let ceil_div = |n: u64, d: u64| n.div_ceil(d) as u32;
+        Self {
+            hash_node_calls: 2 + ceil_div(total_depth, positions),
+            record_reads: ceil_div(total_reads, positions),
+            record_len: path_record_len(height) as u32,
+        }
+    }
+
+    /// The model as an [`OperationCost`]: the hashes, the record reads (one
+    /// seek and one record of loaded bytes each). The slot put and the record
+    /// put are real storage writes and carry their own cost at commit.
+    pub fn cost(&self) -> OperationCost {
+        OperationCost {
+            seek_count: self.record_reads,
+            storage_loaded_bytes: self.record_reads as u64 * self.record_len as u64,
+            hash_node_calls: self.hash_node_calls,
+            ..Default::default()
+        }
+    }
+}
+
+/// The fixed cost root-maintenance version 1 charges for one insert into a
+/// tree of `height`, whatever the position — see [`V1InsertModel`].
+pub fn v1_insert_model_cost(height: u8) -> OperationCost {
+    V1InsertModel::for_height(height).cost()
+}
+
+/// Write `value` at the next position, write its path record, and return
+/// the new root and the position. The caller has checked the tree is not
+/// full. The returned cost is the fixed model for the tree's height plus
+/// whatever the storage context charged for the two puts.
 pub(super) fn insert_next<'db, S: StorageContext<'db>>(
     tree: &mut DenseFixedSizedMerkleTree<S>,
     value: &[u8],
     accounting: SlotWriteAccounting,
 ) -> CostResult<([u8; 32], u16), DenseMerkleError> {
-    let mut cost = OperationCost::default();
+    // The model is what this insert is charged; the work below is real but
+    // its cost is not what is returned.
+    let mut cost = v1_insert_model_cost(tree.height());
+    let mut work = OperationCost::default();
+
     let position = tree.count();
-    cost_return_on_error!(cost, tree.put_value(position, value, accounting));
+    let put_slot = tree.put_value(position, value, accounting);
+    cost += put_slot.cost;
+    if let Err(e) = put_slot.value {
+        return Err(e).wrap_with_cost(cost);
+    }
     tree.set_count(position + 1);
 
-    match maintain_path(tree, position, value, accounting).unwrap_add_cost(&mut cost) {
-        Ok(root) => Ok((root, position)).wrap_with_cost(cost),
+    match maintain_path(tree, position, value, accounting).unwrap_add_cost(&mut work) {
+        Ok((root, record_put_cost)) => {
+            cost += record_put_cost;
+            Ok((root, position)).wrap_with_cost(cost)
+        }
         Err(e) => {
             // Roll back the in-memory view: the count, the cached value, and
-            // every cached record — the path may have been half rewritten,
-            // and storage (which the caller discards with its transaction)
-            // is re-read next time rather than trusted from memory.
+            // every cached record — storage (which the caller discards with
+            // its transaction) is re-read next time rather than trusted from
+            // memory.
             tree.set_count(position);
             tree.uncache_value(position);
             tree.clear_record_cache();
@@ -99,16 +188,20 @@ pub(super) fn insert_next<'db, S: StorageContext<'db>>(
     }
 }
 
-/// Hash the new leaf at `position` and rewrite the records of its ancestors.
-/// Returns the root. `tree.count()` already includes `position`.
+/// Hash the new leaf at `position`, derive the node hashes of its ancestors,
+/// and write its path record. Returns the root and the cost the storage
+/// context charged for the record put (the rest of the returned cost is the
+/// real work, which the caller discards in favour of the model).
+/// `tree.count()` already includes `position`.
 fn maintain_path<'db, S: StorageContext<'db>>(
     tree: &mut DenseFixedSizedMerkleTree<S>,
     position: u16,
     value: &[u8],
     accounting: SlotWriteAccounting,
-) -> CostResult<[u8; 32], DenseMerkleError> {
+) -> CostResult<([u8; 32], OperationCost), DenseMerkleError> {
     let mut cost = OperationCost::default();
     let generation = tree.generation();
+    let height = tree.height();
     let count = tree.count();
 
     // The new leaf. Both children are at or beyond `count`: empty.
@@ -116,27 +209,8 @@ fn maintain_path<'db, S: StorageContext<'db>>(
     cost.hash_node_calls += 1;
     let leaf_hash = node_hash(&value_hash, &ZERO_HASH, &ZERO_HASH);
     cost.hash_node_calls += 1;
-    // Its record key can pre-exist only if the slot itself does (an earlier
-    // epoch wrote both); the owner's slot accounting says whether that is
-    // possible, and if so the key is read to size the write.
-    let leaf_committed = match accounting {
-        SlotWriteAccounting::AsNew => false,
-        SlotWriteAccounting::Overwrite { .. } => {
-            cost_return_on_error!(cost, tree.read_record_from_storage(position)).is_some()
-        }
-    };
-    cost_return_on_error!(
-        cost,
-        tree.put_record(
-            position,
-            HashRecord {
-                generation,
-                value_hash,
-                node_hash: leaf_hash,
-            },
-            leaf_committed,
-        )
-    );
+    let mut record = PathRecord::new(generation, value_hash, height);
+    record.set_entry(depth_of(position), leaf_hash);
 
     let mut current = position;
     let mut current_hash = leaf_hash;
@@ -153,8 +227,7 @@ fn maintain_path<'db, S: StorageContext<'db>>(
         } else {
             ZERO_HASH
         };
-        let (parent_value_hash, parent_committed) =
-            cost_return_on_error!(cost, parent_value_hash(tree, parent));
+        let parent_value_hash = cost_return_on_error!(cost, parent_value_hash(tree, parent));
         let (left, right) = if current_is_left {
             (current_hash, sibling_hash)
         } else {
@@ -162,65 +235,60 @@ fn maintain_path<'db, S: StorageContext<'db>>(
         };
         let parent_hash = node_hash(&parent_value_hash, &left, &right);
         cost.hash_node_calls += 1;
-        cost_return_on_error!(
-            cost,
-            tree.put_record(
-                parent,
-                HashRecord {
-                    generation,
-                    value_hash: parent_value_hash,
-                    node_hash: parent_hash,
-                },
-                parent_committed,
-            )
-        );
+        record.set_entry(depth_of(parent), parent_hash);
         current = parent;
         current_hash = parent_hash;
     }
 
-    Ok(current_hash).wrap_with_cost(cost)
+    // The leaf's record key can pre-exist only if the slot itself does (an
+    // earlier epoch wrote both); under `Overwrite` the owner says so and the
+    // key is read once to size the write. `Churn` sizes it as churn without
+    // looking; `AsNew` slots never had a record.
+    let committed = match accounting {
+        SlotWriteAccounting::Overwrite { .. } => {
+            cost_return_on_error!(cost, tree.read_record_from_storage(position)).is_some()
+        }
+        SlotWriteAccounting::AsNew | SlotWriteAccounting::Churn => false,
+    };
+    let put = tree.put_record(position, record, committed, accounting);
+    let put_cost = put.cost;
+    match put.value {
+        Ok(()) => Ok((current_hash, put_cost)).wrap_with_cost(cost),
+        Err(e) => Err(e).wrap_with_cost(cost),
+    }
 }
 
-/// The subtree hash of filled position `s` (off the insert path): its current
-/// record's `node_hash`, or — when no current record exists — the walk over
-/// its values, whose result is recorded so the next insert finds it.
+/// The subtree hash of filled position `s` (off the insert path): the entry
+/// for `s`'s depth in the path record of the last insert into `s`'s subtree.
+/// When that record is missing or lacks the entry (the subtree was filled
+/// without records, under version 0), the subtree is walked from its values
+/// — read-only: nothing is written outside the inserting position's own
+/// record, so what an insert writes never depends on the buffer's history.
 fn subtree_hash<'db, S: StorageContext<'db>>(
     tree: &mut DenseFixedSizedMerkleTree<S>,
     s: u16,
 ) -> CostResult<[u8; 32], DenseMerkleError> {
     let mut cost = OperationCost::default();
-    let (record, committed) = cost_return_on_error!(cost, tree.resolve_record(s));
-    if let Some(record) = record {
-        return Ok(record.node_hash).wrap_with_cost(cost);
+    let depth = depth_of(s);
+    let last = last_filled_in_subtree(s, tree.count(), tree.height()).unwrap_or(s);
+    let (record, _) = cost_return_on_error!(cost, tree.resolve_record(last));
+    if let Some(hash) = record.as_ref().and_then(|r| r.entry(depth)) {
+        return Ok(hash).wrap_with_cost(cost);
     }
-    let (value_hash, subtree_hash) = cost_return_on_error!(cost, tree.hash_node_with_value_hash(s));
-    cost_return_on_error!(
-        cost,
-        tree.put_record(
-            s,
-            HashRecord {
-                generation: tree.generation(),
-                value_hash,
-                node_hash: subtree_hash,
-            },
-            committed,
-        )
-    );
-    Ok(subtree_hash).wrap_with_cost(cost)
+    tree.hash_node(s).add_cost(cost)
 }
 
-/// The value hash of ancestor `a` (on the insert path), and whether its
-/// record key exists in committed storage. From its current record when
-/// there is one; otherwise its value is read and hashed (its record is about
-/// to be rewritten by the caller, so none is written here).
+/// The value hash of ancestor `a` (on the insert path): from `a`'s own path
+/// record; otherwise (`a` was inserted without a record, under version 0)
+/// `a`'s value is read and hashed — read-only, see [`subtree_hash`].
 fn parent_value_hash<'db, S: StorageContext<'db>>(
     tree: &mut DenseFixedSizedMerkleTree<S>,
     a: u16,
-) -> CostResult<([u8; 32], bool), DenseMerkleError> {
+) -> CostResult<[u8; 32], DenseMerkleError> {
     let mut cost = OperationCost::default();
-    let (record, committed) = cost_return_on_error!(cost, tree.resolve_record(a));
+    let (record, _) = cost_return_on_error!(cost, tree.resolve_record(a));
     if let Some(record) = record {
-        return Ok((record.value_hash, committed)).wrap_with_cost(cost);
+        return Ok(record.value_hash).wrap_with_cost(cost);
     }
     let value = match cost_return_on_error!(cost, tree.get_value(a)) {
         Some(v) => v,
@@ -232,14 +300,13 @@ fn parent_value_hash<'db, S: StorageContext<'db>>(
             .wrap_with_cost(cost);
         }
     };
-    let value_hash = *blake3::hash(&value).as_bytes();
     cost.hash_node_calls += 1;
-    Ok((value_hash, committed)).wrap_with_cost(cost)
+    Ok(*blake3::hash(&value).as_bytes()).wrap_with_cost(cost)
 }
 
-/// The root: the record at position 0 when a current one exists (this
-/// session's, or stored), otherwise the walk over the values. An empty tree
-/// has root `[0; 32]` and costs nothing.
+/// The root: `entry[0]` of the last insert's record when current and present
+/// (this session's, or stored), otherwise the walk over the values. An
+/// empty tree has root `[0; 32]` and costs nothing.
 ///
 /// A walk here is not recorded (this is a read); the next insert records it.
 pub(super) fn root_hash<'db, S: StorageContext<'db>>(
@@ -249,17 +316,21 @@ pub(super) fn root_hash<'db, S: StorageContext<'db>>(
     if tree.count() == 0 {
         return Ok(ZERO_HASH).wrap_with_cost(cost);
     }
-    if let Some(cached) = tree.cached_record(0) {
-        // Charged like the storage read it stands in for, so a root read
-        // costs the same in the session that wrote the record and later.
+    let last = tree.count() - 1;
+    if let Some(cached) = tree.cached_record(last) {
+        // Charged like the storage read it stands in for.
         cost.seek_count += 1;
-        cost.storage_loaded_bytes += HASH_RECORD_LEN as u64;
-        return Ok(cached.record.node_hash).wrap_with_cost(cost);
+        cost.storage_loaded_bytes += path_record_len(tree.height()) as u64;
+        if let Some(root) = cached.record.entry(0) {
+            return Ok(root).wrap_with_cost(cost);
+        }
+        return tree.compute_root_hash().add_cost(cost);
     }
     if let Some((Some(record), true)) =
-        cost_return_on_error!(cost, tree.read_record_from_storage(0))
+        cost_return_on_error!(cost, tree.read_record_from_storage(last))
+        && let Some(root) = record.entry(0)
     {
-        return Ok(record.node_hash).wrap_with_cost(cost);
+        return Ok(root).wrap_with_cost(cost);
     }
     tree.compute_root_hash().add_cost(cost)
 }

--- a/grovedb-merkle-mountain-range/src/storage_adapter.rs
+++ b/grovedb-merkle-mountain-range/src/storage_adapter.rs
@@ -59,6 +59,13 @@ pub enum LeafValueStorageCost {
     /// function of the value bytes — it runs at flush time, which may be long
     /// after the leaf was pushed.
     PartlyPrepaid(fn(&[u8]) -> u32),
+    /// Every node written — leaf and internal — is already paid for by the
+    /// owner (the bulk-append tree charges each append its share of the
+    /// chunk blob, its framing and the MMR nodes, amortized over the epoch),
+    /// so the put carries zero-byte cost information: nothing added, nothing
+    /// replaced, no key charged. The owner bills the amortized figures
+    /// itself.
+    Prepaid,
 }
 
 impl<'a, C> MmrStore<'a, C> {
@@ -101,6 +108,12 @@ impl<'a, C> MmrStore<'a, C> {
         serialized_len: u32,
     ) -> Option<KeyValueStorageCost> {
         match (self.leaf_value_storage_cost, value) {
+            (LeafValueStorageCost::Prepaid, _) => Some(KeyValueStorageCost {
+                key_storage_cost: StorageCost::default(),
+                value_storage_cost: StorageCost::default(),
+                new_node: false,
+                needs_value_verification: false,
+            }),
             (LeafValueStorageCost::New, _) | (_, None) => None,
             (LeafValueStorageCost::PartlyPrepaid(prepaid), Some(value)) => {
                 // The paid size of a stored value is its length plus the

--- a/grovedb-private-document-store/src/store.rs
+++ b/grovedb-private-document-store/src/store.rs
@@ -779,39 +779,23 @@ mod atomicity_tests {
             .unwrap()
             .expect("new");
 
-        // First append (position 0, the root of the buffer): the leaf is
-        // hashed twice (value hash + node hash) and has no ancestors; the
-        // bulk state root reads the position-0 record (no hash); then the
-        // bulk state root (1) and the composite pds_state root (1).
-        let ctx = store.append(&[1u8; 8], GroveVersion::latest());
-        ctx.value.expect("append");
-        assert_eq!(
-            ctx.cost.hash_node_calls, 4,
-            "2 dense + 1 bulk root + 1 composite, got {:?}",
-            ctx.cost
-        );
-
-        // Second append (position 1, depth 1): leaf (2) + its one ancestor
-        // (1) = 3 dense hashes, plus the two roots. Under GROVE_V1..V3 this
-        // would re-walk both filled positions (4).
-        let ctx = store.append(&[2u8; 8], GroveVersion::latest());
-        ctx.value.expect("append");
-        assert_eq!(
-            ctx.cost.hash_node_calls, 5,
-            "3 dense + 1 bulk root + 1 composite, got {:?}",
-            ctx.cost
-        );
-
-        // Third (position 2, depth 1 again): 3 dense + 2 roots — the same
-        // as the second append, not 2 more: the work follows the depth of
-        // the inserted position, not how full the buffer is.
-        let ctx = store.append(&[3u8; 8], GroveVersion::latest());
-        ctx.value.expect("append");
-        assert_eq!(
-            ctx.cost.hash_node_calls, 5,
-            "3 dense + 1 bulk root + 1 composite, got {:?}",
-            ctx.cost
-        );
+        // Under GROVE_V4 every buffered append is charged the dense
+        // buffer's fixed model for its height — at `chunk_power = 4`: two
+        // leaf hashes plus the rounded-up average ancestor depth (3) = 5 —
+        // plus the bulk state root (1; read from the record, no hash) and
+        // the composite pds_state root (1), whatever the position.
+        let model = grovedb_bulk_append_tree::V1InsertModel::for_height(4);
+        assert_eq!(model.hash_node_calls, 5);
+        for entry in [[1u8; 8], [2u8; 8], [3u8; 8]] {
+            let ctx = store.append(&entry, GroveVersion::latest());
+            ctx.value.expect("append");
+            assert_eq!(
+                ctx.cost.hash_node_calls,
+                model.hash_node_calls + 2,
+                "model dense + 1 bulk root + 1 composite, got {:?}",
+                ctx.cost
+            );
+        }
     }
 
     /// Compaction is the expensive branch of an append — it reads every
@@ -856,15 +840,17 @@ mod atomicity_tests {
             compacting_cost
         );
 
-        // A plain buffered append afterwards reads nothing back.
+        // A plain buffered append afterwards is charged the buffer's fixed
+        // model (its hashes and record reads) plus the two roots — not the
+        // compaction's read-back.
+        let model = grovedb_bulk_append_tree::V1InsertModel::for_height(2);
         let plain = store.append(&[4u8; 8], GroveVersion::latest());
         plain.value.expect("buffered append");
-        assert!(
-            plain.cost.storage_loaded_bytes < compacting_cost.storage_loaded_bytes,
-            "a buffered append must be cheaper in loaded bytes than a \
-             compacting one (buffered {:?} vs compacting {:?})",
-            plain.cost,
-            compacting_cost
+        assert_eq!(
+            plain.cost.hash_node_calls,
+            model.hash_node_calls + 2,
+            "buffered: model dense + 1 bulk root + 1 composite, got {:?}",
+            plain.cost
         );
     }
 

--- a/grovedb-private-document-store/src/store.rs
+++ b/grovedb-private-document-store/src/store.rs
@@ -112,8 +112,10 @@ impl<'db, S: StorageContext<'db>> PrivateDocumentStore<S> {
             ))
             .wrap_with_cost(cost);
         }
+        // The store enforces one entry size; told the size, the bulk tree
+        // charges no per-entry blob framing under the fixed cost model.
         let bulk_tree = match BulkAppendTree::from_state(total_count, chunk_power, storage) {
-            Ok(t) => t,
+            Ok(t) => t.with_fixed_entry_size(entry_size),
             Err(e) => {
                 return Err(PrivateDocumentStoreError::InvalidData(format!(
                     "bulk tree: {}",
@@ -782,19 +784,20 @@ mod atomicity_tests {
 
         // Under GROVE_V4 every append is charged the dense buffer's fixed
         // model for its height — at `chunk_power = 4`: two leaf hashes plus
-        // the rounded-up average ancestor depth (3) = 5 — plus one amortized
-        // compaction blake3, the bulk state root (1; read from the record,
-        // no hash) and the composite pds_state root (1), whatever the
-        // position.
+        // the rounded-up average ancestor depth (3) = 5 — plus the amortized
+        // compaction bound (5 at chunk_power 4), the bulk state root (1;
+        // read from the record, no hash) and the composite pds_state root
+        // (1), whatever the position.
         let model = grovedb_bulk_append_tree::V1InsertModel::for_height(4);
         assert_eq!(model.hash_node_calls, 5);
+        let amortized = grovedb_bulk_append_tree::amortized_compaction_hashes(4);
         for entry in [[1u8; 8], [2u8; 8], [3u8; 8]] {
             let ctx = store.append(&entry, GroveVersion::latest());
             ctx.value.expect("append");
             assert_eq!(
                 ctx.cost.hash_node_calls,
-                model.hash_node_calls + 1 + 2,
-                "model dense + 1 amortized compaction + 1 bulk root + 1 composite, got {:?}",
+                model.hash_node_calls + amortized + 2,
+                "model dense + amortized compaction + 1 bulk root + 1 composite, got {:?}",
                 ctx.cost
             );
         }
@@ -850,7 +853,7 @@ mod atomicity_tests {
         }
         assert_eq!(
             compacting_cost.hash_node_calls,
-            model.hash_node_calls + 1 + 2,
+            model.hash_node_calls + grovedb_bulk_append_tree::amortized_compaction_hashes(2) + 2,
             "model + amortized compaction + bulk root + composite, got {:?}",
             compacting_cost
         );

--- a/grovedb-private-document-store/src/store.rs
+++ b/grovedb-private-document-store/src/store.rs
@@ -519,10 +519,11 @@ impl<'db, S: StorageContext<'db>> PrivateDocumentStore<S> {
     /// `BulkAppendTree::buffer_record_mismatch`.
     pub fn buffer_record_mismatch(
         &self,
+        grove_version: &GroveVersion,
     ) -> Result<Option<grovedb_bulk_append_tree::BufferRecordMismatch>, PrivateDocumentStoreError>
     {
         self.bulk_tree
-            .buffer_record_mismatch()
+            .buffer_record_mismatch(grove_version)
             .map_err(|e| PrivateDocumentStoreError::InvalidData(format!("record audit: {}", e)))
     }
 
@@ -779,11 +780,12 @@ mod atomicity_tests {
             .unwrap()
             .expect("new");
 
-        // Under GROVE_V4 every buffered append is charged the dense
-        // buffer's fixed model for its height — at `chunk_power = 4`: two
-        // leaf hashes plus the rounded-up average ancestor depth (3) = 5 —
-        // plus the bulk state root (1; read from the record, no hash) and
-        // the composite pds_state root (1), whatever the position.
+        // Under GROVE_V4 every append is charged the dense buffer's fixed
+        // model for its height — at `chunk_power = 4`: two leaf hashes plus
+        // the rounded-up average ancestor depth (3) = 5 — plus one amortized
+        // compaction blake3, the bulk state root (1; read from the record,
+        // no hash) and the composite pds_state root (1), whatever the
+        // position.
         let model = grovedb_bulk_append_tree::V1InsertModel::for_height(4);
         assert_eq!(model.hash_node_calls, 5);
         for entry in [[1u8; 8], [2u8; 8], [3u8; 8]] {
@@ -791,8 +793,8 @@ mod atomicity_tests {
             ctx.value.expect("append");
             assert_eq!(
                 ctx.cost.hash_node_calls,
-                model.hash_node_calls + 2,
-                "model dense + 1 bulk root + 1 composite, got {:?}",
+                model.hash_node_calls + 1 + 2,
+                "model dense + 1 amortized compaction + 1 bulk root + 1 composite, got {:?}",
                 ctx.cost
             );
         }
@@ -800,57 +802,66 @@ mod atomicity_tests {
 
     /// Compaction is the expensive branch of an append — it reads every
     /// buffered entry back out of storage, hashes the chunk blob, and pushes
-    /// it through the MMR — and all of that used to be discarded, so a
-    /// compacting append billed no more I/O than a buffered one.
+    /// it through the MMR — but under GROVE_V4 that work is amortized into
+    /// every append's fixed model: the compacting append is charged exactly
+    /// what a buffered one is (the model, one amortized compaction blake3,
+    /// the two roots), plus nothing for its read-back; only the bulk state
+    /// root's record read differs (the buffer is empty right after).
     #[test]
-    fn compacting_append_bills_its_reads_and_hashes() {
+    fn compacting_append_is_charged_the_fixed_model() {
         // chunk_power 2: the buffer holds 3, so the 4th append compacts.
         let mut store = PrivateDocumentStore::new(8, 2, MemStorageContext::new())
             .unwrap()
             .expect("new");
+        let model = grovedb_bulk_append_tree::V1InsertModel::for_height(2);
+        let mut buffered_costs = Vec::new();
         for i in 0..3u8 {
-            store
-                .append(&[i; 8], GroveVersion::latest())
-                .unwrap()
-                .expect("append");
+            let ctx = store.append(&[i; 8], GroveVersion::latest());
+            ctx.value.expect("append");
+            buffered_costs.push(ctx.cost);
         }
-
         // The 4th append does not fit the buffer, so it compacts.
         let compacting = store.append(&[3u8; 8], GroveVersion::latest());
         compacting.value.expect("compacting append");
         let compacting_cost = compacting.cost;
 
-        assert!(
-            compacting_cost.seek_count > 0 && compacting_cost.storage_loaded_bytes > 0,
-            "compaction reads every buffered entry; those reads must be billed, got {:?}",
-            compacting_cost
-        );
-        // 3 buffered entries read back, at the committed 8 bytes each.
-        assert!(
-            compacting_cost.storage_loaded_bytes >= 24,
-            "expected at least the 3 x 8 bytes compaction reads back, got {:?}",
-            compacting_cost
-        );
-        // 1 chunk-blob leaf hash + 1 bulk state root + 1 composite root. The
-        // MMR push collapses no peaks at size 0 and the root takes the
-        // single-element path, so neither adds a hash here.
+        // A buffered append's slot and record churn is carried by its puts
+        // (billed at commit, not in this crate-level cost); the compacting
+        // append writes neither and is charged the same churn here instead
+        // — so at the commit level the two are identical.
+        let churn = {
+            let paid = |len: u32| len + 1;
+            paid(8) + paid(grovedb_bulk_append_tree::path_record_len(2) as u32)
+        };
+        for (i, buffered) in buffered_costs.iter().enumerate() {
+            assert_eq!(
+                buffered.hash_node_calls, compacting_cost.hash_node_calls,
+                "append {i}"
+            );
+            assert_eq!(
+                buffered.storage_cost.added_bytes, compacting_cost.storage_cost.added_bytes,
+                "append {i}"
+            );
+            assert_eq!(
+                buffered.storage_cost.replaced_bytes + churn,
+                compacting_cost.storage_cost.replaced_bytes,
+                "append {i}: the compacting append carries the churn its missing puts would"
+            );
+        }
         assert_eq!(
-            compacting_cost.hash_node_calls, 3,
-            "1 leaf + 1 bulk root + 1 composite, got {:?}",
+            compacting_cost.hash_node_calls,
+            model.hash_node_calls + 1 + 2,
+            "model + amortized compaction + bulk root + composite, got {:?}",
             compacting_cost
         );
-
-        // A plain buffered append afterwards is charged the buffer's fixed
-        // model (its hashes and record reads) plus the two roots — not the
-        // compaction's read-back.
-        let model = grovedb_bulk_append_tree::V1InsertModel::for_height(2);
-        let plain = store.append(&[4u8; 8], GroveVersion::latest());
-        plain.value.expect("buffered append");
+        // The read-back and the MMR work are not billed: the reads are the
+        // model's plus the two fixed root reads of the state root (the
+        // persisted MMR root and the last insert's record), whether or not
+        // this particular state needs them.
+        assert_eq!(compacting_cost.seek_count, model.record_reads + 2);
         assert_eq!(
-            plain.cost.hash_node_calls,
-            model.hash_node_calls + 2,
-            "buffered: model dense + 1 bulk root + 1 composite, got {:?}",
-            plain.cost
+            compacting_cost.storage_loaded_bytes,
+            model.record_reads as u64 * model.record_len as u64 + 32 + model.record_len as u64
         );
     }
 
@@ -1215,7 +1226,7 @@ mod error_path_tests {
         // state every real read after a restart is in.
         let storage = PrivateDocumentStore::into_storage_for_test(store);
         storage.fail_reads();
-        let mut store = PrivateDocumentStore::from_state(6, 8, 2, storage)
+        let store = PrivateDocumentStore::from_state(6, 8, 2, storage)
             .unwrap()
             .expect("reopen");
 

--- a/grovedb-version/src/version/bulk_append_tree_versions.rs
+++ b/grovedb-version/src/version/bulk_append_tree_versions.rs
@@ -24,8 +24,12 @@ pub struct BulkAppendTreeCostVersions {
     /// compaction's own `get_root` performs, so a compaction landing on a
     /// multi-peak MMR under-reports by `peaks - 1`.
     ///
-    /// Version 1 adds that bagging term. Shipped chunk bytes and roots are
-    /// unaffected; what moves is the fee a compacting append is charged.
+    /// Version 1 reports nothing for the compaction itself: its hashes (the
+    /// chunk-leaf hash, the push merges, the root bagging) are amortized
+    /// over the epoch as one blake3 on every append
+    /// (`AMORTIZED_COMPACTION_HASHES`), so a compacting append is charged
+    /// what any other append is. Shipped chunk bytes and roots are
+    /// unaffected; what moves is where the fee lands.
     pub compaction_hash_count: FeatureVersion,
     /// How an append's data-storage writes are reported to the storage cost
     /// layer (issue #822).
@@ -36,18 +40,22 @@ pub struct BulkAppendTreeCostVersions {
     /// was built from, are both billed as permanent growth — the whole blob
     /// (≈ 630 KB at `chunk_power` 11) lands on the one compacting append.
     ///
-    /// Version 1 charges each entry's permanent bytes once, at its own
-    /// append: the entry's chunk-blob share (`value.len()`) is reported as
-    /// added storage on every append; the dense buffer is churn — every
-    /// slot write and every path record write (epoch 1 included) is reported
-    /// as an in-place replacement of its own size, nothing added, no key
-    /// charged, nothing read to size it — since the buffer is a fixed-size
-    /// per-tree scratch area rewritten every epoch, not any entry's
-    /// long-term storage; the compaction blob is reported as a replacement
-    /// of the entry bytes it supersedes, with only its framing (and the MMR
-    /// internal nodes) added; and the buffer's fixed root-maintenance model
-    /// (`dense_tree_versions.root_maintenance`) is billed alongside the hash
-    /// count. Stored bytes, chunks and roots are identical under both
-    /// versions.
+    /// Version 1 charges every append the FIXED per-append model, whatever
+    /// its position: the entry's long-term footprint as added storage — its
+    /// chunk-blob share (`value.len()`) plus the epoch's share of the blob
+    /// framing and MMR nodes (`amortized_compaction_added_bytes`) — and
+    /// churn as replaced storage — its buffer slot and path record (epoch 1
+    /// included, nothing read to size them; the buffer is a fixed-size
+    /// per-tree scratch area rewritten every epoch) and its own bytes again
+    /// as its part of the blob rewrite; plus the buffer's fixed
+    /// root-maintenance model (`dense_tree_versions.root_maintenance`) and
+    /// one amortized compaction blake3. The compacting append writes the
+    /// blob and the MMR nodes prepaid (zero-byte cost information) and is
+    /// charged the slot / record churn it does not write, so its figure is
+    /// the same; it also persists the MMR root (key `r`, 32 bytes, prepaid)
+    /// so a reopened tree reads it instead of bagging the peaks' blobs, and
+    /// the state root's two root reads are charged as the model. Stored
+    /// chunks and roots are identical under both versions; version 1 adds
+    /// the persisted root key.
     pub append_storage_accounting: FeatureVersion,
 }

--- a/grovedb-version/src/version/bulk_append_tree_versions.rs
+++ b/grovedb-version/src/version/bulk_append_tree_versions.rs
@@ -25,11 +25,14 @@ pub struct BulkAppendTreeCostVersions {
     /// multi-peak MMR under-reports by `peaks - 1`.
     ///
     /// Version 1 reports nothing for the compaction itself: its hashes (the
-    /// chunk-leaf hash, the push merges, the root bagging) are amortized
-    /// over the epoch as one blake3 on every append
-    /// (`AMORTIZED_COMPACTION_HASHES`), so a compacting append is charged
-    /// what any other append is. Shipped chunk bytes and roots are
-    /// unaffected; what moves is where the fee lands.
+    /// chunk-leaf hash, the push merges, the root bagging — at most 65 per
+    /// chunk with 32-bit MMR keys) are amortized over the epoch and charged
+    /// on every append as the per-chunk bound over `2^chunk_power`, rounded
+    /// up (`amortized_compaction_hashes`: one blake3 per append from
+    /// `chunk_power` 7, 33 at `chunk_power` 1), so a compacting append is
+    /// charged what any other append is and no prefix of the tree's life is
+    /// ever under-prepaid. Shipped chunk bytes and roots are unaffected;
+    /// what moves is where the fee lands.
     pub compaction_hash_count: FeatureVersion,
     /// How an append's data-storage writes are reported to the storage cost
     /// layer (issue #822).
@@ -42,8 +45,11 @@ pub struct BulkAppendTreeCostVersions {
     ///
     /// Version 1 charges every append the FIXED per-append model, whatever
     /// its position: the entry's long-term footprint as added storage — its
-    /// chunk-blob share (`value.len()`) plus the epoch's share of the blob
-    /// framing and MMR nodes (`amortized_compaction_added_bytes`) — and
+    /// chunk-blob share (`value.len()`, plus the variable format's four-byte
+    /// per-entry prefix unless the owner declared a fixed entry size with
+    /// `BulkAppendTree::with_fixed_entry_size`, as `CommitmentTree` and
+    /// `PrivateDocumentStore` do) plus the epoch's share of the blob framing
+    /// and MMR nodes (`amortized_compaction_added_bytes`) — and
     /// churn as replaced storage — its buffer slot and path record (epoch 1
     /// included, nothing read to size them; the buffer is a fixed-size
     /// per-tree scratch area rewritten every epoch) and its own bytes again

--- a/grovedb-version/src/version/bulk_append_tree_versions.rs
+++ b/grovedb-version/src/version/bulk_append_tree_versions.rs
@@ -54,8 +54,11 @@ pub struct BulkAppendTreeCostVersions {
     /// charged the slot / record churn it does not write, so its figure is
     /// the same; it also persists the MMR root (key `r`, 32 bytes, prepaid)
     /// so a reopened tree reads it instead of bagging the peaks' blobs, and
-    /// the state root's two root reads are charged as the model. Stored
-    /// chunks and roots are identical under both versions; version 1 adds
-    /// the persisted root key.
+    /// the state root's two root reads are charged as the model. A tree
+    /// whose last compaction predates version 1 has no such key: its first
+    /// version-1 append bags the peaks once and backfills the key (one
+    /// prepaid put, not billed — like the dense buffer's read-only
+    /// catch-up). Stored chunks and roots are identical under both
+    /// versions; version 1 adds the persisted root key.
     pub append_storage_accounting: FeatureVersion,
 }

--- a/grovedb-version/src/version/bulk_append_tree_versions.rs
+++ b/grovedb-version/src/version/bulk_append_tree_versions.rs
@@ -38,11 +38,16 @@ pub struct BulkAppendTreeCostVersions {
     ///
     /// Version 1 charges each entry's permanent bytes once, at its own
     /// append: the entry's chunk-blob share (`value.len()`) is reported as
-    /// added storage on every append; a buffer slot that already holds a
-    /// committed value is reported as replaced (growth added, shrink not
-    /// credited) and a slot written for the first time stays fully added; the
-    /// compaction blob is reported as a replacement of the entry bytes it
-    /// supersedes, with only its framing (and the MMR internal nodes) added.
-    /// Stored bytes, chunks and roots are identical under both versions.
+    /// added storage on every append; the dense buffer is churn — every
+    /// slot write and every path record write (epoch 1 included) is reported
+    /// as an in-place replacement of its own size, nothing added, no key
+    /// charged, nothing read to size it — since the buffer is a fixed-size
+    /// per-tree scratch area rewritten every epoch, not any entry's
+    /// long-term storage; the compaction blob is reported as a replacement
+    /// of the entry bytes it supersedes, with only its framing (and the MMR
+    /// internal nodes) added; and the buffer's fixed root-maintenance model
+    /// (`dense_tree_versions.root_maintenance`) is billed alongside the hash
+    /// count. Stored bytes, chunks and roots are identical under both
+    /// versions.
     pub append_storage_accounting: FeatureVersion,
 }

--- a/grovedb-version/src/version/commitment_tree_versions.rs
+++ b/grovedb-version/src/version/commitment_tree_versions.rs
@@ -27,4 +27,19 @@ pub struct CommitmentTreeCostVersions {
     /// paid size, `added_bytes` = growth only, shrink not credited); the very
     /// first save of a tree, which creates the key, stays fully added.
     pub frontier_save_storage_accounting: FeatureVersion,
+    /// How the Sinsemilla frontier's per-append cost is charged.
+    ///
+    /// Version 0 charges the actual work of the position: `32 +
+    /// trailing_ones(position)` Sinsemilla hashes on an append, the frontier's
+    /// actual serialized size (`42 + 32 · popcount(position)` bytes) when it
+    /// is loaded at open and rewritten at save. Version 1 charges a fixed
+    /// model derived from the tree's depth instead — `depth + 1` Sinsemilla
+    /// hashes (the root walk plus the average ommer merge) and a
+    /// `42 + 32 · depth/2`-byte frontier (the average over the position
+    /// space) loaded and replaced — so every append to a commitment tree
+    /// costs the same whatever its position. When set, it also decides the
+    /// save's storage accounting (a replacement of the model size), taking
+    /// precedence over `frontier_save_storage_accounting`. Frontier bytes
+    /// and anchors are identical under both.
+    pub frontier_cost_model: FeatureVersion,
 }

--- a/grovedb-version/src/version/dense_tree_versions.rs
+++ b/grovedb-version/src/version/dense_tree_versions.rs
@@ -23,19 +23,26 @@ pub struct DenseTreeVersions {
     /// insert of an epoch costs O(k), and a full `2^h - 1` buffer O(2^h) on
     /// its last insert. Reading the root costs the same walk.
     ///
-    /// Version 1 (GROVE_V4+) persists a per-position hash record
-    /// (`generation || value_hash || node_hash`, keyed `b'h' || position`)
-    /// and updates only the inserted position and its ancestors: an insert
-    /// reads at most two records per level (the parent's own record, for its
-    /// value hash, and the off-path sibling's), writes one record per level,
-    /// and hashes once per level plus twice for the leaf — O(h) for a tree of
-    /// height `h` instead of O(count). The root is the record at position 0
-    /// (one read). Records tagged with an older generation (an earlier epoch
-    /// over the same slot keys) or absent altogether (a buffer filled under
-    /// version 0) are not trusted: the sibling subtree is recomputed from its
-    /// values, exactly as version 0 would, and its record is written so the
-    /// next insert is O(h) again — a one-time catch-up that costs no more than
-    /// the version-0 walk.
+    /// Version 1 (GROVE_V4+) writes ONE path record per insert, under the
+    /// inserting position's key (`b'h' || position`): the position's value
+    /// hash and the node hash of every position on its ancestor path
+    /// (`generation || present mask || value_hash || one 32-byte entry per
+    /// level`, a fixed size for the tree's height). An insert derives its
+    /// ancestors' hashes from earlier inserts' records — the record of the
+    /// last insert into a subtree holds that subtree's current hash, located
+    /// arithmetically from `count` — reading at most two records per level
+    /// and hashing once per level plus twice for the leaf; the root is the
+    /// last insert's record. Every insert is CHARGED a fixed figure for the
+    /// tree's height (the blake3 calls and record reads averaged over a full
+    /// buffer, rounded up — `v1_insert_model_cost`), not the work of its
+    /// particular position, plus its two puts (slot, record) of
+    /// position-independent size: the cost of appending to a tree of a given
+    /// height is the same whatever the position. Records tagged with an older
+    /// generation (an earlier epoch over the same slot keys) or absent
+    /// altogether (a buffer filled under version 0) are not trusted: the
+    /// subtree is recomputed from its values, exactly as version 0 would —
+    /// read-only, billed the same model, and over once the epoch that
+    /// switched versions ends.
     ///
     /// Stored values, positions, proofs and root hashes are identical under
     /// both versions; what differs is the records written alongside the

--- a/grovedb-version/src/version/v1.rs
+++ b/grovedb-version/src/version/v1.rs
@@ -290,6 +290,8 @@ pub const GROVE_V1: GroveVersion = GroveVersion {
     commitment_tree_versions: CommitmentTreeVersions {
         cost: CommitmentTreeCostVersions {
             frontier_save_storage_accounting: 0,
+            // The frontier's actual per-position work. Locked.
+            frontier_cost_model: 0,
         },
     },
     // Dense-buffer root maintenance: the shipped behaviour, which keeps no

--- a/grovedb-version/src/version/v2.rs
+++ b/grovedb-version/src/version/v2.rs
@@ -289,6 +289,8 @@ pub const GROVE_V2: GroveVersion = GroveVersion {
     commitment_tree_versions: CommitmentTreeVersions {
         cost: CommitmentTreeCostVersions {
             frontier_save_storage_accounting: 0,
+            // The frontier's actual per-position work. Locked.
+            frontier_cost_model: 0,
         },
     },
     // Dense-buffer root maintenance: the shipped behaviour, which keeps no

--- a/grovedb-version/src/version/v3.rs
+++ b/grovedb-version/src/version/v3.rs
@@ -304,6 +304,8 @@ pub const GROVE_V3: GroveVersion = GroveVersion {
     commitment_tree_versions: CommitmentTreeVersions {
         cost: CommitmentTreeCostVersions {
             frontier_save_storage_accounting: 0,
+            // The frontier's actual per-position work. Locked.
+            frontier_cost_model: 0,
         },
     },
     // Dense-buffer root maintenance: the shipped behaviour, which keeps no

--- a/grovedb-version/src/version/v4.rs
+++ b/grovedb-version/src/version/v4.rs
@@ -102,37 +102,43 @@
 //! - `bulk_append_tree_versions.cost.append_storage_accounting: 1` and
 //!   `commitment_tree_versions.cost.frontier_save_storage_accounting: 1` —
 //!   the append-only family (`BulkAppendTree`, `CommitmentTree`,
-//!   `PrivateDocumentStore`) reports write churn as replacement instead of
-//!   as new storage (issue #822). Each entry's permanent bytes — its share
-//!   of the eventual chunk blob — are charged as `added_bytes` once, at its
-//!   own append; a dense-buffer slot that already holds a committed value
-//!   (epoch 2 onward) is reported as `replaced_bytes` (growth added, shrink
-//!   not credited); the compaction blob is reported as a replacement of the
-//!   entry bytes it supersedes, so only its framing and the MMR internal
-//!   nodes are added; and the in-place frontier rewrite is a replacement of
-//!   the bytes loaded at open. V1..V3 keep issuing every data put with no
-//!   cost information, which bills key + value as new storage every time —
-//!   ≈ 2× the bytes that persist, with the whole ≈ 630 KB blob landing on
-//!   one append per epoch at `chunk_power` 11. Stored bytes, roots and
-//!   proofs are identical under both; gated because the figures are fees.
+//!   `PrivateDocumentStore`) charges an entry's long-term bytes and reports
+//!   everything else as churn (issue #822). Each entry's permanent bytes —
+//!   its share of the eventual chunk blob — are charged as `added_bytes`
+//!   once, at its own append; the dense buffer (slot and path record, a
+//!   fixed per-tree scratch area rewritten every epoch) is `replaced_bytes`
+//!   only, epoch 1 included, with nothing read to size it; the compaction
+//!   blob is reported as a replacement of the entry bytes it supersedes, so
+//!   only its framing and the MMR internal nodes are added; the in-place
+//!   frontier rewrite is a replacement of the bytes loaded at open; and the
+//!   buffer's fixed root-maintenance model is billed alongside the hash
+//!   count. V1..V3 keep issuing every data put with no cost information,
+//!   which bills key + value as new storage every time — ≈ 2× the bytes
+//!   that persist, with the whole ≈ 630 KB blob landing on one append per
+//!   epoch at `chunk_power` 11. Stored bytes, roots and proofs are identical
+//!   under both; gated because the figures are fees.
 //!
 //! - `dense_tree_versions.root_maintenance: 1` — the dense fixed-sized Merkle
 //!   tree (the buffer of `BulkAppendTree`, `CommitmentTree` and
 //!   `PrivateDocumentStore`, and the `DenseAppendOnlyFixedSizeTree` element)
-//!   keeps a per-position hash record (`generation || value_hash ||
-//!   node_hash`, key `b'h' || position`) and updates only the inserted
-//!   position's ancestor path: O(height) reads, hashes and record writes per
-//!   insert, and a one-record read for the root. V1..V3 keep no intermediate
-//!   hashes and re-derive the root from every filled position on every insert
-//!   — O(count) per insert, O(2^chunk_power) at the end of each epoch, which
-//!   is the dominant per-append cost of the shielded pool at `chunk_power`
-//!   11 (≈ 2k reads and ≈ 4k blake3 calls on the last insert of every epoch).
-//!   Stored values, positions, proofs and roots are identical under both; a
-//!   buffer filled under V1..V3 is caught up from its values the first time a
-//!   V4 insert needs a record it lacks (at most one V1..V3-sized walk per
-//!   tree), so the V4 estimators keep the full-walk hash bound and add the
-//!   records' storage. Gated because the work — and so the fee — moves, and
-//!   because V4 writes keys V1..V3 never read.
+//!   writes one fixed-size path record per insert (key `b'h' || position`:
+//!   the position's value hash and the node hash of every position on its
+//!   ancestor path) and derives an insert's ancestor hashes from earlier
+//!   inserts' records: O(height) reads and hashes, ONE record write, and a
+//!   one-record read for the root. Every insert is charged a fixed,
+//!   height-derived model (`v1_insert_model_cost`: the reads and hashes
+//!   averaged over a full buffer, rounded up) plus its two
+//!   position-independent puts, so the cost of an append no longer depends
+//!   on the buffer position. V1..V3 keep no intermediate hashes and
+//!   re-derive the root from every filled position on every insert —
+//!   O(count) per insert, O(2^chunk_power) at the end of each epoch, which
+//!   was the dominant per-append cost of the shielded pool at `chunk_power`
+//!   11 (≈ 2k reads and ≈ 4k blake3 calls on the last insert of every
+//!   epoch). Stored values, positions, proofs and roots are identical under
+//!   both; a buffer filled under V1..V3 is caught up from its values by the
+//!   V4 inserts that need it (read-only, billed the same model, over with
+//!   the epoch the switch happened in). Gated because the work — and so the
+//!   fee — moves, and because V4 writes keys V1..V3 never read.
 //!
 //! Note that `GroveVersion::latest()` resolves to this version, so anything
 //! defaulting to "latest" — tests, benchmarks, tools — exercises every gate

--- a/grovedb-version/src/version/v4.rs
+++ b/grovedb-version/src/version/v4.rs
@@ -102,21 +102,32 @@
 //! - `bulk_append_tree_versions.cost.append_storage_accounting: 1` and
 //!   `commitment_tree_versions.cost.frontier_save_storage_accounting: 1` —
 //!   the append-only family (`BulkAppendTree`, `CommitmentTree`,
-//!   `PrivateDocumentStore`) charges an entry's long-term bytes and reports
-//!   everything else as churn (issue #822). Each entry's permanent bytes —
-//!   its share of the eventual chunk blob — are charged as `added_bytes`
-//!   once, at its own append; the dense buffer (slot and path record, a
-//!   fixed per-tree scratch area rewritten every epoch) is `replaced_bytes`
-//!   only, epoch 1 included, with nothing read to size it; the compaction
-//!   blob is reported as a replacement of the entry bytes it supersedes, so
-//!   only its framing and the MMR internal nodes are added; the in-place
-//!   frontier rewrite is a replacement of the bytes loaded at open; and the
-//!   buffer's fixed root-maintenance model is billed alongside the hash
-//!   count. V1..V3 keep issuing every data put with no cost information,
-//!   which bills key + value as new storage every time — ≈ 2× the bytes
-//!   that persist, with the whole ≈ 630 KB blob landing on one append per
-//!   epoch at `chunk_power` 11. Stored bytes, roots and proofs are identical
-//!   under both; gated because the figures are fees.
+//!   `PrivateDocumentStore`) charges every append the FIXED per-append model
+//!   (issue #822): the entry's long-term footprint as `added_bytes` — its
+//!   share of the eventual chunk blob plus the epoch's share of the blob
+//!   framing and MMR nodes — and churn as `replaced_bytes` — its buffer
+//!   slot and path record (epoch 1 included, nothing read to size them) and
+//!   its own bytes again as its part of the blob rewrite — plus the buffer's
+//!   fixed root-maintenance model and one amortized compaction blake3. The
+//!   compacting append writes the blob, the MMR nodes and the persisted MMR
+//!   root (new key `r`) prepaid and is charged the same as any other
+//!   append; a reopened tree reads the persisted root instead of bagging
+//!   the peaks' blobs. V1..V3 keep issuing every data put with no cost
+//!   information, which bills key + value as new storage every time — ≈ 2×
+//!   the bytes that persist, with the whole ≈ 630 KB blob landing on one
+//!   append per epoch at `chunk_power` 11. Stored chunks, roots and proofs
+//!   are identical under both; gated because the figures are fees.
+//!
+//! - `commitment_tree_versions.cost.frontier_cost_model: 1` — the Sinsemilla
+//!   frontier is charged a fixed, depth-derived model on every append: 33
+//!   Sinsemilla hashes (the 32-deep root walk plus the average ommer merge)
+//!   and a 554-byte frontier (the average over the position space) loaded
+//!   at open and replaced at save — instead of `32 + trailing_ones(position)`
+//!   hashes and the position's actual serialized size. With the gates above,
+//!   a `CommitmentTreeInsert` costs the same at every position; the only
+//!   residual is the commit-time seek count of a compacting append's MMR
+//!   puts (bounded, once per epoch). V1..V3 keep the actual figures; gated
+//!   because the figures are fees.
 //!
 //! - `dense_tree_versions.root_maintenance: 1` — the dense fixed-sized Merkle
 //!   tree (the buffer of `BulkAppendTree`, `CommitmentTree` and
@@ -469,9 +480,13 @@ pub const GROVE_V4: GroveVersion = GroveVersion {
     // Frontier save: the in-place rewrite of `__ct_data__` is reported as a
     // replacement of the bytes loaded at open, with only growth added
     // (issue #822). Frontier bytes and anchors are unchanged.
+    // Frontier: the in-place rewrite is a replacement, and — with the cost
+    // model — every append is charged the fixed, depth-derived figure (33
+    // Sinsemilla hashes, a 554-byte frontier) whatever its position.
     commitment_tree_versions: CommitmentTreeVersions {
         cost: CommitmentTreeCostVersions {
             frontier_save_storage_accounting: 1,
+            frontier_cost_model: 1,
         },
     },
     // Dense-buffer root maintenance: per-position hash records, so an insert

--- a/grovedb-version/src/version/v4.rs
+++ b/grovedb-version/src/version/v4.rs
@@ -477,12 +477,11 @@ pub const GROVE_V4: GroveVersion = GroveVersion {
             append_storage_accounting: 1,
         },
     },
-    // Frontier save: the in-place rewrite of `__ct_data__` is reported as a
-    // replacement of the bytes loaded at open, with only growth added
-    // (issue #822). Frontier bytes and anchors are unchanged.
-    // Frontier: the in-place rewrite is a replacement, and — with the cost
-    // model — every append is charged the fixed, depth-derived figure (33
-    // Sinsemilla hashes, a 554-byte frontier) whatever its position.
+    // Frontier: the in-place rewrite of `__ct_data__` is reported as a
+    // replacement, not new storage (issue #822), and — with the cost model —
+    // every append is charged the fixed, depth-derived figure (33 Sinsemilla
+    // hashes, a 554-byte frontier loaded and replaced) whatever its
+    // position. Frontier bytes and anchors are unchanged.
     commitment_tree_versions: CommitmentTreeVersions {
         cost: CommitmentTreeCostVersions {
             frontier_save_storage_accounting: 1,

--- a/grovedb-version/src/version/v4.rs
+++ b/grovedb-version/src/version/v4.rs
@@ -104,11 +104,15 @@
 //!   the append-only family (`BulkAppendTree`, `CommitmentTree`,
 //!   `PrivateDocumentStore`) charges every append the FIXED per-append model
 //!   (issue #822): the entry's long-term footprint as `added_bytes` — its
-//!   share of the eventual chunk blob plus the epoch's share of the blob
-//!   framing and MMR nodes — and churn as `replaced_bytes` — its buffer
-//!   slot and path record (epoch 1 included, nothing read to size them) and
-//!   its own bytes again as its part of the blob rewrite — plus the buffer's
-//!   fixed root-maintenance model and one amortized compaction blake3. The
+//!   share of the eventual chunk blob (plus the variable format's four-byte
+//!   per-entry prefix unless the owner declared a fixed entry size, as the
+//!   commitment tree and the private document store do) plus the epoch's
+//!   share of the blob framing and MMR nodes — and churn as `replaced_bytes`
+//!   — its buffer slot and path record (epoch 1 included, nothing read to
+//!   size them) and its own bytes again as its part of the blob rewrite —
+//!   plus the buffer's fixed root-maintenance model and the compaction's
+//!   hashes amortized as a per-chunk bound over the epoch (one blake3 per
+//!   append at `chunk_power` ≥ 7). The
 //!   compacting append writes the blob, the MMR nodes and the persisted MMR
 //!   root (new key `r`) prepaid and is charged the same as any other
 //!   append; a reopened tree reads the persisted root instead of bagging

--- a/grovedb/src/batch/estimated_costs/average_case_costs.rs
+++ b/grovedb/src/batch/estimated_costs/average_case_costs.rs
@@ -288,14 +288,19 @@ impl GroveOp {
                 // The compaction share shrinks with the epoch, so an
                 // undeclared layer takes the largest share (epoch 2), not the
                 // ceiling epoch's.
-                let amortized_compaction_added = match append_tree_chunk_power {
-                    Some(chunk_power) => {
-                        grovedb_bulk_append_tree::amortized_compaction_added_bytes(
-                            1u64 << chunk_power.min(16) as u32,
-                        )
-                    }
-                    None => super::max_amortized_compaction_added_bytes(),
-                };
+                let (amortized_compaction_added, amortized_compaction_hashes) =
+                    match append_tree_chunk_power {
+                        Some(chunk_power) => (
+                            grovedb_bulk_append_tree::amortized_compaction_added_bytes(
+                                1u64 << chunk_power.min(16) as u32,
+                            ),
+                            grovedb_bulk_append_tree::amortized_compaction_hashes(chunk_power),
+                        ),
+                        None => (
+                            super::max_amortized_compaction_added_bytes(),
+                            grovedb_bulk_append_tree::max_amortized_compaction_hashes(),
+                        ),
+                    };
                 // The puts a compacting append issues at commit instead of
                 // its slot and record: the chunk blob and up to the MMR
                 // merge bound of internal nodes — bounded, once per epoch.
@@ -326,8 +331,12 @@ impl GroveOp {
                         .saturating_add(buffer.cost.seek_count)
                         .saturating_add(MAX_COMPACTION_PUTS),
                     storage_cost: StorageCost {
-                        // Chunk-blob share + amortized framing and MMR node.
-                        added_bytes: entry_size.saturating_add(amortized_compaction_added),
+                        // Chunk-blob share + the variable format's per-entry
+                        // prefix (a generic bulk tree declares no entry
+                        // size) + amortized framing and MMR node.
+                        added_bytes: entry_size
+                            .saturating_add(grovedb_bulk_append_tree::VARIABLE_ENTRY_FRAMING_BYTES)
+                            .saturating_add(amortized_compaction_added),
                         // Slot and record (churn) + the value's part of the
                         // blob rewrite.
                         replaced_bytes: paid_entry
@@ -346,7 +355,7 @@ impl GroveOp {
                     hash_node_calls: buffer
                         .cost
                         .hash_node_calls
-                        .saturating_add(grovedb_bulk_append_tree::AMORTIZED_COMPACTION_HASHES)
+                        .saturating_add(amortized_compaction_hashes)
                         .saturating_add(1),
                     sinsemilla_hash_calls: 0,
                 })
@@ -2170,7 +2179,9 @@ mod tests {
         );
 
         // The estimate tracks the declared chunk power: a larger epoch means
-        // a deeper dense-buffer walk.
+        // a deeper dense-buffer model (more record reads and hashes) and a
+        // smaller amortized compaction share — the hash figure is exactly
+        // the model's plus the compaction bound plus the three roots.
         let small = op
             .average_case_cost(&key, &layer_info, Some(2), false, grove_version)
             .cost_as_result()
@@ -2179,11 +2190,25 @@ mod tests {
             .average_case_cost(&key, &layer_info, Some(10), false, grove_version)
             .cost_as_result()
             .expect("cost at chunk_power 10");
+        let own_hashes = |chunk_power: u8| {
+            super::super::dense_buffer_model(chunk_power)
+                .cost
+                .hash_node_calls
+                + grovedb_bulk_append_tree::amortized_compaction_hashes(chunk_power)
+                + 3
+        };
+        // What remains is the parent Merk's own hashing, the same at both.
+        assert!(small.hash_node_calls >= own_hashes(2));
+        assert_eq!(
+            small.hash_node_calls - own_hashes(2),
+            big.hash_node_calls - own_hashes(10),
+            "the append's own hashes are the model's plus the compaction bound plus the roots"
+        );
         assert!(
-            big.hash_node_calls > small.hash_node_calls,
-            "a larger declared epoch must cost more hashing ({} vs {})",
-            big.hash_node_calls,
-            small.hash_node_calls
+            big.storage_loaded_bytes > small.storage_loaded_bytes,
+            "a larger declared epoch reads more records ({} vs {})",
+            big.storage_loaded_bytes,
+            small.storage_loaded_bytes
         );
         // An entry's ADDED storage is its long-term footprint — its share
         // of the chunk blob; the buffer slot it passes through is churn

--- a/grovedb/src/batch/estimated_costs/average_case_costs.rs
+++ b/grovedb/src/batch/estimated_costs/average_case_costs.rs
@@ -273,49 +273,25 @@ impl GroveOp {
                 );
                 use grovedb_costs::storage_cost::{removal::StorageRemovedBytes, StorageCost};
                 let entry_size = value.len() as u32;
-                // Every append writes its buffer slot and its path record —
-                // churn under the GROVE_V4 accounting (issue #822): replaced,
-                // never added — and charges its chunk-blob share as added
-                // storage. The compaction — the blob replacing the epoch's
-                // entry bytes, plus its framing — is charged at the tree's
-                // epoch scale when its own layer is declared with
-                // `TreeType::BulkAppendTree(chunk_power)`, and amortized to
-                // one entry otherwise. The buffer's fixed root-maintenance
-                // model is charged at the declared scale, or the physical
-                // ceiling when undeclared.
-                //
-                // A BulkAppendTree accepts variable-size values, so the epoch
-                // is modelled as values the size of this one: exact for
-                // same-size values, an average otherwise — the bound-seeking
-                // worst-case arm saturates that dimension instead.
-                let epoch_entries: u32 = append_tree_chunk_power
-                    .map(|chunk_power| 1u32 << chunk_power.min(16) as u32)
-                    .unwrap_or(1);
+                // The fixed per-append model (GROVE_V4 accounting, issue
+                // #822): the value's chunk-blob share plus its share of the
+                // blob framing and MMR nodes as added storage; its buffer
+                // slot, path record and blob-rewrite part as churn; the
+                // buffer's root-maintenance model and one amortized
+                // compaction blake3 — at the tree's epoch scale when its own
+                // layer is declared with `TreeType::BulkAppendTree(chunk_power)`,
+                // at the physical ceiling otherwise.
+                let chunk_power =
+                    append_tree_chunk_power.unwrap_or(super::PHYSICAL_MAX_CHUNK_POWER);
+                let epoch_entries: u64 = 1u64 << chunk_power.min(16) as u32;
                 let paid_entry = entry_size.saturating_add(entry_size.required_space() as u32);
-                // Hashes: the buffer model, the state root and the running
-                // hash, and a compaction's chunk-leaf hash plus the MMR push
-                // merges and root bagging (each bounded by the 64-bit
-                // position space).
-                const MAX_MMR_MERGES: u32 = 65;
-                // MMR leaf key + envelope, variable-format header and
-                // per-entry length prefixes, and the internal nodes the push
-                // creates (key + 33-byte node + length each) — one per peak
-                // the push collapses, which the appender chooses by when it
-                // appends, so bounded by the position space rather than
-                // amortized to one.
-                let blob_framing = 37u32
-                    .saturating_add(37)
-                    .saturating_add(1)
-                    .saturating_add(epoch_entries.saturating_mul(4))
-                    .saturating_add(71 * MAX_MMR_MERGES);
-                let buffer = super::dense_buffer_model(
-                    append_tree_chunk_power.unwrap_or(super::PHYSICAL_MAX_CHUNK_POWER),
-                );
-                let hash_calls = buffer
-                    .cost
-                    .hash_node_calls
-                    .saturating_add(2)
-                    .saturating_add(2 * MAX_MMR_MERGES);
+                let buffer = super::dense_buffer_model(chunk_power);
+                let amortized_compaction_added =
+                    grovedb_bulk_append_tree::amortized_compaction_added_bytes(epoch_entries);
+                // The puts a compacting append issues at commit instead of
+                // its slot and record: the chunk blob and up to the MMR
+                // merge bound of internal nodes — bounded, once per epoch.
+                const MAX_COMPACTION_PUTS: u32 = 1 + 65;
                 // The preprocessing read of the stored element loads its
                 // caller-supplied flags too; bound them with the parent
                 // layer's declared flags size — the same metadata the
@@ -337,16 +313,18 @@ impl GroveOp {
                 item_cost.add_cost(OperationCost {
                     // The stored element read by preprocessing + 1 buffer
                     // entry write + 1 path record write + the buffer model's
-                    // record reads.
-                    seek_count: 3u32.saturating_add(buffer.cost.seek_count),
+                    // record reads + the compaction's puts as a bound.
+                    seek_count: 3u32
+                        .saturating_add(buffer.cost.seek_count)
+                        .saturating_add(MAX_COMPACTION_PUTS),
                     storage_cost: StorageCost {
-                        // Chunk-blob share + framing.
-                        added_bytes: entry_size.saturating_add(blob_framing),
-                        // Slot and record (churn) + the blob replacing the
-                        // epoch's entry bytes.
+                        // Chunk-blob share + amortized framing and MMR node.
+                        added_bytes: entry_size.saturating_add(amortized_compaction_added),
+                        // Slot and record (churn) + the value's part of the
+                        // blob rewrite.
                         replaced_bytes: paid_entry
                             .saturating_add(record_put)
-                            .saturating_add(epoch_entries.saturating_mul(entry_size)),
+                            .saturating_add(entry_size),
                         removed_bytes: StorageRemovedBytes::NoStorageRemoval,
                     },
                     // The stored element (fixed fields + Merk framing, with
@@ -355,7 +333,13 @@ impl GroveOp {
                     storage_loaded_bytes: (super::CT_ELEMENT_LOAD_BASE + element_flags_load_bound)
                         as u64
                         + buffer.cost.storage_loaded_bytes,
-                    hash_node_calls: hash_calls,
+                    // The buffer model, the amortized compaction, and the
+                    // state root.
+                    hash_node_calls: buffer
+                        .cost
+                        .hash_node_calls
+                        .saturating_add(grovedb_bulk_append_tree::AMORTIZED_COMPACTION_HASHES)
+                        .saturating_add(1),
                     sinsemilla_hash_calls: 0,
                 })
             }
@@ -407,6 +391,7 @@ impl GroveOp {
                     entry.len() as u32,
                     chunk_power,
                     element_flags_load_bound,
+                    grovedb_bulk_append_tree::amortized_compaction_added_bytes(1u64 << chunk_power),
                 ))
             }
 
@@ -645,6 +630,7 @@ impl GroveOp {
             payload.len() as u32,
             chunk_power,
             element_flags_load_bound,
+            grovedb_bulk_append_tree::amortized_compaction_added_bytes(1u64 << chunk_power),
         ))
     }
 }

--- a/grovedb/src/batch/estimated_costs/average_case_costs.rs
+++ b/grovedb/src/batch/estimated_costs/average_case_costs.rs
@@ -273,15 +273,16 @@ impl GroveOp {
                 );
                 use grovedb_costs::storage_cost::{removal::StorageRemovedBytes, StorageCost};
                 let entry_size = value.len() as u32;
-                // Every append writes its buffer slot and, under the GROVE_V4
-                // accounting (issue #822), charges its chunk-blob share as
-                // added storage, reads the slot's committed value to size a
-                // rewrite (epoch 2 on) and reports that rewrite as replaced.
-                // The compaction — the blob replacing the epoch's entry
-                // bytes, plus its framing — is charged at the tree's epoch
-                // scale when its own layer is declared with
+                // Every append writes its buffer slot and its path record —
+                // churn under the GROVE_V4 accounting (issue #822): replaced,
+                // never added — and charges its chunk-blob share as added
+                // storage. The compaction — the blob replacing the epoch's
+                // entry bytes, plus its framing — is charged at the tree's
+                // epoch scale when its own layer is declared with
                 // `TreeType::BulkAppendTree(chunk_power)`, and amortized to
-                // one entry otherwise.
+                // one entry otherwise. The buffer's fixed root-maintenance
+                // model is charged at the declared scale, or the physical
+                // ceiling when undeclared.
                 //
                 // A BulkAppendTree accepts variable-size values, so the epoch
                 // is modelled as values the size of this one: exact for
@@ -291,41 +292,30 @@ impl GroveOp {
                     .map(|chunk_power| 1u32 << chunk_power.min(16) as u32)
                     .unwrap_or(1);
                 let paid_entry = entry_size.saturating_add(entry_size.required_space() as u32);
+                // Hashes: the buffer model, the state root and the running
+                // hash, and a compaction's chunk-leaf hash plus the MMR push
+                // merges and root bagging (each bounded by the 64-bit
+                // position space).
+                const MAX_MMR_MERGES: u32 = 65;
                 // MMR leaf key + envelope, variable-format header and
-                // per-entry length prefixes, and one internal node.
+                // per-entry length prefixes, and the internal nodes the push
+                // creates (key + 33-byte node + length each) — one per peak
+                // the push collapses, which the appender chooses by when it
+                // appends, so bounded by the position space rather than
+                // amortized to one.
                 let blob_framing = 37u32
                     .saturating_add(37)
                     .saturating_add(1)
                     .saturating_add(epoch_entries.saturating_mul(4))
-                    .saturating_add(71);
-                // Hashes. Undeclared: the historical amortized figure (one
-                // running-hash call), an average with no epoch to scale by.
-                // Declared: an upper bound for the epoch — up to a
-                // full-buffer walk (two hashes per filled position: the
-                // GROVE_V1..V3 root recompute, and the one-time catch-up a
-                // buffer filled under those versions pays at its first
-                // GROVE_V4 append; a V4 append otherwise hashes only its
-                // ancestor path), the state root, and a compaction's
-                // chunk-leaf hash plus the MMR push merges and root bagging
-                // (each bounded by the 64-bit position space).
-                const AVG_HASH_CALLS: u32 = 1;
-                const MAX_MMR_MERGES: u32 = 65;
-                let hash_calls = if append_tree_chunk_power.is_some() {
-                    2u32.saturating_mul(epoch_entries.saturating_sub(1))
-                        .saturating_add(2)
-                        .saturating_add(2 * MAX_MMR_MERGES)
-                } else {
-                    AVG_HASH_CALLS
-                };
-                // The buffer's hash records (GROVE_V4 root maintenance):
-                // the ancestor-path rewrites, and the catch-up of a buffer
-                // filled under GROVE_V3. At the declared epoch scale, or the
-                // physical ceiling when undeclared. The bulk append bills
-                // their writes (at commit), not their reads.
-                let records = super::dense_record_maintenance_bound(
+                    .saturating_add(71 * MAX_MMR_MERGES);
+                let buffer = super::dense_buffer_model(
                     append_tree_chunk_power.unwrap_or(super::PHYSICAL_MAX_CHUNK_POWER),
-                    true,
                 );
+                let hash_calls = buffer
+                    .cost
+                    .hash_node_calls
+                    .saturating_add(2)
+                    .saturating_add(2 * MAX_MMR_MERGES);
                 // The preprocessing read of the stored element loads its
                 // caller-supplied flags too; bound them with the parent
                 // layer's declared flags size — the same metadata the
@@ -341,30 +331,30 @@ impl GroveOp {
                         return Err(Error::MerkError(e)).wrap_with_cost(OperationCost::default())
                     }
                 };
+                let record_put = buffer
+                    .record_len
+                    .saturating_add(buffer.record_len.required_space() as u32);
                 item_cost.add_cost(OperationCost {
-                    // 1 buffer entry write + 1 committed-slot read + the
-                    // record writes.
-                    seek_count: 2u32.saturating_add(records.record_writes),
+                    // The stored element read by preprocessing + 1 buffer
+                    // entry write + 1 path record write + the buffer model's
+                    // record reads.
+                    seek_count: 3u32.saturating_add(buffer.cost.seek_count),
                     storage_cost: StorageCost {
-                        // Slot (new in epoch 1) + chunk-blob share + framing
-                        // + records written for the first time.
-                        added_bytes: entry_size
-                            .saturating_mul(2)
-                            .saturating_add(blob_framing)
-                            .saturating_add(records.added_bytes),
-                        // Slot rewrite + the blob replacing the epoch's
-                        // entry bytes + the records rewritten on the path.
+                        // Chunk-blob share + framing.
+                        added_bytes: entry_size.saturating_add(blob_framing),
+                        // Slot and record (churn) + the blob replacing the
+                        // epoch's entry bytes.
                         replaced_bytes: paid_entry
-                            .saturating_add(epoch_entries.saturating_mul(entry_size))
-                            .saturating_add(records.replaced_bytes),
+                            .saturating_add(record_put)
+                            .saturating_add(epoch_entries.saturating_mul(entry_size)),
                         removed_bytes: StorageRemovedBytes::NoStorageRemoval,
                     },
                     // The stored element (fixed fields + Merk framing, with
-                    // the flags bound) read by preprocessing, and the
-                    // committed slot value read to size the rewrite.
+                    // the flags bound) read by preprocessing, and the buffer
+                    // model's records.
                     storage_loaded_bytes: (super::CT_ELEMENT_LOAD_BASE + element_flags_load_bound)
                         as u64
-                        + entry_size as u64,
+                        + buffer.cost.storage_loaded_bytes,
                     hash_node_calls: hash_calls,
                     sinsemilla_hash_calls: 0,
                 })
@@ -2201,14 +2191,15 @@ mod tests {
             big.hash_node_calls,
             small.hash_node_calls
         );
-        // Each entry is written TWICE across its lifetime: once into the
-        // dense buffer and once more into the chunk blob when the epoch
-        // compacts. The amortized per-append charge is therefore 2x the
-        // entry size, so doubling the entry grows added_bytes by 2 x 64.
+        // An entry's ADDED storage is its long-term footprint — its share
+        // of the chunk blob; the buffer slot it passes through is churn
+        // (replaced). So doubling the entry grows added_bytes by 64, and
+        // replaced_bytes by the slot's growth.
         assert_eq!(
             cost_large.storage_cost.added_bytes - cost.storage_cost.added_bytes,
-            128
+            64
         );
+        assert!(cost_large.storage_cost.replaced_bytes > cost.storage_cost.replaced_bytes);
     }
 
     #[test]

--- a/grovedb/src/batch/estimated_costs/average_case_costs.rs
+++ b/grovedb/src/batch/estimated_costs/average_case_costs.rs
@@ -283,11 +283,19 @@ impl GroveOp {
                 // at the physical ceiling otherwise.
                 let chunk_power =
                     append_tree_chunk_power.unwrap_or(super::PHYSICAL_MAX_CHUNK_POWER);
-                let epoch_entries: u64 = 1u64 << chunk_power.min(16) as u32;
                 let paid_entry = entry_size.saturating_add(entry_size.required_space() as u32);
                 let buffer = super::dense_buffer_model(chunk_power);
-                let amortized_compaction_added =
-                    grovedb_bulk_append_tree::amortized_compaction_added_bytes(epoch_entries);
+                // The compaction share shrinks with the epoch, so an
+                // undeclared layer takes the largest share (epoch 2), not the
+                // ceiling epoch's.
+                let amortized_compaction_added = match append_tree_chunk_power {
+                    Some(chunk_power) => {
+                        grovedb_bulk_append_tree::amortized_compaction_added_bytes(
+                            1u64 << chunk_power.min(16) as u32,
+                        )
+                    }
+                    None => super::max_amortized_compaction_added_bytes(),
+                };
                 // The puts a compacting append issues at commit instead of
                 // its slot and record: the chunk blob and up to the MMR
                 // merge bound of internal nodes — bounded, once per epoch.

--- a/grovedb/src/batch/estimated_costs/mod.rs
+++ b/grovedb/src/batch/estimated_costs/mod.rs
@@ -169,67 +169,50 @@ pub(in crate::batch) fn commitment_tree_insert_op_cost(
     payload_len: u32,
     chunk_power: u8,
     element_flags_load_bound: u32,
+    amortized_compaction_added: u32,
 ) -> OperationCost {
     // A stored note entry: cmx (32) || rho (32) || cv_net (32) || payload.
     let entry_size = 96u64 + payload_len as u64;
 
-    // Epoch size for the compaction bound. Clamped to the physical ceiling
-    // so hand-built layer information cannot overflow the shift.
-    let epoch_size: u32 = 1u32 << chunk_power.min(PHYSICAL_MAX_CHUNK_POWER);
-
     // The dense buffer's fixed root-maintenance charge, billed by the
     // commitment tree's append through `storage_accounting_cost`.
     let buffer = dense_buffer_model(chunk_power);
+    // The compaction, amortized over the epoch (bulk-append tree fixed
+    // model): one blake3 per append, and — `amortized_compaction_added`,
+    // supplied by the caller: the declared epoch's share, or the largest
+    // share the type permits for a bound — the blob framing and MMR nodes
+    // as added storage.
+    // The frontier's fixed model: the depth-deep root walk plus the average
+    // ommer merge, and the average serialized frontier loaded and replaced.
+    let frontier_len = grovedb_commitment_tree::MODEL_FRONTIER_SERIALIZED_LEN;
 
-    // Chunk-blob framing per blob: the fixed-format header (format byte,
-    // entry count, entry size) inside the MMR leaf envelope (flag, hash,
-    // length) — 9 + 37 — with margin. Every note in a commitment tree has
-    // the same size, so its blobs always take the fixed format, which
-    // carries no per-entry framing.
-    const CHUNK_BLOB_OVERHEAD: u64 = 64;
-    // An MMR internal node: 1 (flag) + 32 (hash).
-    const MMR_INTERNAL_NODE_SIZE: u64 = 33;
-
-    // The epoch term multiplies the entry size by up to 2^16, which
-    // overflows u32 for hand-built ops with oversized payloads (the op
-    // is public; the apply path only rejects wrong-sized payloads
-    // later). Sum in u64 and saturate at u32::MAX — a wrapped figure
-    // would silently UNDER-estimate, the exact failure this model exists
-    // to prevent, while a saturated one merely over-reserves for an op
-    // the apply would reject anyway.
-    //
-    // Added storage — what this append makes the database permanently
-    // larger by:
-    // - the note's share of the eventual chunk blob (its own bytes),
-    //   charged at every append so the blob is a replacement when it lands,
-    // - the frontier's very first save (key + value); later saves only
-    //   add growth (at most one ommer), which this term dominates,
-    // - on compaction: the blob's framing beyond the prepaid entry bytes,
-    //   and the MMR merge cascade's internal nodes.
-    // The buffer slot and the path record are churn: never added.
-    let added_bytes_u64: u64 = entry_size
-        + (MAX_FRONTIER_SIZE as u64 + PER_PUT_OVERHEAD as u64)
-        + (CHUNK_BLOB_OVERHEAD + PER_PUT_OVERHEAD as u64)
-        + FRONTIER_DEPTH as u64 * (MMR_INTERNAL_NODE_SIZE + PER_PUT_OVERHEAD as u64);
-    // Replaced storage — bytes rewritten over bytes that were already
-    // paid for, or churn:
+    // Added storage — the note's long-term footprint: its share of the
+    // eventual chunk blob (its own bytes), charged at every append so the
+    // blob is prepaid when it lands, plus its share of the blob framing and
+    // the MMR nodes. The buffer slot, the path record and the frontier are
+    // churn: never added.
+    let added_bytes_u64: u64 = entry_size + amortized_compaction_added as u64;
+    // Replaced storage — churn:
     // - the note's buffer slot (every epoch, epoch 1 included),
     // - the path record the insert writes (fixed size for the height),
-    // - the re-serialized frontier (up to MAX_FRONTIER_SIZE),
-    // - on compaction: the whole epoch's entry bytes, which the chunk blob
-    //   supersedes and every append already charged as added.
+    // - the note's own bytes again, as its part of the blob rewrite the
+    //   epoch's compaction performs,
+    // - the re-serialized frontier, at the model size.
     let replaced_bytes_u64: u64 = (entry_size + PER_PUT_OVERHEAD as u64)
         + (buffer.record_len as u64 + PER_PUT_OVERHEAD as u64)
-        + (MAX_FRONTIER_SIZE as u64 + PER_PUT_OVERHEAD as u64)
-        + epoch_size as u64 * entry_size;
+        + entry_size
+        + (frontier_len as u64 + PER_PUT_OVERHEAD as u64);
+
+    // The puts a compacting append issues at commit instead of its slot and
+    // record: the chunk blob and up to the MMR merge bound of internal nodes
+    // — the one position-dependent residual (bounded, once per epoch).
+    const MAX_COMPACTION_PUTS: u32 = 1 + 65;
 
     OperationCost {
         // 2 reads (CommitmentTree element, frontier) + the buffer model's
-        // record reads, and up to 4 + FRONTIER_DEPTH writes (note entry,
-        // path record, frontier, chunk blob, MMR internal nodes; a
-        // compacting append writes no slot or record and a buffered one no
-        // MMR node, summed as a bound).
-        seek_count: 6 + FRONTIER_DEPTH + buffer.cost.seek_count,
+        // record reads, and 3 writes (note entry, path record, frontier);
+        // plus the compaction's puts as a bound.
+        seek_count: 5 + buffer.cost.seek_count + MAX_COMPACTION_PUTS,
         storage_cost: StorageCost {
             added_bytes: u32::try_from(added_bytes_u64).unwrap_or(u32::MAX),
             // The parent-Merk node replacement is charged by the
@@ -239,17 +222,17 @@ pub(in crate::batch) fn commitment_tree_insert_op_cost(
         },
         // Reads: the stored CommitmentTree element (fixed serialized
         // fields + Merk node framing, plus the caller-supplied flags
-        // bound) + the serialized frontier + the buffer model's records.
-        storage_loaded_bytes: (CT_ELEMENT_LOAD_BASE
-            + element_flags_load_bound
-            + MAX_FRONTIER_SIZE
-            + PER_PUT_OVERHEAD) as u64
+        // bound) + the model-sized frontier + the buffer model's records.
+        storage_loaded_bytes: (CT_ELEMENT_LOAD_BASE + element_flags_load_bound + frontier_len)
+            as u64
             + buffer.cost.storage_loaded_bytes,
-        // Blake3: the buffer model (fixed per insert), plus on compaction
-        // the chunk-leaf hash and MMR merge cascade, plus the bulk state
-        // root and the ct_state binding hash.
-        hash_node_calls: buffer.cost.hash_node_calls + FRONTIER_DEPTH + 4,
-        sinsemilla_hash_calls: MAX_SINSEMILLA_HASHES_PER_APPEND,
+        // Blake3: the buffer model, the amortized compaction, the bulk
+        // state root and the ct_state binding hash — the same at every
+        // position.
+        hash_node_calls: buffer.cost.hash_node_calls
+            + grovedb_bulk_append_tree::AMORTIZED_COMPACTION_HASHES
+            + 2,
+        sinsemilla_hash_calls: grovedb_commitment_tree::MODEL_FRONTIER_APPEND_SINSEMILLA_HASHES,
     }
 }
 
@@ -288,77 +271,57 @@ pub(in crate::batch) fn private_document_store_insert_op_cost(
     entry_size: u32,
     chunk_power: u8,
     element_flags_load_bound: u32,
+    amortized_compaction_added: u32,
 ) -> OperationCost {
     let chunk_power = chunk_power.clamp(1, PHYSICAL_MAX_CHUNK_POWER);
-    let epoch_entries: u32 = 1u32 << chunk_power;
-    // The buffer holds `2^chunk_power - 1` positions; a compacting append
-    // reads every one of them back to build the chunk blob.
-    let compaction_reads: u32 = epoch_entries - 1;
     let buffer = dense_buffer_model(chunk_power);
-    /// MMR push merges plus root bagging (bounded by the 64-bit position
-    /// space).
-    const MAX_MMR_MERGES: u32 = 65;
-    const MAX_MMR_READS: u32 = 64;
     /// Bulk state root + composite pds_state root + the committed-config
     /// hash paid when the store is opened.
     const ROOT_AND_CONFIG_HASHES: u32 = 3;
-    // A compacted epoch is not stored as a bare payload: the chunk blob
-    // carries a 9-byte header, sits inside a 37-byte MMR leaf envelope, and
-    // every internal MMR node the push creates costs a further 33 bytes.
-    const CHUNK_HEADER_BYTES: u32 = 9;
-    const MMR_LEAF_ENVELOPE_BYTES: u32 = 37;
-    const MMR_INTERNAL_NODE_BYTES: u32 = 33;
-    const MMR_SERIALIZATION_OVERHEAD: u32 =
-        CHUNK_HEADER_BYTES + MMR_LEAF_ENVELOPE_BYTES + MMR_INTERNAL_NODE_BYTES * MAX_MMR_MERGES;
-    // `entry_size` is capped at `u16::MAX` at every creation site precisely
-    // so this product stays representable in the u32 `added_bytes` field.
-    let max_compaction_blob = epoch_entries
-        .saturating_mul(entry_size)
-        .saturating_add(MMR_SERIALIZATION_OVERHEAD);
+    /// The puts a compacting append issues at commit instead of its slot and
+    /// record: the chunk blob and up to the MMR merge bound of internal
+    /// nodes — the one position-dependent residual (bounded, once per
+    /// epoch).
+    const MAX_COMPACTION_PUTS: u32 = 1 + 65;
     // A NonCounted-wrapped store serializes one byte wider, and the apply
     // path preserves that wrapper. Neither the op nor the declared layer
     // records whether this store is wrapped, so charge the byte
     // unconditionally.
     const NON_COUNTED_WRAPPER_BYTE: u32 = 1;
     OperationCost {
-        // Writes: the buffer entry, its path record, the chunk blob and the
-        // MMR nodes; reads: the stored element, the last insert's record
-        // for the state root, the MMR siblings, the epoch read back on
-        // compaction, and the buffer model's record reads.
-        seek_count: (1 + 1 + 1 + MAX_MMR_MERGES)
+        // Reads: the stored element, the last insert's record for the state
+        // root, the buffer model's record reads; writes: the buffer entry
+        // and its path record; plus the compaction's puts as a bound.
+        seek_count: 2u32
+            .saturating_add(buffer.cost.seek_count)
             .saturating_add(2)
-            .saturating_add(MAX_MMR_READS)
-            .saturating_add(compaction_reads)
-            .saturating_add(buffer.cost.seek_count),
+            .saturating_add(MAX_COMPACTION_PUTS),
         storage_cost: StorageCost {
-            // The entry's chunk-blob share (GROVE_V4 accounting, issue
-            // #822), the blob's framing and MMR nodes, the wrapper byte.
+            // The entry's chunk-blob share plus its share of the blob
+            // framing and MMR nodes (GROVE_V4 accounting, issue #822), and
+            // the wrapper byte.
             added_bytes: entry_size
-                .saturating_add(MMR_SERIALIZATION_OVERHEAD)
+                .saturating_add(amortized_compaction_added)
                 .saturating_add(NON_COUNTED_WRAPPER_BYTE),
             // The buffer slot and the path record (churn, every epoch), and
-            // the compaction blob (a replacement of the epoch's prepaid
-            // entry bytes).
+            // the entry's own bytes as its part of the blob rewrite.
             replaced_bytes: entry_size
                 .saturating_add(PER_PUT_OVERHEAD)
                 .saturating_add(buffer.record_len)
                 .saturating_add(PER_PUT_OVERHEAD)
-                .saturating_add(max_compaction_blob),
+                .saturating_add(entry_size),
             removed_bytes: StorageRemovedBytes::NoStorageRemoval,
         },
         // The stored element (fixed fields + Merk framing, with the flags
-        // bound), the epoch read back on compaction, the blob read back as
-        // an MMR peak, the MMR siblings, the buffer model's records and the
-        // root record.
+        // bound), the buffer model's records and the root record.
         storage_loaded_bytes: (CT_ELEMENT_LOAD_BASE + element_flags_load_bound) as u64
-            + compaction_reads as u64 * entry_size as u64
-            + max_compaction_blob as u64
-            + (MMR_INTERNAL_NODE_BYTES * MAX_MMR_READS) as u64
             + buffer.cost.storage_loaded_bytes
             + buffer.record_len as u64,
-        // The buffer model, a compacting append's chunk leaf hash and MMR
-        // cascade, and the roots.
-        hash_node_calls: buffer.cost.hash_node_calls + 1 + MAX_MMR_MERGES + ROOT_AND_CONFIG_HASHES,
+        // The buffer model, the amortized compaction, and the roots — the
+        // same at every position.
+        hash_node_calls: buffer.cost.hash_node_calls
+            + grovedb_bulk_append_tree::AMORTIZED_COMPACTION_HASHES
+            + ROOT_AND_CONFIG_HASHES,
         sinsemilla_hash_calls: 0,
     }
 }
@@ -397,6 +360,15 @@ pub(in crate::batch) fn dense_tree_insert_op_cost(value_size: u32, height: u8) -
         hash_node_calls: buffer.cost.hash_node_calls,
         sinsemilla_hash_calls: 0,
     }
+}
+
+/// The largest per-append share of the compaction overhead the type
+/// permits — the smallest epoch (`chunk_power` 1) — for the worst-case
+/// estimators, which have no declaration channel. The share shrinks as the
+/// epoch grows, so the ceiling epoch is NOT the bound here.
+#[cfg(feature = "minimal")]
+pub(in crate::batch) fn max_amortized_compaction_added_bytes() -> u32 {
+    grovedb_bulk_append_tree::amortized_compaction_added_bytes(2)
 }
 
 /// Estimated costs types

--- a/grovedb/src/batch/estimated_costs/mod.rs
+++ b/grovedb/src/batch/estimated_costs/mod.rs
@@ -230,7 +230,7 @@ pub(in crate::batch) fn commitment_tree_insert_op_cost(
         // state root and the ct_state binding hash — the same at every
         // position.
         hash_node_calls: buffer.cost.hash_node_calls
-            + grovedb_bulk_append_tree::AMORTIZED_COMPACTION_HASHES
+            + grovedb_bulk_append_tree::amortized_compaction_hashes(chunk_power)
             + 2,
         sinsemilla_hash_calls: grovedb_commitment_tree::MODEL_FRONTIER_APPEND_SINSEMILLA_HASHES,
     }
@@ -320,7 +320,7 @@ pub(in crate::batch) fn private_document_store_insert_op_cost(
         // The buffer model, the amortized compaction, and the roots — the
         // same at every position.
         hash_node_calls: buffer.cost.hash_node_calls
-            + grovedb_bulk_append_tree::AMORTIZED_COMPACTION_HASHES
+            + grovedb_bulk_append_tree::amortized_compaction_hashes(chunk_power)
             + ROOT_AND_CONFIG_HASHES,
         sinsemilla_hash_calls: 0,
     }

--- a/grovedb/src/batch/estimated_costs/mod.rs
+++ b/grovedb/src/batch/estimated_costs/mod.rs
@@ -89,64 +89,35 @@ pub const PHYSICAL_MAX_CHUNK_POWER: u8 = 16;
 #[cfg(feature = "minimal")]
 const PER_PUT_OVERHEAD: u32 = 50;
 
-/// Per-insert upper bound on the dense buffer's hash-record maintenance
-/// (root-maintenance version 1, GROVE_V4+) for a buffer of `height`
-/// (`chunk_power` for the append-only family, the element's height for a
-/// `DenseAppendOnlyFixedSizeTree`).
+/// The dense buffer's fixed per-insert root-maintenance charge under
+/// GROVE_V4 (`dense_tree_versions.root_maintenance = 1`) for a tree of
+/// `height` (`chunk_power` for the append-only family, the element's height
+/// for a `DenseAppendOnlyFixedSizeTree`): what every insert is billed for
+/// the buffer — the blake3 calls and path-record reads, averaged over a full
+/// buffer and rounded up — whatever its position. Exactly the figure the
+/// dense tree returns (`v1_insert_model_cost`), so an estimate built on it
+/// is tight, not a bound; the slot and record puts the insert issues are
+/// real writes sized by the owner's accounting (see the callers).
 ///
-/// An insert at depth `d` (≤ `height - 1`) rewrites the records of the
-/// `d + 1` positions on its ancestor path, reads at most the parent's and
-/// the sibling's record per level plus — for a slot that already holds a
-/// committed value — its own record once to size the write, and hashes
-/// `2 + d` times. A buffer filled under GROVE_V1..V3 (no records) is caught
-/// up by the first GROVE_V4 insert that needs them: each sibling subtree
-/// without a current record is walked from its values (the full walk, in
-/// total no more than the version-0 `2 * count` hashes) and its root
-/// recorded — at most one more record per level. `catch_up` includes those
-/// writes; pass `false` for a tree that can only have been written under
-/// GROVE_V4 (the `PrivateDocumentStore`, which activates in V4).
-///
-/// Reads are bounded here for the callers that bill them (the
-/// `CostResult`-returning appends: `PrivateDocumentStore`,
-/// `DenseAppendOnlyFixedSizeTree`); the `Result`-returning bulk / commitment
-/// appends drop them and bill the hash count alone, as they always have.
-/// Record writes reach every caller's cost at commit.
+/// A buffer filled under GROVE_V1..V3 is caught up from its values by its
+/// first V4 inserts; that work is real but billed the same model, so no
+/// estimator needs a full-buffer walk any more.
 #[cfg(feature = "minimal")]
-pub(in crate::batch) struct DenseRecordMaintenanceBound {
-    /// Record puts (one seek each at commit).
-    pub record_writes: u32,
-    /// Record reads (one seek each).
-    pub record_reads: u32,
-    /// Bytes a record put can add: key, record and framing, per write.
-    pub added_bytes: u32,
-    /// Bytes a record rewrite replaces, per write.
-    pub replaced_bytes: u32,
-    /// Bytes the record reads load.
-    pub loaded_bytes: u64,
-    /// blake3 calls: two for the leaf, one per ancestor level.
-    pub hash_calls: u32,
+pub(in crate::batch) struct DenseBufferModel {
+    /// The model: record reads (seeks + loaded bytes) and blake3 calls.
+    pub cost: OperationCost,
+    /// Bytes of one path record for this height: what the insert's record
+    /// put writes.
+    pub record_len: u32,
 }
 
 #[cfg(feature = "minimal")]
-pub(in crate::batch) fn dense_record_maintenance_bound(
-    height: u8,
-    catch_up: bool,
-) -> DenseRecordMaintenanceBound {
-    use grovedb_dense_fixed_sized_merkle_tree::HASH_RECORD_LEN;
-    let height = height.clamp(1, PHYSICAL_MAX_CHUNK_POWER) as u32;
-    let path_records = height;
-    let catch_up_records = if catch_up { height - 1 } else { 0 };
-    let record_writes = path_records + catch_up_records;
-    // Parent + sibling per ancestor level, plus the own-record sizing read.
-    let record_reads = 2 * (height - 1) + 1;
-    let record_put_bytes = HASH_RECORD_LEN as u32 + PER_PUT_OVERHEAD;
-    DenseRecordMaintenanceBound {
-        record_writes,
-        record_reads,
-        added_bytes: record_writes * record_put_bytes,
-        replaced_bytes: record_writes * record_put_bytes,
-        loaded_bytes: record_reads as u64 * HASH_RECORD_LEN as u64,
-        hash_calls: 2 + (height - 1),
+pub(in crate::batch) fn dense_buffer_model(height: u8) -> DenseBufferModel {
+    use grovedb_dense_fixed_sized_merkle_tree::V1InsertModel;
+    let model = V1InsertModel::for_height(height.clamp(1, PHYSICAL_MAX_CHUNK_POWER));
+    DenseBufferModel {
+        cost: model.cost(),
+        record_len: model.record_len,
     }
 }
 
@@ -163,9 +134,9 @@ const CT_ELEMENT_LOAD_BASE: u32 = 256;
 /// Upper-bound cost of the append work a single `CommitmentTreeInsert`
 /// performs outside the parent Merk (which is charged separately via
 /// `average/worst_case_merk_replace_tree`): frontier I/O and Sinsemilla
-/// hashing, the note write into the dense buffer (with its per-append
-/// root recompute), and a full epoch compaction (chunk-blob write plus
-/// MMR merge cascade).
+/// hashing, the note write into the dense buffer with the buffer's fixed
+/// root-maintenance model, and a full epoch compaction (chunk-blob write
+/// plus MMR merge cascade).
 ///
 /// `chunk_power` is the tree's epoch scale: the average-case estimator
 /// requires it declared in the tree's own layer in the estimation paths
@@ -188,8 +159,11 @@ const CT_ELEMENT_LOAD_BASE: u32 = 256;
 /// control (see issue #812).
 ///
 /// The storage terms follow the GROVE_V4 accounting of the append-only
-/// family (issue #822), which charges each note's permanent bytes once
-/// and reports write churn as replacement — see the field comments.
+/// family (issue #822): a note's ADDED storage is its long-term footprint —
+/// its share of the chunk blob (prepaid at its append), the blob's framing
+/// and the MMR nodes, amortized — while the dense buffer (slot and path
+/// record, a fixed per-tree scratch area rewritten every epoch) and the
+/// frontier are churn, reported as REPLACED bytes only.
 #[cfg(feature = "minimal")]
 pub(in crate::batch) fn commitment_tree_insert_op_cost(
     payload_len: u32,
@@ -199,16 +173,13 @@ pub(in crate::batch) fn commitment_tree_insert_op_cost(
     // A stored note entry: cmx (32) || rho (32) || cv_net (32) || payload.
     let entry_size = 96u64 + payload_len as u64;
 
-    // Epoch size for the compaction and dense-recompute bounds. Clamped
-    // to the physical ceiling so hand-built layer information cannot
-    // overflow the shift.
+    // Epoch size for the compaction bound. Clamped to the physical ceiling
+    // so hand-built layer information cannot overflow the shift.
     let epoch_size: u32 = 1u32 << chunk_power.min(PHYSICAL_MAX_CHUNK_POWER);
 
-    // The dense buffer's hash records (GROVE_V4 root maintenance): the
-    // ancestor-path rewrites every append performs, plus the catch-up a
-    // buffer filled under GROVE_V3 pays once. Their reads are not billed
-    // by the commitment tree's append (see `dense_record_maintenance_bound`).
-    let records = dense_record_maintenance_bound(chunk_power, true);
+    // The dense buffer's fixed root-maintenance charge, billed by the
+    // commitment tree's append through `storage_accounting_cost`.
+    let buffer = dense_buffer_model(chunk_power);
 
     // Chunk-blob framing per blob: the fixed-format header (format byte,
     // entry count, entry size) inside the MMR leaf envelope (flag, hash,
@@ -229,43 +200,36 @@ pub(in crate::batch) fn commitment_tree_insert_op_cost(
     //
     // Added storage — what this append makes the database permanently
     // larger by:
-    // - the note's dense-buffer slot when written for the first time
-    //   (epoch 1), key included; later epochs rewrite it (replaced below),
     // - the note's share of the eventual chunk blob (its own bytes),
     //   charged at every append so the blob is a replacement when it lands,
     // - the frontier's very first save (key + value); later saves only
     //   add growth (at most one ommer), which this term dominates,
     // - on compaction: the blob's framing beyond the prepaid entry bytes,
-    //   and the MMR merge cascade's internal nodes,
-    // - the buffer's hash records written for the first time (the new
-    //   leaf's in epoch 1; on a GROVE_V3 → V4 catch-up, every record the
-    //   insert derives).
-    let added_bytes_u64: u64 = (entry_size + PER_PUT_OVERHEAD as u64)
-        + entry_size
+    //   and the MMR merge cascade's internal nodes.
+    // The buffer slot and the path record are churn: never added.
+    let added_bytes_u64: u64 = entry_size
         + (MAX_FRONTIER_SIZE as u64 + PER_PUT_OVERHEAD as u64)
         + (CHUNK_BLOB_OVERHEAD + PER_PUT_OVERHEAD as u64)
-        + FRONTIER_DEPTH as u64 * (MMR_INTERNAL_NODE_SIZE + PER_PUT_OVERHEAD as u64)
-        + records.added_bytes as u64;
+        + FRONTIER_DEPTH as u64 * (MMR_INTERNAL_NODE_SIZE + PER_PUT_OVERHEAD as u64);
     // Replaced storage — bytes rewritten over bytes that were already
-    // paid for:
-    // - the note's buffer slot from epoch 2 on,
+    // paid for, or churn:
+    // - the note's buffer slot (every epoch, epoch 1 included),
+    // - the path record the insert writes (fixed size for the height),
     // - the re-serialized frontier (up to MAX_FRONTIER_SIZE),
     // - on compaction: the whole epoch's entry bytes, which the chunk blob
-    //   supersedes and every append already charged as added,
-    // - the buffer's hash records rewritten along the ancestor path.
+    //   supersedes and every append already charged as added.
     let replaced_bytes_u64: u64 = (entry_size + PER_PUT_OVERHEAD as u64)
+        + (buffer.record_len as u64 + PER_PUT_OVERHEAD as u64)
         + (MAX_FRONTIER_SIZE as u64 + PER_PUT_OVERHEAD as u64)
-        + epoch_size as u64 * entry_size
-        + records.replaced_bytes as u64;
+        + epoch_size as u64 * entry_size;
 
     OperationCost {
-        // 3 reads (CommitmentTree element, frontier, and the committed
-        // note slot a rewrite is sized against) and up to 3 + FRONTIER_DEPTH
-        // writes (note entry, frontier, chunk blob, MMR internal nodes),
-        // plus the hash-record writes (a compacting append writes no
-        // records and a buffered one no MMR nodes, so the two never stack;
-        // summed here as a bound).
-        seek_count: 6 + FRONTIER_DEPTH + records.record_writes,
+        // 2 reads (CommitmentTree element, frontier) + the buffer model's
+        // record reads, and up to 4 + FRONTIER_DEPTH writes (note entry,
+        // path record, frontier, chunk blob, MMR internal nodes; a
+        // compacting append writes no slot or record and a buffered one no
+        // MMR node, summed as a bound).
+        seek_count: 6 + FRONTIER_DEPTH + buffer.cost.seek_count,
         storage_cost: StorageCost {
             added_bytes: u32::try_from(added_bytes_u64).unwrap_or(u32::MAX),
             // The parent-Merk node replacement is charged by the
@@ -275,21 +239,16 @@ pub(in crate::batch) fn commitment_tree_insert_op_cost(
         },
         // Reads: the stored CommitmentTree element (fixed serialized
         // fields + Merk node framing, plus the caller-supplied flags
-        // bound) + the serialized frontier + the committed note the
-        // rewritten buffer slot holds (epoch 2 on).
+        // bound) + the serialized frontier + the buffer model's records.
         storage_loaded_bytes: (CT_ELEMENT_LOAD_BASE
             + element_flags_load_bound
             + MAX_FRONTIER_SIZE
             + PER_PUT_OVERHEAD) as u64
-            + entry_size,
-        // Blake3: up to a full-buffer walk — two hashes per filled slot.
-        // From GROVE_V4 a buffered append hashes only its ancestor path
-        // (`records.hash_calls`), but a buffer filled under GROVE_V3 pays
-        // the walk once when its first V4 append catches its records up,
-        // and that insert is admitted under this bound, so the walk stays.
-        // Plus on compaction the chunk-leaf hash and MMR merge cascade,
-        // plus the bulk state root and the ct_state binding hash.
-        hash_node_calls: (2 * (epoch_size - 1)).max(records.hash_calls) + FRONTIER_DEPTH + 4,
+            + buffer.cost.storage_loaded_bytes,
+        // Blake3: the buffer model (fixed per insert), plus on compaction
+        // the chunk-leaf hash and MMR merge cascade, plus the bulk state
+        // root and the ct_state binding hash.
+        hash_node_calls: buffer.cost.hash_node_calls + FRONTIER_DEPTH + 4,
         sinsemilla_hash_calls: MAX_SINSEMILLA_HASHES_PER_APPEND,
     }
 }
@@ -297,11 +256,11 @@ pub(in crate::batch) fn commitment_tree_insert_op_cost(
 /// Upper-bound cost of the append work a single `PrivateDocumentStoreInsert`
 /// performs outside the parent Merk (charged separately via
 /// `average/worst_case_merk_replace_tree`): the entry write into the dense
-/// buffer with its hash-record maintenance (GROVE_V4 root maintenance — the
-/// store activates in V4, so every store's buffer has records and none ever
-/// pays a V3 catch-up walk), and a full epoch compaction (the epoch read back
-/// position by position, the chunk blob written and pushed through the MMR,
-/// the blob read back as a peak when the MMR root is bagged).
+/// buffer with the buffer's fixed root-maintenance model (GROVE_V4; the
+/// store activates in V4, so every store's buffer has records), and a full
+/// epoch compaction (the epoch read back position by position, the chunk
+/// blob written and pushed through the MMR, the blob read back as a peak
+/// when the MMR root is bagged).
 ///
 /// `chunk_power` is the store's epoch scale: the average-case estimator
 /// requires it declared in the store's own layer
@@ -315,25 +274,27 @@ pub(in crate::batch) fn commitment_tree_insert_op_cost(
 ///
 /// A genuine UPPER BOUND over every position, shared by both estimators for
 /// the same reason as [`commitment_tree_insert_op_cost`]: the expensive
-/// positions (the deepest ancestor path, the compaction) are deterministic
-/// and adversary-reachable, so an "average" is not a meaningful bound, and
-/// two differing models would be silently non-interchangeable (issue #812).
-/// A buffered append hashes its ancestor path and writes no MMR node; a
-/// compacting append reads the epoch back and writes no record — never both,
-/// summed here as a bound.
+/// position (the compaction) is deterministic and adversary-reachable, so
+/// an "average" is not a meaningful bound, and two differing models would
+/// be silently non-interchangeable (issue #812). A buffered append is billed
+/// the buffer model and writes no MMR node; a compacting append reads the
+/// epoch back and writes no slot or record — never both, summed here.
+///
+/// Storage follows the GROVE_V4 accounting: the entry's added bytes are its
+/// long-term footprint (its chunk-blob share, the blob framing and MMR nodes
+/// amortized); the buffer slot and path record are churn, replaced only.
 #[cfg(feature = "minimal")]
 pub(in crate::batch) fn private_document_store_insert_op_cost(
     entry_size: u32,
     chunk_power: u8,
     element_flags_load_bound: u32,
 ) -> OperationCost {
-    use grovedb_dense_fixed_sized_merkle_tree::HASH_RECORD_LEN;
     let chunk_power = chunk_power.clamp(1, PHYSICAL_MAX_CHUNK_POWER);
     let epoch_entries: u32 = 1u32 << chunk_power;
     // The buffer holds `2^chunk_power - 1` positions; a compacting append
     // reads every one of them back to build the chunk blob.
     let compaction_reads: u32 = epoch_entries - 1;
-    let records = dense_record_maintenance_bound(chunk_power, false);
+    let buffer = dense_buffer_model(chunk_power);
     /// MMR push merges plus root bagging (bounded by the 64-bit position
     /// space).
     const MAX_MMR_MERGES: u32 = 65;
@@ -360,94 +321,80 @@ pub(in crate::batch) fn private_document_store_insert_op_cost(
     // unconditionally.
     const NON_COUNTED_WRAPPER_BYTE: u32 = 1;
     OperationCost {
-        // Writes: the buffer entry, the chunk blob and the MMR nodes; reads:
-        // the stored element, the committed slot value a rewrite is sized
-        // against, the position-0 record for the state root, the MMR
-        // siblings, the epoch read back on compaction, and the record reads;
-        // plus the record writes.
-        seek_count: (1 + 1 + MAX_MMR_MERGES)
-            .saturating_add(3)
+        // Writes: the buffer entry, its path record, the chunk blob and the
+        // MMR nodes; reads: the stored element, the last insert's record
+        // for the state root, the MMR siblings, the epoch read back on
+        // compaction, and the buffer model's record reads.
+        seek_count: (1 + 1 + 1 + MAX_MMR_MERGES)
+            .saturating_add(2)
             .saturating_add(MAX_MMR_READS)
             .saturating_add(compaction_reads)
-            .saturating_add(records.record_reads)
-            .saturating_add(records.record_writes),
+            .saturating_add(buffer.cost.seek_count),
         storage_cost: StorageCost {
-            // The buffer slot (new in epoch 1; a rewrite later, replaced
-            // below), the entry's chunk-blob share (GROVE_V4 accounting,
-            // issue #822), the blob's framing, the wrapper byte, and the
-            // records written for the first time.
+            // The entry's chunk-blob share (GROVE_V4 accounting, issue
+            // #822), the blob's framing and MMR nodes, the wrapper byte.
             added_bytes: entry_size
-                .saturating_add(entry_size)
                 .saturating_add(MMR_SERIALIZATION_OVERHEAD)
-                .saturating_add(NON_COUNTED_WRAPPER_BYTE)
-                .saturating_add(records.added_bytes),
-            // The slot rewrite from epoch 2 on, the compaction blob (a
-            // replacement of the epoch's prepaid entry bytes), and the
-            // records rewritten along the path.
+                .saturating_add(NON_COUNTED_WRAPPER_BYTE),
+            // The buffer slot and the path record (churn, every epoch), and
+            // the compaction blob (a replacement of the epoch's prepaid
+            // entry bytes).
             replaced_bytes: entry_size
-                .saturating_add(max_compaction_blob)
-                .saturating_add(records.replaced_bytes),
+                .saturating_add(PER_PUT_OVERHEAD)
+                .saturating_add(buffer.record_len)
+                .saturating_add(PER_PUT_OVERHEAD)
+                .saturating_add(max_compaction_blob),
             removed_bytes: StorageRemovedBytes::NoStorageRemoval,
         },
         // The stored element (fixed fields + Merk framing, with the flags
-        // bound), the committed slot value, the epoch read back on
-        // compaction, the blob read back as an MMR peak, the MMR siblings,
-        // the record reads and the root record.
+        // bound), the epoch read back on compaction, the blob read back as
+        // an MMR peak, the MMR siblings, the buffer model's records and the
+        // root record.
         storage_loaded_bytes: (CT_ELEMENT_LOAD_BASE + element_flags_load_bound) as u64
-            + entry_size as u64
             + compaction_reads as u64 * entry_size as u64
             + max_compaction_blob as u64
             + (MMR_INTERNAL_NODE_BYTES * MAX_MMR_READS) as u64
-            + records.loaded_bytes
-            + HASH_RECORD_LEN as u64,
-        // A buffered append's ancestor path, a compacting append's chunk
-        // leaf hash and MMR cascade, and the roots.
-        hash_node_calls: records.hash_calls + 1 + MAX_MMR_MERGES + ROOT_AND_CONFIG_HASHES,
+            + buffer.cost.storage_loaded_bytes
+            + buffer.record_len as u64,
+        // The buffer model, a compacting append's chunk leaf hash and MMR
+        // cascade, and the roots.
+        hash_node_calls: buffer.cost.hash_node_calls + 1 + MAX_MMR_MERGES + ROOT_AND_CONFIG_HASHES,
         sinsemilla_hash_calls: 0,
     }
 }
 
-/// Upper-bound cost of the work a single `DenseTreeInsert` performs outside
-/// the parent Merk (charged separately via `average/worst_case_merk_replace_tree`)
-/// on a `DenseAppendOnlyFixedSizeTree` of `height`: the value write and the
-/// root derivation the insert bills in full (its append returns the whole
-/// cost).
-///
-/// Under GROVE_V1..V3 root maintenance every insert walked every filled
-/// position (one read and two blake3 calls each). Under GROVE_V4 an insert
-/// maintains its ancestor path's hash records — O(height) — but a tree
-/// filled under V1..V3 pays the walk once more when its first V4 insert
-/// derives the records it lacks, and that insert is admitted under this
-/// bound, so the full-buffer walk stays: `2^height - 1` value reads (the
-/// loaded bytes scale with the value size — the op's value is the only size
-/// the estimator sees, so it stands in for the buffered values) and two
-/// hashes each, plus the record reads, writes and storage (catch-up
-/// included).
+/// Cost of the work a single `DenseTreeInsert` performs outside the parent
+/// Merk (charged separately via `average/worst_case_merk_replace_tree`) on a
+/// `DenseAppendOnlyFixedSizeTree` of `height`: the value write, the path
+/// record write, and the buffer's fixed root-maintenance model (GROVE_V4),
+/// which the insert bills in full (its append returns the whole cost). A
+/// standalone dense tree's buffer IS its long-term storage, so its slot and
+/// record are new storage (the record's key is the inserting position's,
+/// written once; a catch-up of a buffer filled under GROVE_V1..V3 may
+/// rewrite one, bounded by a second record as replaced).
 ///
 /// `height` is the tree's declared height (`TreeType::DenseAppendOnlyFixedSizeTree(height)`
 /// on the tree's own layer, average case) or [`PHYSICAL_MAX_CHUNK_POWER`]
 /// (worst case, and when undeclared); clamped to the constructor's range.
 #[cfg(feature = "minimal")]
 pub(in crate::batch) fn dense_tree_insert_op_cost(value_size: u32, height: u8) -> OperationCost {
-    let height = height.clamp(1, PHYSICAL_MAX_CHUNK_POWER);
-    let capacity: u32 = (1u32 << height) - 1;
-    let records = dense_record_maintenance_bound(height, true);
+    let buffer = dense_buffer_model(height);
+    let record_put = buffer.record_len.saturating_add(PER_PUT_OVERHEAD);
     OperationCost {
-        // The value write, the walk's value reads, the record reads and
-        // writes.
-        seek_count: 1u32
-            .saturating_add(capacity)
-            .saturating_add(records.record_reads)
-            .saturating_add(records.record_writes),
+        // The stored element read by preprocessing, the value write, the
+        // record write, and the model's record reads.
+        seek_count: 3u32.saturating_add(buffer.cost.seek_count),
         storage_cost: StorageCost {
-            added_bytes: value_size.saturating_add(records.added_bytes),
-            replaced_bytes: records.replaced_bytes,
+            // The value (key included) and the record: new storage.
+            added_bytes: value_size
+                .saturating_add(PER_PUT_OVERHEAD)
+                .saturating_add(record_put),
+            replaced_bytes: record_put,
             removed_bytes: StorageRemovedBytes::NoStorageRemoval,
         },
-        storage_loaded_bytes: (value_size as u64).saturating_mul(capacity as u64)
-            + records.loaded_bytes,
-        // The walk (two per filled position) dominates the ancestor path.
-        hash_node_calls: (2 * capacity).max(records.hash_calls),
+        // The stored element and the model's records.
+        storage_loaded_bytes: CT_ELEMENT_LOAD_BASE as u64 + buffer.cost.storage_loaded_bytes,
+        hash_node_calls: buffer.cost.hash_node_calls,
         sinsemilla_hash_calls: 0,
     }
 }

--- a/grovedb/src/batch/estimated_costs/worst_case_costs.rs
+++ b/grovedb/src/batch/estimated_costs/worst_case_costs.rs
@@ -269,7 +269,11 @@ impl GroveOp {
                         .saturating_add(buffer.cost.seek_count)
                         .saturating_add(MAX_COMPACTION_PUTS),
                     storage_cost: StorageCost {
-                        added_bytes: value_size.saturating_add(amortized_compaction_added),
+                        // Value + the variable format's per-entry prefix +
+                        // the compaction share.
+                        added_bytes: value_size
+                            .saturating_add(grovedb_bulk_append_tree::VARIABLE_ENTRY_FRAMING_BYTES)
+                            .saturating_add(amortized_compaction_added),
                         // Slot (key included as a bound), record, and the
                         // value's part of the blob rewrite.
                         replaced_bytes: paid_value
@@ -285,7 +289,7 @@ impl GroveOp {
                         as u64
                         + buffer.cost.storage_loaded_bytes,
                     hash_node_calls: buffer.cost.hash_node_calls
-                        + grovedb_bulk_append_tree::AMORTIZED_COMPACTION_HASHES
+                        + grovedb_bulk_append_tree::max_amortized_compaction_hashes()
                         + 1,
                     sinsemilla_hash_calls: 0,
                 })

--- a/grovedb/src/batch/estimated_costs/worst_case_costs.rs
+++ b/grovedb/src/batch/estimated_costs/worst_case_costs.rs
@@ -249,49 +249,39 @@ impl GroveOp {
                     grove_version,
                 );
                 // Worst case: compaction trigger. Buffer fills → serialize
-                // chunk blob → compute dense Merkle root → push to MMR.
+                // chunk blob → push to MMR. The buffer's own work is the
+                // fixed root-maintenance model at the physical ceiling.
                 use grovedb_costs::storage_cost::{removal::StorageRemovedBytes, StorageCost};
                 let value_size = value.len() as u32;
                 /// Largest epoch the type permits: `2^16` entries.
                 const MAX_EPOCH_ENTRIES: u32 = 1 << 16;
-                // Dense buffer: up to a full-buffer walk, two hashes per
-                // filled position (the GROVE_V1..V3 root recompute, and the
-                // one-time catch-up a buffer filled under those versions
-                // pays at its first GROVE_V4 append; a V4 append otherwise
-                // hashes only its ancestor path). Chunk-leaf hash: 1. MMR
-                // push and root bagging: up to 65 merges.
-                const MAX_HASH_CALLS: u32 = 2 * (MAX_EPOCH_ENTRIES - 1) + 1 + 65;
+                let buffer = super::dense_buffer_model(super::PHYSICAL_MAX_CHUNK_POWER);
+                // Chunk-leaf hash: 1. MMR push and root bagging: up to 65
+                // merges. Plus the buffer model.
                 const MAX_MMR_MERGES: u32 = 65;
-                // Writes: buffer entry + chunk blob + MMR nodes
-                const MAX_WRITES: u32 = 1 + 1 + MAX_MMR_MERGES;
+                let max_hash_calls = buffer.cost.hash_node_calls + 1 + MAX_MMR_MERGES;
+                // Writes: buffer entry + path record + chunk blob + MMR nodes
+                const MAX_WRITES: u32 = 1 + 1 + 1 + MAX_MMR_MERGES;
                 const MAX_READS: u32 = 64; // MMR sibling reads
                                            // Added storage under the GROVE_V4 accounting (issue #822):
-                                           // the value's buffer slot (new, or grown on a rewrite) and
-                                           // its chunk-blob share, plus on compaction the blob's framing
-                                           // — MMR leaf key and envelope, variable-format header and one
-                                           // 4-byte length prefix per entry of the largest epoch, the
-                                           // value-length varint — and every MMR internal node the push
-                                           // creates (key + 33-byte node + length).
+                                           // the value's chunk-blob share, plus on compaction the
+                                           // blob's framing — MMR leaf key and envelope, variable-format
+                                           // header and one 4-byte length prefix per entry of the
+                                           // largest epoch, the value-length varint — and every MMR
+                                           // internal node the push creates (key + 33-byte node +
+                                           // length). The buffer slot and record are churn (replaced).
                 const PER_PUT_KEY_AND_LENGTHS: u32 = 50;
                 const MAX_BLOB_FRAMING: u32 = 37 + 37 + 1 + 4 * MAX_EPOCH_ENTRIES + 5;
                 const MMR_INTERNAL_NODE_PUT: u32 = 37 + 33 + 1;
-                // The buffer's hash records (GROVE_V4 root maintenance) at
-                // the physical ceiling, catch-up included; the bulk append
-                // bills their writes (at commit), not their reads.
-                let records =
-                    super::dense_record_maintenance_bound(super::PHYSICAL_MAX_CHUNK_POWER, true);
                 let max_added = value_size
-                    .saturating_mul(2)
                     .saturating_add(PER_PUT_KEY_AND_LENGTHS)
                     .saturating_add(MAX_BLOB_FRAMING)
-                    .saturating_add(MMR_INTERNAL_NODE_PUT * MAX_MMR_MERGES)
-                    .saturating_add(records.added_bytes);
+                    .saturating_add(MMR_INTERNAL_NODE_PUT * MAX_MMR_MERGES);
                 item_cost.add_cost(OperationCost {
-                    // +1: the read of the committed slot value that sizes a
-                    // rewrite. The record writes and the compaction writes
-                    // never stack (a compacting append writes no records);
-                    // summed as a bound.
-                    seek_count: MAX_WRITES + MAX_READS + 1 + records.record_writes,
+                    // The writes, the MMR sibling reads and the buffer
+                    // model's record reads (a compacting append writes no
+                    // slot or record; summed as a bound).
+                    seek_count: MAX_WRITES + MAX_READS + buffer.cost.seek_count,
                     storage_cost: StorageCost {
                         added_bytes: max_added,
                         // The compaction blob is reported as a replacement
@@ -301,15 +291,18 @@ impl GroveOp {
                         // bound: the type permits values up to u32::MAX
                         // bytes (chunk entry lengths are u32). A smaller
                         // figure would not be an upper bound, so this
-                        // dimension saturates (and so covers the record
-                        // rewrites too).
+                        // dimension saturates (and so covers the slot and
+                        // record churn too).
                         replaced_bytes: u32::MAX,
                         removed_bytes: StorageRemovedBytes::NoStorageRemoval,
                     },
-                    // MMR sibling reads + the committed slot value, which is
-                    // bounded only by the u32 entry length.
-                    storage_loaded_bytes: (33 * MAX_READS) as u64 + u32::MAX as u64,
-                    hash_node_calls: MAX_HASH_CALLS,
+                    // MMR sibling reads, the buffer model's records, and the
+                    // epoch read back on compaction, which is bounded only
+                    // by the u32 entry length.
+                    storage_loaded_bytes: (33 * MAX_READS) as u64
+                        + buffer.cost.storage_loaded_bytes
+                        + u32::MAX as u64,
+                    hash_node_calls: max_hash_calls,
                     sinsemilla_hash_calls: 0,
                 })
             }

--- a/grovedb/src/batch/estimated_costs/worst_case_costs.rs
+++ b/grovedb/src/batch/estimated_costs/worst_case_costs.rs
@@ -248,61 +248,45 @@ impl GroveOp {
                     propagate,
                     grove_version,
                 );
-                // Worst case: compaction trigger. Buffer fills → serialize
-                // chunk blob → push to MMR. The buffer's own work is the
-                // fixed root-maintenance model at the physical ceiling.
+                // The fixed per-append model at the physical ceiling (the op
+                // carries only the value): the buffer's root-maintenance
+                // model, the amortized compaction, the value's chunk-blob
+                // share and its churn — plus the compacting append's puts as
+                // a bound, the one position-dependent residual.
                 use grovedb_costs::storage_cost::{removal::StorageRemovedBytes, StorageCost};
                 let value_size = value.len() as u32;
-                /// Largest epoch the type permits: `2^16` entries.
-                const MAX_EPOCH_ENTRIES: u32 = 1 << 16;
                 let buffer = super::dense_buffer_model(super::PHYSICAL_MAX_CHUNK_POWER);
-                // Chunk-leaf hash: 1. MMR push and root bagging: up to 65
-                // merges. Plus the buffer model.
-                const MAX_MMR_MERGES: u32 = 65;
-                let max_hash_calls = buffer.cost.hash_node_calls + 1 + MAX_MMR_MERGES;
-                // Writes: buffer entry + path record + chunk blob + MMR nodes
-                const MAX_WRITES: u32 = 1 + 1 + 1 + MAX_MMR_MERGES;
-                const MAX_READS: u32 = 64; // MMR sibling reads
-                                           // Added storage under the GROVE_V4 accounting (issue #822):
-                                           // the value's chunk-blob share, plus on compaction the
-                                           // blob's framing — MMR leaf key and envelope, variable-format
-                                           // header and one 4-byte length prefix per entry of the
-                                           // largest epoch, the value-length varint — and every MMR
-                                           // internal node the push creates (key + 33-byte node +
-                                           // length). The buffer slot and record are churn (replaced).
+                // The compaction share shrinks with the epoch: the smallest
+                // epoch is the bound.
+                let amortized_compaction_added = super::max_amortized_compaction_added_bytes();
+                const MAX_COMPACTION_PUTS: u32 = 1 + 65;
                 const PER_PUT_KEY_AND_LENGTHS: u32 = 50;
-                const MAX_BLOB_FRAMING: u32 = 37 + 37 + 1 + 4 * MAX_EPOCH_ENTRIES + 5;
-                const MMR_INTERNAL_NODE_PUT: u32 = 37 + 33 + 1;
-                let max_added = value_size
-                    .saturating_add(PER_PUT_KEY_AND_LENGTHS)
-                    .saturating_add(MAX_BLOB_FRAMING)
-                    .saturating_add(MMR_INTERNAL_NODE_PUT * MAX_MMR_MERGES);
+                let paid_value = value_size.saturating_add(5); // + the value-length varint
                 item_cost.add_cost(OperationCost {
-                    // The writes, the MMR sibling reads and the buffer
-                    // model's record reads (a compacting append writes no
-                    // slot or record; summed as a bound).
-                    seek_count: MAX_WRITES + MAX_READS + buffer.cost.seek_count,
+                    // The stored element read, the slot and record writes, the
+                    // model's record reads, the compaction's puts.
+                    seek_count: 3u32
+                        .saturating_add(buffer.cost.seek_count)
+                        .saturating_add(MAX_COMPACTION_PUTS),
                     storage_cost: StorageCost {
-                        added_bytes: max_added,
-                        // The compaction blob is reported as a replacement
-                        // of the epoch's entry bytes — the sum of whatever
-                        // values an earlier state buffered, which neither
-                        // the op nor the worst-case layer information can
-                        // bound: the type permits values up to u32::MAX
-                        // bytes (chunk entry lengths are u32). A smaller
-                        // figure would not be an upper bound, so this
-                        // dimension saturates (and so covers the slot and
-                        // record churn too).
-                        replaced_bytes: u32::MAX,
+                        added_bytes: value_size.saturating_add(amortized_compaction_added),
+                        // Slot (key included as a bound), record, and the
+                        // value's part of the blob rewrite.
+                        replaced_bytes: paid_value
+                            .saturating_add(PER_PUT_KEY_AND_LENGTHS)
+                            .saturating_add(buffer.record_len)
+                            .saturating_add(PER_PUT_KEY_AND_LENGTHS)
+                            .saturating_add(value_size),
                         removed_bytes: StorageRemovedBytes::NoStorageRemoval,
                     },
-                    // MMR sibling reads, the buffer model's records, and the
-                    // epoch read back on compaction, which is bounded only
-                    // by the u32 entry length.
-                    storage_loaded_bytes: (33 * MAX_READS) as u64
-                        + buffer.cost.storage_loaded_bytes
-                        + u32::MAX as u64,
-                    hash_node_calls: max_hash_calls,
+                    // The stored element with the largest flags a Merk node
+                    // can hold, and the model's records.
+                    storage_loaded_bytes: (super::CT_ELEMENT_LOAD_BASE + MERK_BIGGEST_VALUE_SIZE)
+                        as u64
+                        + buffer.cost.storage_loaded_bytes,
+                    hash_node_calls: buffer.cost.hash_node_calls
+                        + grovedb_bulk_append_tree::AMORTIZED_COMPACTION_HASHES
+                        + 1,
                     sinsemilla_hash_calls: 0,
                 })
             }
@@ -335,6 +319,7 @@ impl GroveOp {
                     entry.len() as u32,
                     super::PHYSICAL_MAX_CHUNK_POWER,
                     MERK_BIGGEST_VALUE_SIZE,
+                    super::max_amortized_compaction_added_bytes(),
                 ))
             }
             GroveOp::DenseTreeInsert { value } => {
@@ -554,6 +539,9 @@ impl GroveOp {
             // worst-case paths — charge the largest value a Merk node can
             // store, consistent with the rest of the worst-case machinery.
             MERK_BIGGEST_VALUE_SIZE,
+            // The buffer model grows with the height, the compaction share
+            // shrinks with the epoch: each at its own worst.
+            super::max_amortized_compaction_added_bytes(),
         ))
     }
 }
@@ -1416,10 +1404,14 @@ mod tests {
         // blob at the physical ceiling — reported as a replacement of the
         // epoch's prepaid entry bytes (GROVE_V4 accounting, issue #822) —
         // plus the per-append slot write and chunk-blob share as added.
-        assert!(cost.storage_cost.replaced_bytes >= 128 * 65536);
-        assert!(cost.storage_cost.added_bytes >= 128 + 128);
-        // The compacting append reads the whole epoch back.
-        assert!(cost.seek_count >= 65535);
+        // The fixed model: the entry's slot and blob-rewrite part replaced,
+        // its share added; nothing scales with the epoch any more.
+        assert!(cost.storage_cost.replaced_bytes >= 2 * 128);
+        assert!(cost.storage_cost.replaced_bytes < 128 * 65536);
+        assert!(cost.storage_cost.added_bytes >= 128 + 1);
+        // The compaction's read-back is amortized into the model: no
+        // epoch-sized seek count any more.
+        assert!(cost.seek_count < 65535);
         assert_eq!(cost.sinsemilla_hash_calls, 0);
     }
 
@@ -1836,11 +1828,14 @@ mod tests {
             )
             .cost_as_result()
             .expect("expected worst case cost for oversized payload");
-        assert_eq!(
-            cost.storage_cost.replaced_bytes,
-            u32::MAX,
-            "oversized-payload estimate must saturate, not wrap",
+        // The epoch no longer multiplies anything: the compaction is
+        // amortized into the per-note model, so the figure is finite and
+        // per-note — the u64 sums exist for hand-built payloads only.
+        assert!(
+            cost.storage_cost.replaced_bytes < u32::MAX,
+            "the per-note estimate does not scale with the epoch: {cost:?}",
         );
+        assert!(cost.storage_cost.replaced_bytes >= 2 * (96 + 70_000));
         // The per-note added term (slot + blob share + frontier + framing)
         // is epoch-independent and stays far from saturation.
         assert!(

--- a/grovedb/src/lib.rs
+++ b/grovedb/src/lib.rs
@@ -2488,9 +2488,12 @@ impl GroveDb {
                     if let Some(grovedb_bulk_append_tree::BufferRecordMismatch {
                         recorded,
                         walked,
-                    }) =
-                        self.dense_buffer_record_issue(&element, new_path_ref.clone(), transaction)
-                    {
+                    }) = self.dense_buffer_record_issue(
+                        &element,
+                        new_path_ref.clone(),
+                        transaction,
+                        grove_version,
+                    ) {
                         let mut issue_path = new_path.to_vec();
                         issue_path.push(b"__dense_hash_records__".to_vec());
                         issues.insert(issue_path, (root_hash, walked, recorded));
@@ -2944,6 +2947,7 @@ impl GroveDb {
         element: &Element,
         subtree_path: SubtreePath<'b, B>,
         transaction: &Transaction,
+        grove_version: &GroveVersion,
     ) -> Option<grovedb_bulk_append_tree::BufferRecordMismatch> {
         match element.underlying() {
             Element::CommitmentTree(total_count, chunk_power, _) => {
@@ -2958,10 +2962,11 @@ impl GroveDb {
                     *total_count,
                     *chunk_power,
                     storage_ctx,
+                    grove_version,
                 )
                 .value
                 .ok()?
-                .buffer_record_mismatch()
+                .buffer_record_mismatch(grove_version)
                 .ok()
                 .flatten()
             }
@@ -2979,7 +2984,7 @@ impl GroveDb {
                     storage_ctx,
                 )
                 .ok()?
-                .buffer_record_mismatch()
+                .buffer_record_mismatch(grove_version)
                 .ok()
                 .flatten()
             }
@@ -3019,7 +3024,7 @@ impl GroveDb {
                 )
                 .unwrap()
                 .ok()?
-                .buffer_record_mismatch()
+                .buffer_record_mismatch(grove_version)
                 .ok()
                 .flatten()
             }
@@ -3057,6 +3062,7 @@ impl GroveDb {
                     *total_count,
                     *chunk_power,
                     storage_ctx,
+                    grove_version,
                 )
                 .value
                 {
@@ -3200,6 +3206,7 @@ impl GroveDb {
                     *total_count,
                     *chunk_power,
                     storage_ctx,
+                    grove_version,
                 )
                 .value
                 .map_err(|e| {

--- a/grovedb/src/operations/commitment_tree.rs
+++ b/grovedb/src/operations/commitment_tree.rs
@@ -150,8 +150,13 @@ impl GroveDb {
         //    payload validation in append_raw)
         let mut ct = cost_return_on_error!(
             &mut cost,
-            CommitmentTree::<_, DashMemo>::open(total_count, chunk_power, storage_ctx)
-                .map(|r| r.map_err(map_ct_err))
+            CommitmentTree::<_, DashMemo>::open(
+                total_count,
+                chunk_power,
+                storage_ctx,
+                grove_version
+            )
+            .map(|r| r.map_err(map_ct_err))
         );
 
         let append_result = cost_return_on_error!(
@@ -309,8 +314,13 @@ impl GroveDb {
 
         let ct = cost_return_on_error!(
             &mut cost,
-            CommitmentTree::<_, DashMemo>::open(total_count, chunk_power, storage_ctx)
-                .map(|r| r.map_err(map_ct_err))
+            CommitmentTree::<_, DashMemo>::open(
+                total_count,
+                chunk_power,
+                storage_ctx,
+                grove_version
+            )
+            .map(|r| r.map_err(map_ct_err))
         );
 
         Ok(ct.anchor()).wrap_with_cost(cost)
@@ -365,8 +375,13 @@ impl GroveDb {
 
         let ct = cost_return_on_error!(
             &mut cost,
-            CommitmentTree::<_, DashMemo>::open(total_count, chunk_power, storage_ctx)
-                .map(|r| r.map_err(map_ct_err))
+            CommitmentTree::<_, DashMemo>::open(
+                total_count,
+                chunk_power,
+                storage_ctx,
+                grove_version
+            )
+            .map(|r| r.map_err(map_ct_err))
         );
 
         let epoch_size = ct.epoch_size();
@@ -457,8 +472,13 @@ impl GroveDb {
 
         let ct = cost_return_on_error!(
             &mut cost,
-            CommitmentTree::<_, DashMemo>::open(total_count, chunk_power, storage_ctx)
-                .map(|r| r.map_err(map_ct_err))
+            CommitmentTree::<_, DashMemo>::open(
+                total_count,
+                chunk_power,
+                storage_ctx,
+                grove_version
+            )
+            .map(|r| r.map_err(map_ct_err))
         );
 
         let page = cost_return_on_error!(
@@ -607,8 +627,13 @@ impl GroveDb {
             // Open composite CommitmentTree
             let mut ct = cost_return_on_error!(
                 &mut cost,
-                CommitmentTree::<_, DashMemo>::open(total_count, chunk_power, storage_ctx)
-                    .map(|r| r.map_err(map_ct_err))
+                CommitmentTree::<_, DashMemo>::open(
+                    total_count,
+                    chunk_power,
+                    storage_ctx,
+                    grove_version
+                )
+                .map(|r| r.map_err(map_ct_err))
             );
 
             // Execute all inserts in order

--- a/grovedb/src/tests/append_family_cost_bound_tests.rs
+++ b/grovedb/src/tests/append_family_cost_bound_tests.rs
@@ -304,10 +304,12 @@ mod commitment_tree {
         catch_up_sweep(11, (1 << 11) - 2, 3);
     }
 
-    /// The catch-up happens once: after it, a V4 append is O(chunk_power)
-    /// hashes — far below the V3 full-buffer walk the first append paid.
+    /// The catch-up is physical work, not a charge: the first V4 append
+    /// after a V3 fill (which walks the legacy buffer) and the next one are
+    /// billed exactly the same — the buffer's fixed model plus the
+    /// position-independent rest.
     #[test]
-    fn test_commitment_tree_catch_up_is_paid_once() {
+    fn test_commitment_tree_catch_up_is_not_billed() {
         const CHUNK_POWER: u8 = 8;
         const LEGACY_FILL: u64 = 200;
         let v4 = GroveVersion::latest();
@@ -322,17 +324,14 @@ mod commitment_tree {
         let second = db.apply_batch(vec![ct_op(LEGACY_FILL + 1)], None, None, v4);
         second.value.expect("append after catch-up");
 
-        // The catch-up walks the buffer: two hashes per filled position.
-        assert!(
-            first.cost.hash_node_calls >= 2 * (LEGACY_FILL as u32 + 1),
-            "catch-up should walk the buffer: {:?}",
-            first.cost
-        );
-        // The next append hashes its ancestor path (≤ chunk_power + 1),
-        // the state roots and the Sinsemilla frontier walk only.
-        assert!(
-            second.cost.hash_node_calls < 2 * LEGACY_FILL as u32 / 4,
-            "after catch-up an append must not re-walk the buffer: first {:?}, second {:?}",
+        // What may differ is the frontier (its ommer cascade and serialized
+        // size depend on the global position): the blake3 count and the
+        // seeks — where a walk of the legacy buffer would show — are the
+        // model on both.
+        assert_eq!(
+            (first.cost.hash_node_calls, first.cost.seek_count),
+            (second.cost.hash_node_calls, second.cost.seek_count),
+            "catch-up must not change the charge: first {:?}, second {:?}",
             first.cost,
             second.cost
         );
@@ -582,23 +581,24 @@ mod dense_tree {
             );
             first.get_or_insert(actual.clone());
         }
-        // The catch-up really walked the buffer; the average-case estimate
-        // at the declared height bounds it without the ceiling's 2^16.
+        // The catch-up is not billed: the first insert costs what a later
+        // one does, and the average-case estimate at the declared height is
+        // far below the ceiling's.
         let first = first.expect("first insert ran");
-        assert!(
-            first.hash_node_calls >= 2 * LEGACY_FILL as u32,
-            "catch-up should walk the buffer: {first:?}"
-        );
+        let later = db.apply_batch(vec![dense_op(LEGACY_FILL + 4)], None, None, v4);
+        later.value.expect("insert");
+        assert_eq!(first, later.cost, "catch-up must not change the charge");
         let average = average_case_estimate(
-            vec![dense_op(LEGACY_FILL + 4)],
+            vec![dense_op(LEGACY_FILL + 5)],
             b"dense",
             TreeType::DenseAppendOnlyFixedSizeTree(HEIGHT),
             VALUE_SIZE,
             v4,
         );
+        let worst = worst_case_estimate(vec![dense_op(LEGACY_FILL + 5)], v4);
         assert!(
-            average.hash_node_calls < 2 * (1 << 16),
-            "the declared height bounds below the physical ceiling: {average:?}"
+            average.hash_node_calls < worst.hash_node_calls,
+            "the declared height is tighter than the physical ceiling: {average:?} vs {worst:?}"
         );
     }
 

--- a/grovedb/src/tests/append_storage_accounting_tests.rs
+++ b/grovedb/src/tests/append_storage_accounting_tests.rs
@@ -59,22 +59,10 @@ use crate::{
 /// ciphertext payload (216).
 const NOTE_ENTRY: u32 = 312;
 
-/// Paid key bytes of a dense-buffer slot: 32-byte prefix + 2-byte position
-/// + 1 length byte.
-const SLOT_KEY_PAID: u32 = 35;
-/// Paid key bytes of the frontier: prefix + `__ct_data__` (11) + 1.
-const FRONTIER_KEY_PAID: u32 = 44;
-/// Paid key bytes of a dense-buffer path record: 32-byte prefix + `b'h'` +
-/// 2-byte position + 1 length byte.
-const RECORD_KEY_PAID: u32 = 36;
 /// A path record for a buffer of `chunk_power`: generation (8) + present
 /// mask (2) + value hash (32) + one 32-byte entry per level.
 fn record_len(chunk_power: u8) -> u32 {
     grovedb_dense_fixed_sized_merkle_tree::path_record_len(chunk_power) as u32
-}
-/// The dense buffer's fixed root-maintenance model for `chunk_power`.
-fn buffer_model(chunk_power: u8) -> OperationCost {
-    grovedb_dense_fixed_sized_merkle_tree::v1_insert_model_cost(chunk_power)
 }
 
 fn varint_len(mut n: u32) -> u32 {
@@ -97,128 +85,52 @@ fn paid(len: u32) -> u32 {
 fn frontier_len(position: u64) -> u32 {
     42 + 32 * position.count_ones()
 }
-
-/// GROVE_V4 with both accounting gates switched off: what V1..V3 report,
-/// inside the V4 envelope so nothing else differs.
-fn legacy_accounting() -> GroveVersion {
-    let mut version = GROVE_V4.clone();
-    version
-        .bulk_append_tree_versions
-        .cost
-        .append_storage_accounting = 0;
-    version
-        .commitment_tree_versions
-        .cost
-        .frontier_save_storage_accounting = 0;
-    version
+/// Seek-count residual of the one thing the fixed model cannot flatten: a
+/// compacting append writes the chunk blob and the MMR nodes its push
+/// creates at commit (`1 + trailing_ones(leaf_count_before)`), instead of
+/// the slot and record a buffered append writes (2) — once per epoch,
+/// bounded by the merge count. `leaf_count_before` is the chunk count before
+/// the push.
+fn compaction_seek_residual(leaf_count_before: u64) -> i64 {
+    // + the 32-byte MMR root it persists.
+    1 + leaf_count_before.trailing_ones() as i64 + 1 - 2
 }
 
-/// Expected `(added, replaced)` difference, V4 minus legacy, for the append
-/// that lands at `position` in a tree with `2^chunk_power` entries per epoch
-/// and fixed `entry_len`-byte entries; `with_frontier` for a commitment
-/// tree, which also rewrites its frontier.
-fn expected_delta(
-    position: u64,
-    chunk_power: u8,
-    entry_len: u32,
-    with_frontier: bool,
-) -> (i64, i64) {
-    let epoch = 1u64 << chunk_power;
-    let mut added: i64 = 0;
-    let mut replaced: i64 = 0;
-
-    // The entry's chunk-blob share, charged at every append.
-    added += entry_len as i64;
-
-    if position % epoch == epoch - 1 {
-        // Compacting append: the overflow entry goes straight into the
-        // blob (no slot write). Legacy charges the whole blob as added; V4
-        // reports the epoch's entry bytes as replaced and only the framing
-        // (identical on both sides) as added.
-        let entry_bytes = (epoch * entry_len as u64) as i64;
-        added -= entry_bytes;
-        replaced += entry_bytes;
-    } else {
-        // Buffered append. The slot: legacy charges key + value as new
-        // storage every time; V4 reports churn — the value replaced, nothing
-        // added, no key — epoch 1 included. The path record (GROVE_V4 root
-        // maintenance, written by both sides) follows the slot: legacy's
-        // `AsNew` slot accounting writes it as new (key + record); V4's
-        // `Churn` reports it replaced.
-        added -= (SLOT_KEY_PAID + paid(entry_len)) as i64;
-        replaced += paid(entry_len) as i64;
-        added -= (RECORD_KEY_PAID + paid(record_len(chunk_power))) as i64;
-        replaced += paid(record_len(chunk_power)) as i64;
-    }
-
-    if with_frontier && position > 0 {
-        // Legacy: key + whole frontier added on every save. V4: replaces the
-        // frontier loaded at open, adds growth only.
-        let new = paid(frontier_len(position));
-        let old = paid(frontier_len(position - 1));
-        added += new.saturating_sub(old) as i64 - (FRONTIER_KEY_PAID + new) as i64;
-        replaced += new.min(old) as i64;
-    }
-    // else: the first save creates the key on both sides.
-
-    (added, replaced)
+/// Everything but `seek_count` must be identical; `seek_count` may differ by
+/// exactly `seek_residual`.
+fn assert_fixed(what: &str, base: &OperationCost, cost: &OperationCost, seek_residual: i64) {
+    assert_eq!(
+        (
+            cost.storage_cost.clone(),
+            cost.storage_loaded_bytes,
+            cost.hash_node_calls,
+            cost.sinsemilla_hash_calls
+        ),
+        (
+            base.storage_cost.clone(),
+            base.storage_loaded_bytes,
+            base.hash_node_calls,
+            base.sinsemilla_hash_calls
+        ),
+        "{what}: storage, loaded bytes, hashes and Sinsemilla must be the fixed model;\nbase \
+         {base:?}\ncost {cost:?}"
+    );
+    assert_eq!(
+        cost.seek_count as i64,
+        base.seek_count as i64 + seek_residual,
+        "{what}: seeks must be the fixed model plus the compaction residual {seek_residual};\nbase \
+         {base:?}\ncost {cost:?}"
+    );
 }
 
-/// Expected `(seek_count, storage_loaded_bytes)` difference, V4 minus
-/// legacy, for a buffered (non-compacting) append: the `Result`-returning
-/// bulk / commitment appends bill the dense buffer's fixed root-maintenance
-/// model under V4 (`bill_dense_io`) and drop it under the shipped
-/// accounting; the `CostResult`-returning store append bills the dense
-/// tree's cost under both (`bills_dense_always`), so nothing differs there.
-/// Nothing is read to size a rewrite any more.
-fn expected_read_delta(position: u64, chunk_power: u8, bills_dense_always: bool) -> (u32, u64) {
-    let epoch = 1u64 << chunk_power;
-    if position % epoch == epoch - 1 || bills_dense_always {
-        (0, 0)
-    } else {
-        let model = buffer_model(chunk_power);
-        (model.seek_count, model.storage_loaded_bytes)
-    }
+/// The dense buffer's fixed root-maintenance model for `chunk_power`.
+fn buffer_model(chunk_power: u8) -> OperationCost {
+    grovedb_dense_fixed_sized_merkle_tree::v1_insert_model_cost(chunk_power)
 }
 
-fn delta(v4: &OperationCost, legacy: &OperationCost) -> (i64, i64) {
-    (
-        v4.storage_cost.added_bytes as i64 - legacy.storage_cost.added_bytes as i64,
-        v4.storage_cost.replaced_bytes as i64 - legacy.storage_cost.replaced_bytes as i64,
-    )
-}
-
-/// Everything except the storage figures and the buffer model's reads must
-/// agree: the accounting gates move bytes between `added` and `replaced`
-/// and bill those reads, nothing else.
-fn assert_only_accounting_differs(
-    v4: &OperationCost,
-    legacy: &OperationCost,
-    what: &str,
-    (extra_seeks, extra_loaded): (u32, u64),
-) {
-    assert_eq!(
-        v4.seek_count,
-        legacy.seek_count + extra_seeks,
-        "{what}: seek_count"
-    );
-    assert_eq!(
-        v4.storage_loaded_bytes,
-        legacy.storage_loaded_bytes + extra_loaded,
-        "{what}: storage_loaded_bytes"
-    );
-    assert_eq!(
-        v4.hash_node_calls, legacy.hash_node_calls,
-        "{what}: hash_node_calls"
-    );
-    assert_eq!(
-        v4.sinsemilla_hash_calls, legacy.sinsemilla_hash_calls,
-        "{what}: sinsemilla_hash_calls"
-    );
-    assert_eq!(
-        v4.storage_cost.removed_bytes, legacy.storage_cost.removed_bytes,
-        "{what}: removed_bytes"
-    );
+/// The compaction overhead share an append is charged at `chunk_power`.
+fn amortized(chunk_power: u8) -> u32 {
+    grovedb_bulk_append_tree::amortized_compaction_added_bytes(1u64 << chunk_power)
 }
 
 // ── Commitment tree fixtures ──────────────────────────────────────────
@@ -359,391 +271,283 @@ fn accounting_gates_are_locked_before_v4() {
         1
     );
 }
-
 /// Commitment tree at chunk_power 4, one direct append per position across
-/// two and a half epochs: every append's `(added, replaced)` moves by
-/// exactly the model — fresh slots in epoch 1, slot rewrites from epoch 2,
-/// the blob-as-replacement at positions 15, 31 and 47, and the frontier
-/// rewrite (growth at `2^k - 1`, shrink at `2^k`, first save at 0) — while
-/// nothing else in the cost changes and both trees stay byte-identical.
+/// two and a half epochs: EVERY append is charged the same — the note's
+/// long-term footprint as added storage, the buffer slot / path record /
+/// blob-rewrite part / frontier as replaced, the buffer's fixed model and
+/// the frontier's fixed model in hashes and bytes — at every position,
+/// including the compactions at 15, 31 and 47, whose only trace is the
+/// commit-time seek residual of the blob and MMR node puts.
 #[test]
-fn commitment_tree_append_storage_accounting_matches_model_across_epochs() {
+fn commitment_tree_append_cost_is_fixed_across_positions() {
     const CHUNK_POWER: u8 = 4;
-    let legacy = legacy_accounting();
-    let legacy_db = ct_db(CHUNK_POWER, &legacy);
-    let v4_db = ct_db(CHUNK_POWER, &GROVE_V4);
-
-    for position in 0..40u64 {
-        let legacy_cost = ct_insert(&legacy_db, position as u32, &legacy);
-        let v4_cost = ct_insert(&v4_db, position as u32, &GROVE_V4);
-
-        assert_eq!(
-            delta(&v4_cost, &legacy_cost),
-            expected_delta(position, CHUNK_POWER, NOTE_ENTRY, true),
-            "position {position}: v4 {v4_cost:?}\nlegacy {legacy_cost:?}"
-        );
-        assert_only_accounting_differs(
-            &v4_cost,
-            &legacy_cost,
-            &format!("position {position}"),
-            expected_read_delta(position, CHUNK_POWER, false),
-        );
-        assert_eq!(
-            root_hash(&v4_db, &GROVE_V4),
-            root_hash(&legacy_db, &legacy),
-            "position {position}: the accounting must not touch stored bytes"
-        );
+    let db = ct_db(CHUNK_POWER, &GROVE_V4);
+    let base = ct_insert(&db, 0, &GROVE_V4);
+    for position in 1..48u64 {
+        let cost = ct_insert(&db, position as u32, &GROVE_V4);
+        let residual = if position % 16 == 15 {
+            compaction_seek_residual(position / 16)
+        } else {
+            0
+        };
+        assert_fixed(&format!("position {position}"), &base, &cost, residual);
     }
-    assert_verifies(&v4_db, &GROVE_V4);
-    assert_verifies(&legacy_db, &legacy);
+    // What the fixed charge is made of.
+    let model = buffer_model(CHUNK_POWER);
+    assert_eq!(
+        base.sinsemilla_hash_calls,
+        grovedb_commitment_tree::MODEL_FRONTIER_APPEND_SINSEMILLA_HASHES
+    );
+    // Buffer model + amortized compaction + bulk state root + ct_state root
+    // (+ the parent Merk's own hashing, which does not depend on the
+    // position either).
+    assert!(base.hash_node_calls >= model.hash_node_calls + 1 + 2);
+    // Added: the share plus the amortized compaction overhead (plus the
+    // parent Merk's own growth, none here); the parent element's replaced
+    // bytes sit on top of the append's own churn.
+    let own_added = NOTE_ENTRY + amortized(CHUNK_POWER);
+    assert!(
+        base.storage_cost.added_bytes >= own_added
+            && base.storage_cost.added_bytes < own_added + 64,
+        "{base:?}"
+    );
+    let own_replaced = paid(NOTE_ENTRY)
+        + paid(record_len(CHUNK_POWER))
+        + NOTE_ENTRY
+        + paid(grovedb_commitment_tree::MODEL_FRONTIER_SERIALIZED_LEN);
+    assert!(base.storage_cost.replaced_bytes >= own_replaced, "{base:?}");
+    assert_verifies(&db, &GROVE_V4);
 }
 
-/// The frontier rewrite in isolation, at chunk_power 11 where nothing
-/// compacts: at `2^k - 1` the frontier gains an ommer (replaced at the old
-/// size, 32 bytes added), at `2^k` it collapses to 74 bytes (replaced at the
-/// new size, nothing credited), and in between it is replaced in full.
+/// The same at chunk_power 11 — the shielded pool's scale — around the
+/// epoch boundary: the last buffered append, the compacting one and the
+/// first of the next epoch cost the same, the compaction's seek residual
+/// aside.
 #[test]
-fn frontier_rewrite_replaces_previous_size_and_adds_only_growth() {
-    const CHUNK_POWER: u8 = 11;
-    let legacy = legacy_accounting();
-    let legacy_db = ct_db(CHUNK_POWER, &legacy);
-    let v4_db = ct_db(CHUNK_POWER, &GROVE_V4);
-
-    for position in 0..34u64 {
-        let legacy_cost = ct_insert(&legacy_db, position as u32, &legacy);
-        let v4_cost = ct_insert(&v4_db, position as u32, &GROVE_V4);
-        let (d_added, d_replaced) = delta(&v4_cost, &legacy_cost);
-        // V4 bills the buffer model's reads; nothing else but storage moves.
-        assert_only_accounting_differs(
-            &v4_cost,
-            &legacy_cost,
-            &format!("position {position}"),
-            expected_read_delta(position, CHUNK_POWER, false),
-        );
-
-        // Strip the share and the slot / record churn so only the frontier
-        // is left.
-        let churn_added = -((SLOT_KEY_PAID + paid(NOTE_ENTRY)) as i64)
-            - (RECORD_KEY_PAID + paid(record_len(CHUNK_POWER))) as i64;
-        let churn_replaced = (paid(NOTE_ENTRY) + paid(record_len(CHUNK_POWER))) as i64;
-        let frontier_added = d_added - NOTE_ENTRY as i64 - churn_added;
-        let frontier_replaced = d_replaced - churn_replaced;
-        if position == 0 {
-            assert_eq!(
-                (frontier_added, frontier_replaced),
-                (0, 0),
-                "first save: new on both"
-            );
-            continue;
-        }
-        let new = paid(frontier_len(position));
-        let old = paid(frontier_len(position - 1));
-        assert_eq!(
-            frontier_replaced,
-            new.min(old) as i64,
-            "position {position}: replaced the smaller of previous/new paid size"
-        );
-        assert_eq!(
-            frontier_added,
-            new.saturating_sub(old) as i64 - (FRONTIER_KEY_PAID + new) as i64,
-            "position {position}: legacy key + full value added; v4 growth only"
-        );
-        if position >= 4 && position.is_power_of_two() {
-            // popcount drops from k >= 2 to 1 (positions 1 and 2 keep it at 1).
-            assert!(new < old, "position {position} collapses the frontier");
-            assert_eq!(new.saturating_sub(old), 0, "shrink is not credited");
-        } else if (position + 1).is_power_of_two() {
-            // popcount rises by one: 32 more bytes (plus one more length byte
-            // when the varint widens, e.g. 106 -> 138 at position 7).
-            assert_eq!(
-                frontier_len(position) - frontier_len(position - 1),
-                32,
-                "position {position} gains one ommer"
-            );
-            assert!(new - old >= 32, "position {position}: growth is added");
-        }
-    }
-}
-
-/// The epoch boundary at Dash Platform's chunk_power 11: the compacting
-/// append is no longer a ~630 KB `added_bytes` spike. V4 adds the note's
-/// own 312 bytes plus a few hundred bytes of framing, and reports the
-/// 2048 × 312 entry bytes the blob supersedes as replaced.
-#[test]
-fn epoch_boundary_at_chunk_power_11_is_not_an_added_bytes_spike() {
+fn commitment_tree_epoch_boundary_at_chunk_power_11_is_charged_the_fixed_model() {
     const CHUNK_POWER: u8 = 11;
     const EPOCH: u32 = 1 << CHUNK_POWER as u32;
-    let legacy = legacy_accounting();
-    let legacy_db = ct_db(CHUNK_POWER, &legacy);
-    let v4_db = ct_db(CHUNK_POWER, &GROVE_V4);
-
-    // Seeding 2047 notes walks the dense buffer O(n^2); do both trees at
-    // once.
-    std::thread::scope(|scope| {
-        for (db, version) in [(&legacy_db, &legacy), (&v4_db, &GROVE_V4)] {
-            scope.spawn(move || {
-                let seed: Vec<_> = (0..EPOCH - 1).map(ct_op).collect();
-                db.apply_batch(seed, None, None, version)
-                    .unwrap()
-                    .expect("seed to one before the boundary");
-            });
-        }
-    });
-
-    let legacy_cost = ct_insert(&legacy_db, EPOCH - 1, &legacy);
-    let v4_cost = ct_insert(&v4_db, EPOCH - 1, &GROVE_V4);
-
-    let blob_entry_bytes = (EPOCH * NOTE_ENTRY) as u64; // 638_976
+    let db = ct_db(CHUNK_POWER, &GROVE_V4);
+    let seed: Vec<_> = (0..EPOCH - 2).map(ct_op).collect();
+    db.apply_batch(seed, None, None, &GROVE_V4)
+        .unwrap()
+        .expect("seed to two before the boundary");
+    let before = ct_insert(&db, EPOCH - 2, &GROVE_V4);
+    let compacting = ct_insert(&db, EPOCH - 1, &GROVE_V4);
+    let after = ct_insert(&db, EPOCH, &GROVE_V4);
+    assert_fixed(
+        "compacting append",
+        &before,
+        &compacting,
+        compaction_seek_residual(0),
+    );
+    assert_fixed("first of the next epoch", &before, &after, 0);
+    // No 640 KB anywhere: the blob is prepaid a share at a time.
     assert!(
-        legacy_cost.storage_cost.added_bytes as u64 > blob_entry_bytes,
-        "legacy bills the whole blob as new storage: {legacy_cost:?}"
+        compacting.storage_cost.replaced_bytes < 4_000
+            && compacting.storage_cost.added_bytes < 1_000,
+        "{compacting:?}"
     );
-    assert!(
-        v4_cost.storage_cost.added_bytes < 2_000,
-        "v4 adds the note's share plus framing only: {v4_cost:?}"
-    );
-    assert!(
-        v4_cost.storage_cost.replaced_bytes as u64 >= blob_entry_bytes,
-        "v4 reports the superseded entry bytes as replaced: {v4_cost:?}"
-    );
-    assert_eq!(
-        delta(&v4_cost, &legacy_cost),
-        expected_delta((EPOCH - 1) as u64, CHUNK_POWER, NOTE_ENTRY, true)
-    );
-    // A compacting append writes no slot and reads none.
-    assert_only_accounting_differs(&v4_cost, &legacy_cost, "boundary", (0, 0));
-    assert_eq!(root_hash(&v4_db, &GROVE_V4), root_hash(&legacy_db, &legacy));
 }
 
-/// Over a whole epoch of steady state (epoch 2 at chunk_power 4) the V4
-/// `added_bytes` add up to the bytes that persist — one blob share per
-/// note plus the blob framing and the MMR node — while the legacy figures
-/// add up to that PLUS a second copy of every note (the slot rewrites) and
-/// the blob: ≈ 2× the physical growth.
+/// The frontier is charged its fixed model at every position: the
+/// ommer-heavy positions `2^k - 1` and the collapsing `2^k` cost the same
+/// Sinsemilla hashes and the same frontier bytes as any other.
 #[test]
-fn added_bytes_over_an_epoch_match_physical_growth() {
-    const CHUNK_POWER: u8 = 4;
-    const EPOCH: u64 = 1 << CHUNK_POWER;
-    let legacy = legacy_accounting();
-    let legacy_db = ct_db(CHUNK_POWER, &legacy);
-    let v4_db = ct_db(CHUNK_POWER, &GROVE_V4);
-    for position in 0..EPOCH {
-        ct_insert(&legacy_db, position as u32, &legacy);
-        ct_insert(&v4_db, position as u32, &GROVE_V4);
+fn frontier_is_charged_the_fixed_model_at_every_position() {
+    const CHUNK_POWER: u8 = 11; // nothing compacts in 0..34
+    let db = ct_db(CHUNK_POWER, &GROVE_V4);
+    let base = ct_insert(&db, 0, &GROVE_V4);
+    for position in 1..34u32 {
+        let cost = ct_insert(&db, position, &GROVE_V4);
+        assert_fixed(&format!("position {position}"), &base, &cost, 0);
     }
+    assert_eq!(base.sinsemilla_hash_calls, 33);
+    // The actual frontier at position 33 is 42 + 32·2 = 106 bytes; the
+    // charge is the model's 554 + varint, replaced.
+    assert_eq!(frontier_len(33), 106);
+    assert!(
+        base.storage_loaded_bytes >= grovedb_commitment_tree::MODEL_FRONTIER_SERIALIZED_LEN as u64
+    );
+}
 
+/// Over an epoch, a note's `added_bytes` are its long-term footprint and
+/// nothing else: the same every append, and the sum over the epoch is the
+/// epoch's entry bytes plus the amortized overhead — not the legacy's
+/// "every note twice plus the whole blob".
+#[test]
+fn added_bytes_over_an_epoch_are_the_long_term_footprint() {
+    const CHUNK_POWER: u8 = 4;
+    const EPOCH: u32 = 1 << CHUNK_POWER as u32;
+    let v4_db = ct_db(CHUNK_POWER, &GROVE_V4);
+    let legacy_db = ct_db(CHUNK_POWER, &GROVE_V3);
+    for position in 0..EPOCH {
+        ct_insert(&v4_db, position, &GROVE_V4);
+        ct_insert(&legacy_db, position, &GROVE_V3);
+    }
     let mut v4_added: u64 = 0;
     let mut legacy_added: u64 = 0;
-    let mut expected_added_delta: i64 = 0;
+    let mut per_append = None;
     for position in EPOCH..2 * EPOCH {
-        legacy_added += ct_insert(&legacy_db, position as u32, &legacy)
+        let v4 = ct_insert(&v4_db, position, &GROVE_V4)
+            .storage_cost
+            .added_bytes;
+        assert_eq!(*per_append.get_or_insert(v4), v4, "position {position}");
+        v4_added += v4 as u64;
+        legacy_added += ct_insert(&legacy_db, position, &GROVE_V3)
             .storage_cost
             .added_bytes as u64;
-        v4_added += ct_insert(&v4_db, position as u32, &GROVE_V4)
-            .storage_cost
-            .added_bytes as u64;
-        expected_added_delta += expected_delta(position, CHUNK_POWER, NOTE_ENTRY, true).0;
     }
-    assert_eq!(v4_added as i64 - legacy_added as i64, expected_added_delta);
-
-    // Legacy over the epoch: 15 slot rewrites (key + note) + the whole blob
-    // + 16 frontier saves (key + value) + the parent-Merk update; V4: 16
-    // blob shares + blob framing + frontier growth + the parent-Merk update.
-    // Strip the common parts the model does not see (parent Merk, MMR node,
-    // frontier) by comparing the two sums: legacy carries an extra
-    // 15 × (35 + 314) + (blob - framing = 16 × 312) - 16 × 312 (shares)
-    // + frontier keys/values.
-    let slot_rewrites = 15 * (SLOT_KEY_PAID + paid(NOTE_ENTRY)) as u64;
+    let footprint = EPOCH as u64 * (NOTE_ENTRY + amortized(CHUNK_POWER)) as u64;
     assert!(
-        legacy_added - v4_added >= slot_rewrites,
+        v4_added >= footprint && v4_added < footprint + 64 * EPOCH as u64,
+        "v4 {v4_added} vs footprint {footprint}"
+    );
+    // Legacy: 15 slot rewrites (key + note), the whole blob, 16 frontier
+    // saves — several times the footprint.
+    assert!(
+        legacy_added > 2 * footprint,
         "legacy charges every note twice over its life: legacy {legacy_added}, v4 {v4_added}"
     );
-}
-
-/// An epoch boundary inside ONE batch on a fresh tree: every slot and
-/// record key is written twice in the same session, but a `StorageBatch`
-/// keeps one put per key, so each is charged once — as churn under V4.
-/// Both blobs replace their epochs' prepaid bytes; the shares net out
-/// exactly.
-#[test]
-fn epoch_boundary_inside_one_batch_charges_each_key_once() {
-    const CHUNK_POWER: u8 = 2; // epoch 4, capacity 3
-    let legacy = legacy_accounting();
-    let legacy_db = ct_db(CHUNK_POWER, &legacy);
-    let v4_db = ct_db(CHUNK_POWER, &GROVE_V4);
-
-    let ops = || (0..8u32).map(ct_op).collect::<Vec<_>>();
-    let legacy_ctx = legacy_db.apply_batch(ops(), None, None, &legacy);
-    legacy_ctx.value.expect("legacy batch");
-    let v4_ctx = v4_db.apply_batch(ops(), None, None, &GROVE_V4);
-    v4_ctx.value.expect("v4 batch");
-
-    // Eight shares (8 × 312) exactly cover the two blobs' entry bytes
-    // (2 × 4 × 312) that legacy bills as added and V4 as replaced. The
-    // three slot keys and three record keys are each written twice in the
-    // batch but charged once (a `StorageBatch` keeps one put per key): new
-    // storage under legacy, churn under V4. The single frontier save is the
-    // first (new on both sides).
-    let two_blobs_entry_bytes = 2 * 4 * NOTE_ENTRY as i64;
-    let churn_added = -3 * ((SLOT_KEY_PAID + paid(NOTE_ENTRY)) as i64)
-        - 3 * ((RECORD_KEY_PAID + paid(record_len(CHUNK_POWER))) as i64);
-    let churn_replaced = 3 * (paid(NOTE_ENTRY) + paid(record_len(CHUNK_POWER))) as i64;
     assert_eq!(
-        delta(&v4_ctx.cost, &legacy_ctx.cost),
-        (churn_added, two_blobs_entry_bytes + churn_replaced),
-        "v4 {:?}\nlegacy {:?}",
-        v4_ctx.cost,
-        legacy_ctx.cost
+        root_hash(&v4_db, &GROVE_V4),
+        root_hash(&legacy_db, &GROVE_V3)
     );
-    // V4 bills the buffer model's reads for each of the six buffered
-    // appends; the two compacting ones do no buffer work.
-    let model = buffer_model(CHUNK_POWER);
-    assert_only_accounting_differs(
-        &v4_ctx.cost,
-        &legacy_ctx.cost,
-        "batch",
-        (6 * model.seek_count, 6 * model.storage_loaded_bytes),
-    );
-    assert_eq!(root_hash(&v4_db, &GROVE_V4), root_hash(&legacy_db, &legacy));
-    assert_verifies(&v4_db, &GROVE_V4);
 }
 
-/// A plain `BulkAppendTree` with VARIABLE-size values: a slot rewrite is
-/// sized against the value the slot held in committed storage (growth
-/// added, shrink not credited), the share is the value's own length, and a
-/// variable-format blob still replaces exactly the entry bytes.
+/// An epoch boundary inside ONE batch on a fresh tree: the batch's cost is
+/// the sum of the per-append fixed charges (slot and record keys written
+/// twice in the batch are charged once — a `StorageBatch` keeps one put per
+/// key — as churn), with no blob spike.
 #[test]
-fn bulk_append_tree_accounting_with_variable_size_values() {
+fn epoch_boundary_inside_one_batch_is_the_sum_of_fixed_charges() {
     const CHUNK_POWER: u8 = 2; // epoch 4, capacity 3
-    let legacy = legacy_accounting();
-    let make = |version: &GroveVersion| {
-        let db = make_empty_grovedb();
-        db.insert(
-            EMPTY_PATH,
-            b"bulk",
-            Element::empty_bulk_append_tree(CHUNK_POWER).expect("valid chunk_power"),
-            None,
-            None,
-            version,
-        )
-        .unwrap()
-        .expect("insert bulk append tree");
-        db
-    };
-    let legacy_db = make(&legacy);
-    let v4_db = make(&GROVE_V4);
+    let db = ct_db(CHUNK_POWER, &GROVE_V4);
+    let ops = (0..8u32).map(ct_op).collect::<Vec<_>>();
+    let ctx = db.apply_batch(ops, None, None, &GROVE_V4);
+    ctx.value.expect("v4 batch");
+    let model = buffer_model(CHUNK_POWER);
+    // 8 × (share + amortized) of added storage, plus the parent Merk's.
+    let own_added = 8 * (NOTE_ENTRY + amortized(CHUNK_POWER));
+    assert!(
+        ctx.cost.storage_cost.added_bytes >= own_added
+            && ctx.cost.storage_cost.added_bytes < own_added + 128,
+        "{:?}",
+        ctx.cost
+    );
+    // 8 × the model's reads (compacting appends included).
+    assert!(
+        ctx.cost.seek_count >= 8 * model.seek_count,
+        "{:?}",
+        ctx.cost
+    );
+    assert!(
+        ctx.cost.storage_loaded_bytes >= 8 * model.storage_loaded_bytes,
+        "{:?}",
+        ctx.cost
+    );
+    assert_eq!(ctx.cost.sinsemilla_hash_calls, 8 * 33);
+    assert_verifies(&db, &GROVE_V4);
+}
 
-    // Epoch 1 fixed, epoch 2 variable, epoch 3 fixed again.
+/// A plain `BulkAppendTree` with VARIABLE-size values: the charge differs
+/// between positions only by the value's own bytes — its share (added), its
+/// slot and its blob-rewrite part (replaced) — never by the position.
+#[test]
+fn bulk_append_tree_cost_differs_only_by_the_value_bytes() {
+    const CHUNK_POWER: u8 = 2; // epoch 4, capacity 3
+    let db = make_empty_grovedb();
+    db.insert(
+        EMPTY_PATH,
+        b"bulk",
+        Element::empty_bulk_append_tree(CHUNK_POWER).expect("valid chunk_power"),
+        None,
+        None,
+        &GROVE_V4,
+    )
+    .unwrap()
+    .expect("insert bulk append tree");
     let sizes: [u32; 12] = [8, 8, 8, 8, 8, 16, 4, 8, 8, 8, 8, 8];
-    // Committed value length per slot.
-    let mut slots: [Option<u32>; 3] = [None; 3];
-    let mut epoch_bytes: u32 = 0;
-
+    let mut base: Option<OperationCost> = None;
     for (position, &len) in sizes.iter().enumerate() {
         let value = vec![position as u8 + 1; len as usize];
-        let legacy_ctx = legacy_db.bulk_append(EMPTY_PATH, b"bulk", value.clone(), None, &legacy);
-        legacy_ctx.value.expect("legacy append");
-        let v4_ctx = v4_db.bulk_append(EMPTY_PATH, b"bulk", value, None, &GROVE_V4);
-        v4_ctx.value.expect("v4 append");
-
-        let mut added: i64 = len as i64; // the share
-        let mut replaced: i64 = 0;
-        let mut read: (u32, u64) = (0, 0);
-        epoch_bytes += len;
-        if position % 4 == 3 {
-            // Compaction: the blob replaces the epoch's entry bytes.
-            added -= epoch_bytes as i64;
-            replaced += epoch_bytes as i64;
-            epoch_bytes = 0;
+        let ctx = db.bulk_append(EMPTY_PATH, b"bulk", value, None, &GROVE_V4);
+        ctx.value.expect("v4 append");
+        let cost = ctx.cost;
+        let base = base.get_or_insert(cost.clone());
+        // Normalize the value-size terms away: added = share + amortized;
+        // replaced = paid(slot) + record + share.
+        let mut normalized = cost.clone();
+        normalized.storage_cost.added_bytes = normalized.storage_cost.added_bytes + 8 - len;
+        normalized.storage_cost.replaced_bytes =
+            normalized.storage_cost.replaced_bytes + paid(8) + 8 - paid(len) - len;
+        let residual = if position % 4 == 3 {
+            compaction_seek_residual(position as u64 / 4)
         } else {
-            // Buffered: the slot (its own size, whatever the slot held
-            // before — growth and shrink alike) and the path record are
-            // churn under V4, new storage under legacy; V4 bills the
-            // buffer model's reads.
-            added -= (SLOT_KEY_PAID + paid(len)) as i64;
-            replaced += paid(len) as i64;
-            added -= (RECORD_KEY_PAID + paid(record_len(CHUNK_POWER))) as i64;
-            replaced += paid(record_len(CHUNK_POWER)) as i64;
-            let model = buffer_model(CHUNK_POWER);
-            read = (model.seek_count, model.storage_loaded_bytes);
-        }
-        assert_eq!(
-            delta(&v4_ctx.cost, &legacy_ctx.cost),
-            (added, replaced),
-            "position {position} (len {len}): v4 {:?}\nlegacy {:?}",
-            v4_ctx.cost,
-            legacy_ctx.cost
-        );
-        assert_only_accounting_differs(
-            &v4_ctx.cost,
-            &legacy_ctx.cost,
-            &format!("position {position}"),
-            read,
+            0
+        };
+        assert_fixed(
+            &format!("position {position} (len {len})"),
+            base,
+            &normalized,
+            residual,
         );
     }
-    assert_eq!(root_hash(&v4_db, &GROVE_V4), root_hash(&legacy_db, &legacy));
-    assert_verifies(&v4_db, &GROVE_V4);
+    assert_verifies(&db, &GROVE_V4);
 }
 
-/// `PrivateDocumentStore` (fixed entry size) follows the same model,
-/// including the billed read of the committed entry a rewritten slot holds.
+/// `PrivateDocumentStore` (fixed entry size): the same fixed charge on every
+/// append; the compacting append differs by the seek residual and by the
+/// bulk state root's record read (the buffer is empty right after it).
 #[test]
-fn private_document_store_accounting_matches_model() {
+fn private_document_store_append_cost_is_fixed() {
     const CHUNK_POWER: u8 = 2; // epoch 4
     const ENTRY: u32 = 24;
-    let legacy = legacy_accounting();
-    let make = |version: &GroveVersion| {
-        let db = make_empty_grovedb();
-        db.insert(
-            EMPTY_PATH,
-            b"docs",
-            Element::empty_private_document_store(ENTRY, CHUNK_POWER).expect("valid config"),
-            None,
-            None,
-            version,
-        )
-        .unwrap()
-        .expect("insert private document store");
-        db
-    };
-    let legacy_db = make(&legacy);
-    let v4_db = make(&GROVE_V4);
-
+    let db = make_empty_grovedb();
+    db.insert(
+        EMPTY_PATH,
+        b"docs",
+        Element::empty_private_document_store(ENTRY, CHUNK_POWER).expect("valid config"),
+        None,
+        None,
+        &GROVE_V4,
+    )
+    .unwrap()
+    .expect("insert private document store");
+    let mut base: Option<OperationCost> = None;
     for position in 0..12u64 {
         let entry = vec![position as u8 + 1; ENTRY as usize];
-        let legacy_ctx = legacy_db.private_document_store_insert(
-            EMPTY_PATH,
-            b"docs",
-            entry.clone(),
-            None,
-            &legacy,
-        );
-        legacy_ctx.value.expect("legacy append");
-        let v4_ctx =
-            v4_db.private_document_store_insert(EMPTY_PATH, b"docs", entry, None, &GROVE_V4);
-        v4_ctx.value.expect("v4 append");
-
-        assert_eq!(
-            delta(&v4_ctx.cost, &legacy_ctx.cost),
-            expected_delta(position, CHUNK_POWER, ENTRY, false),
-            "position {position}: v4 {:?}\nlegacy {:?}",
-            v4_ctx.cost,
-            legacy_ctx.cost
-        );
-        assert_only_accounting_differs(
-            &v4_ctx.cost,
-            &legacy_ctx.cost,
-            &format!("position {position}"),
-            expected_read_delta(position, CHUNK_POWER, true),
-        );
+        let ctx = db.private_document_store_insert(EMPTY_PATH, b"docs", entry, None, &GROVE_V4);
+        ctx.value.expect("v4 append");
+        let cost = ctx.cost;
+        let base = base.get_or_insert(cost.clone());
+        let residual = if position % 4 == 3 {
+            compaction_seek_residual(position / 4)
+        } else {
+            0
+        };
+        assert_fixed(&format!("position {position}"), base, &cost, residual);
     }
-    assert_eq!(root_hash(&v4_db, &GROVE_V4), root_hash(&legacy_db, &legacy));
-    assert_verifies(&v4_db, &GROVE_V4);
+    assert_verifies(&db, &GROVE_V4);
 }
 
 /// The standalone `MmrTree` and dense tree never rewrite a key (every
 /// append lands on a fresh position), so their accounting is untouched:
 /// identical costs with the gates on and off.
+/// GROVE_V4 with the append-only family's accounting gates switched off.
+fn legacy_accounting() -> GroveVersion {
+    let mut version = GROVE_V4.clone();
+    version
+        .bulk_append_tree_versions
+        .cost
+        .append_storage_accounting = 0;
+    version
+        .commitment_tree_versions
+        .cost
+        .frontier_save_storage_accounting = 0;
+    version
+}
+
 #[test]
 fn standalone_mmr_and_dense_trees_are_unaffected() {
     let legacy = legacy_accounting();
@@ -883,26 +687,23 @@ fn bulk_compaction_actual(seed: Vec<Vec<u8>>, last: Vec<u8>) -> OperationCost {
     ctx.cost
 }
 
-/// The compaction blob replaces the epoch's entry bytes — whatever sizes
-/// an earlier state buffered — so the BulkAppend estimates must dominate a
-/// compaction whose actual `replaced_bytes` comes from large buffered
-/// values even when the compacting value itself is tiny: the worst-case
-/// arm (no declaration channel) saturates that dimension; the declared
-/// average-case arm models an epoch of same-size values and is an upper
-/// bound exactly there.
+/// Under the fixed model the compaction blob is prepaid a share at a time,
+/// so a compacting append over LARGE buffered values costs a tiny overflow
+/// value exactly what any append of that value costs — and both estimators
+/// dominate it without any epoch-sized term.
 #[test]
 fn bulk_append_estimates_dominate_actual_compaction_with_variable_sizes() {
     let grove_version = GroveVersion::latest();
     const BIG: usize = 10 * 1024;
 
     // Fifteen 10 KiB values, then a 16-byte overflow value that compacts
-    // them: 15 * 10 KiB of replaced bytes for a 16-byte op.
+    // them: the 16-byte op is charged its own bytes, not the 150 KiB blob.
     let small = vec![9u8; 16];
     let actual_mixed =
         bulk_compaction_actual((0..15u8).map(|i| vec![i; BIG]).collect(), small.clone());
     assert!(
-        actual_mixed.storage_cost.replaced_bytes as usize >= 15 * BIG,
-        "the blob replaces the buffered entry bytes: {actual_mixed:?}"
+        (actual_mixed.storage_cost.replaced_bytes as usize) < BIG,
+        "the blob is prepaid; the compacting op is charged its own churn only: {actual_mixed:?}"
     );
     let worst = bulk_worst_case_estimate(vec![bulk_op(small.clone())], grove_version);
     assert!(
@@ -910,12 +711,12 @@ fn bulk_append_estimates_dominate_actual_compaction_with_variable_sizes() {
         "worst case must dominate a compaction over larger buffered values;\nestimated \
          {worst:?}\nactual {actual_mixed:?}"
     );
-    // The undeclared average is an amortized one-entry figure; the declared
-    // one models same-size values — neither claims to bound this shape.
-    let average_undeclared =
-        bulk_average_case_estimate(vec![bulk_op(small.clone())], None, 16, grove_version);
+    let average_declared_small =
+        bulk_average_case_estimate(vec![bulk_op(small.clone())], Some(4), 16, grove_version);
     assert!(
-        average_undeclared.storage_cost.replaced_bytes < actual_mixed.storage_cost.replaced_bytes
+        average_declared_small.worse_or_eq_than(&actual_mixed),
+        "declared average case must dominate the compacting op too;\nestimated \
+         {average_declared_small:?}\nactual {actual_mixed:?}"
     );
 
     // Sixteen same-size values: the declared average-case estimate is an

--- a/grovedb/src/tests/append_storage_accounting_tests.rs
+++ b/grovedb/src/tests/append_storage_accounting_tests.rs
@@ -64,11 +64,18 @@ const NOTE_ENTRY: u32 = 312;
 const SLOT_KEY_PAID: u32 = 35;
 /// Paid key bytes of the frontier: prefix + `__ct_data__` (11) + 1.
 const FRONTIER_KEY_PAID: u32 = 44;
-/// Paid key bytes of a dense-buffer hash record: 32-byte prefix + `b'h'` +
+/// Paid key bytes of a dense-buffer path record: 32-byte prefix + `b'h'` +
 /// 2-byte position + 1 length byte.
 const RECORD_KEY_PAID: u32 = 36;
-/// A hash record: generation (8) + value hash (32) + node hash (32).
-const RECORD_LEN: u32 = grovedb_dense_fixed_sized_merkle_tree::HASH_RECORD_LEN as u32;
+/// A path record for a buffer of `chunk_power`: generation (8) + present
+/// mask (2) + value hash (32) + one 32-byte entry per level.
+fn record_len(chunk_power: u8) -> u32 {
+    grovedb_dense_fixed_sized_merkle_tree::path_record_len(chunk_power) as u32
+}
+/// The dense buffer's fixed root-maintenance model for `chunk_power`.
+fn buffer_model(chunk_power: u8) -> OperationCost {
+    grovedb_dense_fixed_sized_merkle_tree::v1_insert_model_cost(chunk_power)
+}
 
 fn varint_len(mut n: u32) -> u32 {
     let mut len = 1;
@@ -131,22 +138,18 @@ fn expected_delta(
         let entry_bytes = (epoch * entry_len as u64) as i64;
         added -= entry_bytes;
         replaced += entry_bytes;
-    } else if position >= epoch {
-        // Slot rewrite: legacy charges key + value as new; V4 replaces the
-        // value (same size: nothing added) and does not charge the key.
+    } else {
+        // Buffered append. The slot: legacy charges key + value as new
+        // storage every time; V4 reports churn — the value replaced, nothing
+        // added, no key — epoch 1 included. The path record (GROVE_V4 root
+        // maintenance, written by both sides) follows the slot: legacy's
+        // `AsNew` slot accounting writes it as new (key + record); V4's
+        // `Churn` reports it replaced.
         added -= (SLOT_KEY_PAID + paid(entry_len)) as i64;
         replaced += paid(entry_len) as i64;
-        // The slot's hash record (GROVE_V4 root maintenance) follows the
-        // slot: legacy's `AsNew` slot accounting tells the dense tree the
-        // slot cannot pre-exist, so the record is written as new (key +
-        // record); V4's `Overwrite` has it read the record left by the
-        // earlier epoch and report the rewrite as a replacement. The
-        // ancestors' records are sized from the reads both sides perform
-        // identically.
-        added -= (RECORD_KEY_PAID + paid(RECORD_LEN)) as i64;
-        replaced += paid(RECORD_LEN) as i64;
+        added -= (RECORD_KEY_PAID + paid(record_len(chunk_power))) as i64;
+        replaced += paid(record_len(chunk_power)) as i64;
     }
-    // else: a fresh slot is new storage on both sides.
 
     if with_frontier && position > 0 {
         // Legacy: key + whole frontier added on every save. V4: replaces the
@@ -162,26 +165,19 @@ fn expected_delta(
 }
 
 /// Expected `(seek_count, storage_loaded_bytes)` difference, V4 minus
-/// legacy: the read of the committed value a buffer slot holds, which sizes
-/// its rewrite — one seek and `committed_len` bytes, only for a buffered
-/// (non-compacting) append onto a slot committed in an earlier epoch — and,
-/// for the `CostResult`-returning store append that bills the dense tree's
-/// reads (`bills_record_reads`), the read of the slot's hash record that
-/// sizes ITS rewrite (one seek, the record bytes). The bulk / commitment
-/// appends drop the dense tree's reads and bill the hash count alone.
-fn expected_read_delta(
-    position: u64,
-    chunk_power: u8,
-    committed_len: u32,
-    bills_record_reads: bool,
-) -> (u32, u64) {
+/// legacy, for a buffered (non-compacting) append: the `Result`-returning
+/// bulk / commitment appends bill the dense buffer's fixed root-maintenance
+/// model under V4 (`bill_dense_io`) and drop it under the shipped
+/// accounting; the `CostResult`-returning store append bills the dense
+/// tree's cost under both (`bills_dense_always`), so nothing differs there.
+/// Nothing is read to size a rewrite any more.
+fn expected_read_delta(position: u64, chunk_power: u8, bills_dense_always: bool) -> (u32, u64) {
     let epoch = 1u64 << chunk_power;
-    if position % epoch == epoch - 1 || position < epoch {
+    if position % epoch == epoch - 1 || bills_dense_always {
         (0, 0)
-    } else if bills_record_reads {
-        (2, committed_len as u64 + RECORD_LEN as u64)
     } else {
-        (1, committed_len as u64)
+        let model = buffer_model(chunk_power);
+        (model.seek_count, model.storage_loaded_bytes)
     }
 }
 
@@ -192,9 +188,9 @@ fn delta(v4: &OperationCost, legacy: &OperationCost) -> (i64, i64) {
     )
 }
 
-/// Everything except the storage figures and the committed-slot (and, where
-/// billed, committed-record) read must agree: the accounting gates move
-/// bytes between `added` and `replaced` and add those reads, nothing else.
+/// Everything except the storage figures and the buffer model's reads must
+/// agree: the accounting gates move bytes between `added` and `replaced`
+/// and bill those reads, nothing else.
 fn assert_only_accounting_differs(
     v4: &OperationCost,
     legacy: &OperationCost,
@@ -390,7 +386,7 @@ fn commitment_tree_append_storage_accounting_matches_model_across_epochs() {
             &v4_cost,
             &legacy_cost,
             &format!("position {position}"),
-            expected_read_delta(position, CHUNK_POWER, NOTE_ENTRY, false),
+            expected_read_delta(position, CHUNK_POWER, false),
         );
         assert_eq!(
             root_hash(&v4_db, &GROVE_V4),
@@ -417,17 +413,21 @@ fn frontier_rewrite_replaces_previous_size_and_adds_only_growth() {
         let legacy_cost = ct_insert(&legacy_db, position as u32, &legacy);
         let v4_cost = ct_insert(&v4_db, position as u32, &GROVE_V4);
         let (d_added, d_replaced) = delta(&v4_cost, &legacy_cost);
-        // Epoch 1: fresh slots, nothing read.
+        // V4 bills the buffer model's reads; nothing else but storage moves.
         assert_only_accounting_differs(
             &v4_cost,
             &legacy_cost,
             &format!("position {position}"),
-            (0, 0),
+            expected_read_delta(position, CHUNK_POWER, false),
         );
 
-        // Strip the (epoch-1, fresh-slot) share so only the frontier is left.
-        let frontier_added = d_added - NOTE_ENTRY as i64;
-        let frontier_replaced = d_replaced;
+        // Strip the share and the slot / record churn so only the frontier
+        // is left.
+        let churn_added = -((SLOT_KEY_PAID + paid(NOTE_ENTRY)) as i64)
+            - (RECORD_KEY_PAID + paid(record_len(CHUNK_POWER))) as i64;
+        let churn_replaced = (paid(NOTE_ENTRY) + paid(record_len(CHUNK_POWER))) as i64;
+        let frontier_added = d_added - NOTE_ENTRY as i64 - churn_added;
+        let frontier_replaced = d_replaced - churn_replaced;
         if position == 0 {
             assert_eq!(
                 (frontier_added, frontier_replaced),
@@ -560,13 +560,13 @@ fn added_bytes_over_an_epoch_match_physical_growth() {
     );
 }
 
-/// An epoch boundary inside ONE batch on a fresh tree: every slot is
-/// written twice in the same session, but a `StorageBatch` keeps one put
-/// per key and the slot is new in committed storage, so it is charged once
-/// as new — never as a rewrite of a value that was never committed. Both
-/// blobs replace their epochs' prepaid bytes; the shares net out exactly.
+/// An epoch boundary inside ONE batch on a fresh tree: every slot and
+/// record key is written twice in the same session, but a `StorageBatch`
+/// keeps one put per key, so each is charged once — as churn under V4.
+/// Both blobs replace their epochs' prepaid bytes; the shares net out
+/// exactly.
 #[test]
-fn epoch_boundary_inside_one_batch_charges_slots_once_as_new() {
+fn epoch_boundary_inside_one_batch_charges_each_key_once() {
     const CHUNK_POWER: u8 = 2; // epoch 4, capacity 3
     let legacy = legacy_accounting();
     let legacy_db = ct_db(CHUNK_POWER, &legacy);
@@ -579,19 +579,31 @@ fn epoch_boundary_inside_one_batch_charges_slots_once_as_new() {
     v4_ctx.value.expect("v4 batch");
 
     // Eight shares (8 × 312) exactly cover the two blobs' entry bytes
-    // (2 × 4 × 312) that legacy bills as added and V4 as replaced; the
-    // three slots are new on both sides (committed storage held nothing);
-    // the single frontier save is the first (new on both sides).
+    // (2 × 4 × 312) that legacy bills as added and V4 as replaced. The
+    // three slot keys and three record keys are each written twice in the
+    // batch but charged once (a `StorageBatch` keeps one put per key): new
+    // storage under legacy, churn under V4. The single frontier save is the
+    // first (new on both sides).
     let two_blobs_entry_bytes = 2 * 4 * NOTE_ENTRY as i64;
+    let churn_added = -3 * ((SLOT_KEY_PAID + paid(NOTE_ENTRY)) as i64)
+        - 3 * ((RECORD_KEY_PAID + paid(record_len(CHUNK_POWER))) as i64);
+    let churn_replaced = 3 * (paid(NOTE_ENTRY) + paid(record_len(CHUNK_POWER))) as i64;
     assert_eq!(
         delta(&v4_ctx.cost, &legacy_ctx.cost),
-        (0, two_blobs_entry_bytes),
+        (churn_added, two_blobs_entry_bytes + churn_replaced),
         "v4 {:?}\nlegacy {:?}",
         v4_ctx.cost,
         legacy_ctx.cost
     );
-    // Nothing was committed, so no slot is read.
-    assert_only_accounting_differs(&v4_ctx.cost, &legacy_ctx.cost, "batch", (0, 0));
+    // V4 bills the buffer model's reads for each of the six buffered
+    // appends; the two compacting ones do no buffer work.
+    let model = buffer_model(CHUNK_POWER);
+    assert_only_accounting_differs(
+        &v4_ctx.cost,
+        &legacy_ctx.cost,
+        "batch",
+        (6 * model.seek_count, 6 * model.storage_loaded_bytes),
+    );
     assert_eq!(root_hash(&v4_db, &GROVE_V4), root_hash(&legacy_db, &legacy));
     assert_verifies(&v4_db, &GROVE_V4);
 }
@@ -644,20 +656,16 @@ fn bulk_append_tree_accounting_with_variable_size_values() {
             replaced += epoch_bytes as i64;
             epoch_bytes = 0;
         } else {
-            let slot = position % 4;
-            if let Some(previous) = slots[slot] {
-                added += paid(len).saturating_sub(paid(previous)) as i64
-                    - (SLOT_KEY_PAID + paid(len)) as i64;
-                replaced += paid(len).min(paid(previous)) as i64;
-                // The slot's hash record follows the slot (see
-                // `expected_delta`).
-                added -= (RECORD_KEY_PAID + paid(RECORD_LEN)) as i64;
-                replaced += paid(RECORD_LEN) as i64;
-                // The committed value is read to size the rewrite (the
-                // record read is not billed by the bulk append).
-                read = (1, previous as u64);
-            }
-            slots[slot] = Some(len);
+            // Buffered: the slot (its own size, whatever the slot held
+            // before — growth and shrink alike) and the path record are
+            // churn under V4, new storage under legacy; V4 bills the
+            // buffer model's reads.
+            added -= (SLOT_KEY_PAID + paid(len)) as i64;
+            replaced += paid(len) as i64;
+            added -= (RECORD_KEY_PAID + paid(record_len(CHUNK_POWER))) as i64;
+            replaced += paid(record_len(CHUNK_POWER)) as i64;
+            let model = buffer_model(CHUNK_POWER);
+            read = (model.seek_count, model.storage_loaded_bytes);
         }
         assert_eq!(
             delta(&v4_ctx.cost, &legacy_ctx.cost),
@@ -726,7 +734,7 @@ fn private_document_store_accounting_matches_model() {
             &v4_ctx.cost,
             &legacy_ctx.cost,
             &format!("position {position}"),
-            expected_read_delta(position, CHUNK_POWER, ENTRY, true),
+            expected_read_delta(position, CHUNK_POWER, true),
         );
     }
     assert_eq!(root_hash(&v4_db, &GROVE_V4), root_hash(&legacy_db, &legacy));

--- a/grovedb/src/tests/append_storage_accounting_tests.rs
+++ b/grovedb/src/tests/append_storage_accounting_tests.rs
@@ -415,6 +415,50 @@ fn added_bytes_over_an_epoch_are_the_long_term_footprint() {
     );
 }
 
+/// A commitment tree that compacted under GROVE_V3 has no persisted MMR
+/// root. Its first V4 append backfills the key (one extra commit-time put,
+/// prepaid) and is otherwise charged the fixed model; every V4 append after
+/// it is charged exactly the model, reading the key and never the peaks.
+#[test]
+fn legacy_commitment_tree_is_charged_the_fixed_model_after_one_backfill_put() {
+    const CHUNK_POWER: u8 = 4;
+    const EPOCH: u32 = 1 << CHUNK_POWER as u32;
+    let db = ct_db(CHUNK_POWER, &GROVE_V3);
+    for position in 0..EPOCH {
+        ct_insert(&db, position, &GROVE_V3);
+    }
+    let first = ct_insert(&db, EPOCH, &GROVE_V4);
+    let base = ct_insert(&db, EPOCH + 1, &GROVE_V4);
+    assert_fixed("first V4 append (backfill put)", &base, &first, 1);
+    for position in EPOCH + 2..2 * EPOCH + 2 {
+        let cost = ct_insert(&db, position, &GROVE_V4);
+        let residual = if position % EPOCH == EPOCH - 1 {
+            compaction_seek_residual((position / EPOCH) as u64)
+        } else {
+            0
+        };
+        assert_fixed(&format!("position {position}"), &base, &cost, residual);
+    }
+    // The same figure as a tree that ran under V4 from the start.
+    let v4_db = ct_db(CHUNK_POWER, &GROVE_V4);
+    for position in 0..EPOCH + 2 {
+        ct_insert(&v4_db, position, &GROVE_V4);
+    }
+    assert_fixed(
+        "V4-only tree",
+        &base,
+        &ct_insert(&v4_db, EPOCH + 2, &GROVE_V4),
+        0,
+    );
+    assert_eq!(root_hash(&db, &GROVE_V4), {
+        for position in EPOCH + 3..2 * EPOCH + 2 {
+            ct_insert(&v4_db, position, &GROVE_V4);
+        }
+        root_hash(&v4_db, &GROVE_V4)
+    });
+    assert_verifies(&db, &GROVE_V4);
+}
+
 /// An epoch boundary inside ONE batch on a fresh tree: the batch's cost is
 /// the sum of the per-append fixed charges (slot and record keys written
 /// twice in the batch are charged once — a `StorageBatch` keeps one put per

--- a/grovedb/src/tests/commitment_tree_cost_bound_tests.rs
+++ b/grovedb/src/tests/commitment_tree_cost_bound_tests.rs
@@ -339,9 +339,12 @@ fn test_commitment_tree_insert_declared_chunk_power_tightens_estimate() {
         "declared estimate should be far tighter than the physical-ceiling worst case; declared \
          {declared:?}\nworst {worst:?}",
     );
+    // Hashes are the buffer's fixed model, which grows with the height —
+    // not with the epoch — so the declared figure is tighter but not by
+    // orders of magnitude.
     assert!(
-        declared.hash_node_calls < worst.hash_node_calls / 100,
-        "declared estimate should be far tighter than the physical-ceiling worst case; declared \
+        declared.hash_node_calls < worst.hash_node_calls,
+        "declared estimate should be tighter than the physical-ceiling worst case; declared \
          {declared:?}\nworst {worst:?}",
     );
     // ...while still an upper bound of the compaction append.

--- a/grovedb/src/tests/commitment_tree_tests.rs
+++ b/grovedb/src/tests/commitment_tree_tests.rs
@@ -2629,9 +2629,14 @@ fn unsafe_dump_load_subtree_roundtrip_preserves_root_hash() {
         .raw_storage()
         .get_transactional_storage_context(subtree_path.clone(), None, &tx_a)
         .unwrap();
-    let ct_a = CommitmentTree::<_, DashMemo>::open(u64::from(N), TEST_CHUNK_POWER, ctx_open)
-        .value
-        .expect("CommitmentTree::open on A");
+    let ct_a = CommitmentTree::<_, DashMemo>::open(
+        u64::from(N),
+        TEST_CHUNK_POWER,
+        ctx_open,
+        grove_version,
+    )
+    .value
+    .expect("CommitmentTree::open on A");
     let combined_root = ct_a
         .compute_current_state_root(grove_version)
         .expect("compute_current_state_root on A");

--- a/grovedb/src/tests/non_merk_integrity_audit_tests.rs
+++ b/grovedb/src/tests/non_merk_integrity_audit_tests.rs
@@ -6,7 +6,7 @@
 //! written for other values, would verify clean while every V4 read returned
 //! a different root.
 
-use grovedb_dense_fixed_sized_merkle_tree::{position_key, record_key, HashRecord};
+use grovedb_dense_fixed_sized_merkle_tree::{position_key, record_key, PathRecord};
 use grovedb_storage::{Storage, StorageContext};
 use grovedb_version::version::GroveVersion;
 
@@ -76,7 +76,7 @@ fn test_verify_grovedb_detects_dense_payload_tampering_behind_records() {
     );
 }
 
-/// The converse: the values are intact but the position-0 record (current
+/// The converse: the values are intact but the last insert's record (current
 /// generation) claims another root. The child-hash binding still holds —
 /// the audit walks the values — so only the record issue must fire, and it
 /// must fire: every V4 root read would otherwise return the wrong root.
@@ -99,12 +99,13 @@ fn test_verify_grovedb_detects_dense_records_disagreeing_with_values() {
             .unwrap()
             .expect("insert value");
     }
-    let forged = HashRecord {
-        generation: 0,
-        value_hash: [1u8; 32],
-        node_hash: [2u8; 32],
-    };
-    tamper(&db, &[b"dense"], &record_key(0), &forged.to_bytes());
+    // The root is `entry[0]` of the LAST insert's path record (position 4
+    // after five inserts): forge that record with a current generation and
+    // a wrong root.
+    let mut forged = PathRecord::new(0, [1u8; 32], 4);
+    forged.set_entry(0, [2u8; 32]);
+    forged.set_entry(2, [3u8; 32]);
+    tamper(&db, &[b"dense"], &record_key(4), &forged.to_bytes());
 
     let issues = issue_paths(&db, grove_version);
     assert_eq!(


### PR DESCRIPTION
## Summary

Follow-up to #828, on four points raised in review of the shielded pool's per-append cost — after this PR a `CommitmentTreeInsert` (and a bulk-append / `PrivateDocumentStore` append) costs the same at every position of the tree:

1. **An entry's storage cost is its long-term footprint.** The dense buffer is a fixed-size, per-tree scratch area rewritten every epoch; it is not any entry's long-term storage, so nothing of it should be charged as `added_bytes`. Under the V4 accounting (`append_storage_accounting: 1`) the bulk-append tree now asks the dense tree for `SlotWriteAccounting::Churn`: every buffer slot write and every path record write — epoch 1 included, growth and shrink alike — is reported as an in-place replacement of its own size (`replaced_bytes`), nothing added, no key charged, **and nothing is read to size it** (the committed-slot read and the record existence read are gone; `committed_total_count` is removed). An entry's `added_bytes` are its chunk-blob share (prepaid at its append) plus the amortized blob framing and MMR nodes. The standalone `DenseAppendOnlyFixedSizeTree` keeps `AsNew` — its buffer *is* its long-term storage.

2. **All dense-tree costs are fixed at the height's average.** Root-maintenance version 1 now writes **one fixed-size path record per insert** under the inserting position's key (`generation || present u16 || value_hash || entry[depth] × height`, `42 + 32·height` bytes): the position's value hash and the node hash of every position on its ancestor path. An insert derives its ancestors' hashes from earlier inserts' records — the record of the *last insert into a subtree* holds that subtree's current hash, located arithmetically from `count` (`last_filled_in_subtree`); a position's own record holds its value hash for good — so no record is ever rewritten by a normal insert. Every insert is **charged a fixed model for the tree's height** (`V1InsertModel::for_height` / `v1_insert_model_cost`: the blake3 calls `2 + ⌈avg depth⌉` and the record reads, averaged over every position of a full buffer and rounded up — at `chunk_power` 11: 12 blake3, 18 record reads of 394 B) plus its two position-independent puts (slot, record). The cost of appending to a tree of a given height is therefore the same whatever the position; the commit-time seeks are constant too (exactly two puts).

   Catch-up of a buffer filled under V3 is **read-only** (the legacy subtree is walked, nothing synthesized) and billed the same model; for the rolling buffer it ends with the epoch the switch happened in, and the work is never more than V3 did on every insert.

3. **Compaction is not charged to the append that happens to trigger it.** Under `append_storage_accounting: 1` / `compaction_hash_count: 1` the compaction's work is amortized into the fixed per-append model: the per-chunk hash bound over the epoch (`amortized_compaction_hashes(chunk_power) = ⌈65 / 2^chunk_power⌉` — 1 blake3 per append from cp 7, so at the shielded pool's 11; 65 = leaf hash + ≤ 32 merges + ≤ 32 bagging folds with 32-bit MMR keys — charged as a bound so no prefix of the tree's life is ever under-prepaid, at any height), the blob framing + MMR nodes as `amortized_compaction_added_bytes(epoch)` added bytes on every append (`⌈159 / 2^chunk_power⌉` — 1 byte at cp 11), the variable blob format's 4-byte per-entry prefix unless the owner declares a fixed entry size (`BulkAppendTree::with_fixed_entry_size`, enforced on append — `CommitmentTree` and `PrivateDocumentStore` do, so their appends are charged exactly their long-term bytes), and the entry's own bytes once more as `replaced` (its part of the blob rewrite). The compacting append then writes the blob and the MMR nodes **prepaid** (`LeafValueStorageCost::Prepaid`, zero-byte cost information) and is charged the slot/record churn it does not write, so its figure equals every other append's. Its `compaction_hash_count` is 0. It also persists the chunk-MMR root under key `r` (32 B, prepaid) so that reading the state root of a reopened tree costs two fixed reads (persisted root + last record) instead of bagging the peaks — which meant loading a full ≈ 630 KB chunk blob on the live CT path whenever the chunk count is odd. A tree whose last compaction predates V4 has no such key: its first V4 append bags the peaks once and backfills the key (one prepaid put, not billed — like the dense catch-up); every reopen after that reads the key. A present `r` of any length but 32 is `CorruptedData`.

4. **The Sinsemilla frontier is a constant price.** New gate `commitment_tree_versions.cost.frontier_cost_model` (1 from V4): every append is charged 33 Sinsemilla hashes (`MODEL_FRONTIER_APPEND_SINSEMILLA_HASHES`, the 32-deep root walk plus the average ommer merge) and a 554-byte frontier (`MODEL_FRONTIER_SERIALIZED_LEN`, the average over the position space) loaded at open and replaced at save — instead of `32 + trailing_ones(position)` hashes and the position's actual serialized size. `CommitmentTree::open` takes the grove version for the load charge; the save put carries the model cost info (`needs_value_verification: false`). `append_raw` resolves the gate before its first write, so an unknown version rejects a pristine tree.

   **Residual**: the only position-dependent figure left is the commit-time seek count of a compacting append (its blob + MMR-node puts vs. the slot + record puts: `1 + trailing_ones(chunks) + 1 − 2`), bounded and once per epoch; tests pin it as `compaction_seek_residual`.

### Estimators

Built on the same model (`dense_buffer_model`), so they are tight rather than bounds on the dense part: the CT model drops the full-walk hash term and the committed read, charges the slot/record as `replaced` only, the frontier at the model (33 / 554), the amortized compaction share (`amortized_compaction_added_bytes` on the average arm, `max_amortized_compaction_added_bytes` — the epoch-2 share — on the worst arm) and the compacting append's seek residual (`MAX_COMPACTION_PUTS`); the PDS model and the bulk and dense arms likewise. The dense arms' element read/load are now counted.

### What stays

Root hashes, stored values, chunk blobs, proofs — identical. V1..V3 paths byte-for-byte. The audit API from #828 (`root_hash_from_values`, `recorded_root` — now `entry[0]` of the last insert's record — `buffer_record_mismatch`, the `__dense_hash_records__` verify issue) unchanged in behaviour; the forged-record regression forges the last insert's record.

### Tests

- Dense crate: v1 == v0 roots at every fill (heights 1..6, cold/warm sessions), `last_filled_in_subtree`, catch-up (read-only, one record per insert, model charged), stale generations, **every insert charged the model at every position / warm or cold**, one record put of fixed size, ≤ 2·depth record reads, record-put sizing per accounting (`Churn` never reads; `Overwrite` reads once; `AsNew` new), model figures pinned (h=1,2,11,16) and never below the true epoch average, fault rollback, version rejection, record encoding.
- Bulk crate: every slot and record write is churn, no read to size, every append (compacting included) charged the fixed model, `commit_mmr` writes prepaid, `v3`/`v4` roots identical with records and the persisted root as the only storage difference (persisted root == bagged root), hash count per version.
- CT crate: frontier save accounting per version (model replaced 554, unknown version rejected), `open`/`append` charges under the model; PDS crate: compacting append charged the fixed model.
- grovedb: `estimated ≥ actual` sweeps (CT incl. V3→V4 catch-up at cp 4/11, PDS incl. cp-11 boundary, bulk, dense incl. V3-seeded), catch-up not billed, integrity audits (payload tamper / forged last record / V3 buffer), `append_storage_accounting_tests` rewritten around the fixed model: CT cost identical at positions 0..48 (cp 4) and across the cp-11 epoch boundary, frontier charged the model at every position, added bytes over an epoch = long-term footprint (V4 vs V3), epoch boundary inside one batch = sum of fixed charges, bulk/PDS fixed, standalone MMR/dense trees unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional fixed-size entry configuration for more predictable storage usage.
  * Added version-aware cost models for append, commitment-tree, and dense-tree operations.
  * Added automatic persistence and recovery of tree roots during upgrades.

* **Improvements**
  * Improved storage and operation-cost estimates with amortized compaction and variable-entry framing.
  * Dense-tree maintenance now uses more efficient path records and fixed, height-based accounting.

* **Bug Fixes**
  * Invalid persisted roots and unsupported cost-model versions now fail safely without modifying data.
  * Improved integrity checks for aggregate and tree state roots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->