### PR TITLE
feat(append-only): amortize the compaction's commit-time seeks — prepaid puts carry no seek (GROVE_V4)

### DIFF
--- a/costs/src/storage_cost/key_value_cost.rs
+++ b/costs/src/storage_cost/key_value_cost.rs
@@ -49,6 +49,11 @@ pub struct KeyValueStorageCost {
     pub new_node: bool,
     /// Should we verify this at storage time
     pub needs_value_verification: bool,
+    /// The put was billed by its owner in advance — bytes, key and the
+    /// write itself — so the commit path charges it nothing, the seek
+    /// included. Set only by [`prepaid`](Self::prepaid); `Default` is NOT
+    /// prepaid (a default cost info still pays its seek).
+    pub prepaid: bool,
 }
 
 impl KeyValueStorageCost {
@@ -91,6 +96,7 @@ impl KeyValueStorageCost {
                 value_storage_cost,
                 new_node: false,
                 needs_value_verification: false,
+                prepaid: false,
             }
         } else {
             KeyValueStorageCost {
@@ -106,6 +112,7 @@ impl KeyValueStorageCost {
                 },
                 new_node: true,
                 needs_value_verification: false,
+                prepaid: false,
             }
         }
     }
@@ -134,6 +141,7 @@ impl KeyValueStorageCost {
             },
             new_node: false,
             needs_value_verification: true,
+            prepaid: false,
         }
     }
 
@@ -150,19 +158,15 @@ impl KeyValueStorageCost {
             value_storage_cost: StorageCost::default(),
             new_node: false,
             needs_value_verification: false,
+            prepaid: true,
         }
     }
 
     /// Whether this is the cost information of a fully prepaid put (see
     /// [`prepaid`](Self::prepaid)): nothing to bill at commit, the seek
-    /// included. Only an owner that billed the write in advance produces
-    /// this shape — every other constructor charges bytes, a key, or asks
-    /// for value verification.
+    /// included. An explicit marker — a zero-cost `Default` is not prepaid.
     pub fn is_prepaid(&self) -> bool {
-        self.key_storage_cost == StorageCost::default()
-            && self.value_storage_cost == StorageCost::default()
-            && !self.new_node
-            && !self.needs_value_verification
+        self.prepaid
     }
 
     /// Returns the total removed bytes between the key removed bytes and the
@@ -181,6 +185,7 @@ impl Add for KeyValueStorageCost {
             value_storage_cost: self.value_storage_cost + rhs.value_storage_cost,
             new_node: self.new_node & rhs.new_node,
             needs_value_verification: self.needs_value_verification & rhs.needs_value_verification,
+            prepaid: self.prepaid & rhs.prepaid,
         }
     }
 }
@@ -191,6 +196,7 @@ impl AddAssign for KeyValueStorageCost {
         self.value_storage_cost += rhs.value_storage_cost;
         self.new_node &= rhs.new_node;
         self.needs_value_verification &= rhs.needs_value_verification;
+        self.prepaid &= rhs.prepaid;
     }
 }
 
@@ -201,19 +207,30 @@ mod prepaid_tests {
     #[test]
     fn prepaid_is_the_only_shape_that_bills_nothing() {
         assert!(KeyValueStorageCost::prepaid().is_prepaid());
+        // The marker is explicit: a zero-cost default still pays its seek.
+        assert!(!KeyValueStorageCost::default().is_prepaid());
+        assert_ne!(
+            KeyValueStorageCost::prepaid(),
+            KeyValueStorageCost::default()
+        );
         assert!(!KeyValueStorageCost::for_in_place_value_rewrite(0, 0).is_prepaid());
         assert!(!KeyValueStorageCost::for_in_place_value_rewrite(8, 8).is_prepaid());
         assert!(!KeyValueStorageCost::for_updated_root_cost(None, 1).is_prepaid());
         assert!(!KeyValueStorageCost::for_updated_root_cost(Some(1), 1).is_prepaid());
-        let mut new_node = KeyValueStorageCost::prepaid();
-        new_node.new_node = true;
-        assert!(!new_node.is_prepaid());
-        let mut verified = KeyValueStorageCost::prepaid();
-        verified.needs_value_verification = true;
-        assert!(!verified.is_prepaid());
+        let mut unmarked = KeyValueStorageCost::prepaid();
+        unmarked.prepaid = false;
+        assert!(!unmarked.is_prepaid());
         let mut replaced = KeyValueStorageCost::prepaid();
         replaced.value_storage_cost.replaced_bytes = 1;
-        assert!(!replaced.is_prepaid());
+        // Bytes on a prepaid put are still added by the commit path; only the
+        // seek is waived. The marker, not the shape, decides.
+        assert!(replaced.is_prepaid());
+        let mut sum = KeyValueStorageCost::prepaid();
+        sum += KeyValueStorageCost::default();
+        assert!(
+            !sum.is_prepaid(),
+            "a sum with an unprepaid part is not prepaid"
+        );
     }
 }
 

--- a/costs/src/storage_cost/key_value_cost.rs
+++ b/costs/src/storage_cost/key_value_cost.rs
@@ -137,6 +137,34 @@ impl KeyValueStorageCost {
         }
     }
 
+    /// The cost information of a put whose owner has already charged
+    /// everything about it — its key and value bytes AND the write itself —
+    /// in advance (the bulk-append tree prepays each append's share of the
+    /// chunk blob, the MMR nodes and the commit-time puts that compaction
+    /// issues, amortized over the epoch). The commit path bills such a put
+    /// nothing: no added or replaced bytes, no key, no value verification,
+    /// and no seek.
+    pub fn prepaid() -> Self {
+        KeyValueStorageCost {
+            key_storage_cost: StorageCost::default(),
+            value_storage_cost: StorageCost::default(),
+            new_node: false,
+            needs_value_verification: false,
+        }
+    }
+
+    /// Whether this is the cost information of a fully prepaid put (see
+    /// [`prepaid`](Self::prepaid)): nothing to bill at commit, the seek
+    /// included. Only an owner that billed the write in advance produces
+    /// this shape — every other constructor charges bytes, a key, or asks
+    /// for value verification.
+    pub fn is_prepaid(&self) -> bool {
+        self.key_storage_cost == StorageCost::default()
+            && self.value_storage_cost == StorageCost::default()
+            && !self.new_node
+            && !self.needs_value_verification
+    }
+
     /// Returns the total removed bytes between the key removed bytes and the
     /// value removed bytes
     pub fn combined_removed_bytes(self) -> StorageRemovedBytes {
@@ -163,6 +191,29 @@ impl AddAssign for KeyValueStorageCost {
         self.value_storage_cost += rhs.value_storage_cost;
         self.new_node &= rhs.new_node;
         self.needs_value_verification &= rhs.needs_value_verification;
+    }
+}
+
+#[cfg(test)]
+mod prepaid_tests {
+    use super::*;
+
+    #[test]
+    fn prepaid_is_the_only_shape_that_bills_nothing() {
+        assert!(KeyValueStorageCost::prepaid().is_prepaid());
+        assert!(!KeyValueStorageCost::for_in_place_value_rewrite(0, 0).is_prepaid());
+        assert!(!KeyValueStorageCost::for_in_place_value_rewrite(8, 8).is_prepaid());
+        assert!(!KeyValueStorageCost::for_updated_root_cost(None, 1).is_prepaid());
+        assert!(!KeyValueStorageCost::for_updated_root_cost(Some(1), 1).is_prepaid());
+        let mut new_node = KeyValueStorageCost::prepaid();
+        new_node.new_node = true;
+        assert!(!new_node.is_prepaid());
+        let mut verified = KeyValueStorageCost::prepaid();
+        verified.needs_value_verification = true;
+        assert!(!verified.is_prepaid());
+        let mut replaced = KeyValueStorageCost::prepaid();
+        replaced.value_storage_cost.replaced_bytes = 1;
+        assert!(!replaced.is_prepaid());
     }
 }
 

--- a/costs/tests/coverage_regression.rs
+++ b/costs/tests/coverage_regression.rs
@@ -149,6 +149,7 @@ fn add_key_value_storage_costs_respects_verification_flags_and_errors() {
         },
         new_node: true,
         needs_value_verification: false,
+        prepaid: false,
     };
 
     let err = with_mismatch
@@ -178,6 +179,7 @@ fn add_key_value_storage_costs_respects_verification_flags_and_errors() {
         },
         new_node: false,
         needs_value_verification: false,
+        prepaid: false,
     };
 
     update_node
@@ -200,6 +202,7 @@ fn add_key_value_storage_costs_respects_verification_flags_and_errors() {
         },
         new_node: true,
         needs_value_verification: true,
+        prepaid: false,
     };
 
     let err = needs_value_verification
@@ -533,6 +536,7 @@ fn key_value_storage_cost_paths_are_exercised() {
         },
         new_node: true,
         needs_value_verification: true,
+        prepaid: false,
     }
     .combined_removed_bytes();
     assert_eq!(combined, BasicStorageRemoval(12));
@@ -550,6 +554,7 @@ fn key_value_storage_cost_paths_are_exercised() {
         },
         new_node: true,
         needs_value_verification: true,
+        prepaid: false,
     };
     let b = KeyValueStorageCost {
         key_storage_cost: StorageCost {
@@ -564,6 +569,7 @@ fn key_value_storage_cost_paths_are_exercised() {
         },
         new_node: false,
         needs_value_verification: false,
+        prepaid: false,
     };
 
     let sum = a.clone() + b.clone();

--- a/docs/book/src/bulk-append-tree.md
+++ b/docs/book/src/bulk-append-tree.md
@@ -496,11 +496,13 @@ unless the owner declared a fixed entry size with `with_fixed_entry_size` — th
 commitment tree and the private document store do — plus the epoch's share of the
 blob framing and MMR nodes — 1 byte at chunk_power 11) and its churn as
 `replaced` (slot, path record, its part of the blob rewrite). The compacting append
-writes the blob, the MMR nodes and the persisted MMR root prepaid and is charged the
-same; physically it still reads the epoch back and hashes the blob once. The only
-residual is its commit-time seek count (blob + MMR nodes instead of slot + record),
-bounded and once per epoch. A buffer filled under GROVE_V1..V3 is caught up from its
-values by the V4 appends that need it, read-only and billed the same model.
+writes the blob, the MMR nodes and the persisted MMR root prepaid
+(`KeyValueStorageCost::prepaid()` — no bytes and no seek at commit; their seeks are
+amortized into every append as ⌈34 / 2^chunk_power⌉, 1 at chunk_power 11, and the
+compacting append is charged the slot + record seeks it does not issue) and is charged
+the same; physically it still reads the epoch back and hashes the blob once. Nothing
+about the charge depends on the position. A buffer filled under GROVE_V1..V3 is caught
+up from its values by the V4 appends that need it, read-only and billed the same model.
 
 ## Comparison with MmrTree
 

--- a/docs/book/src/commitment-tree.md
+++ b/docs/book/src/commitment-tree.md
@@ -940,7 +940,7 @@ and ZK circuit cost.
 | Frontier bytes loaded | GROVE_V4+: fixed 554 (the average frontier); GROVE_V1..V3: the actual 42 + 32·popcount(position) | GROVE_V4+: 554; GROVE_V1..V3: 1,066 |
 | Frontier bytes written | GROVE_V4+: 554 `replaced`; GROVE_V1..V3: actual | same |
 | BulkAppendTree hashes | GROVE_V4+: fixed model (12 + ⌈65 / 2^chunk_power⌉ = 1 amortized compaction + 1 state root at chunk_power 11, every append, compacting included); GROVE_V1..V3: 2·(buffer fill) + 1 | GROVE_V4+: the same; GROVE_V1..V3: ≈ 2·chunk_size on the last buffered append |
-| BulkAppendTree I/O | GROVE_V4+: the model's record reads (18 at chunk_power 11), slot + record puts (churn: `replaced`, never `added`), blob share + 1 B amortized framing `added` | GROVE_V4+: the same, the compacting append's commit-time puts aside; GROVE_V1..V3: + epoch read-back and MMR writes on chunk compaction |
+| BulkAppendTree I/O | GROVE_V4+: the model's record reads (18 at chunk_power 11) + 1 amortized compaction seek, slot + record puts (churn: `replaced`, never `added`), blob share + 1 B amortized framing `added` | GROVE_V4+: the same (the compacting append's puts are prepaid, no seek); GROVE_V1..V3: + epoch read-back and MMR writes on chunk compaction |
 
 **Cost estimation constants** (from `average_case_costs.rs` and
 `worst_case_costs.rs`):

--- a/docs/crates/costs.md
+++ b/docs/crates/costs.md
@@ -135,7 +135,7 @@ records exist only under `dense_tree_versions.root_maintenance = 1`):
 | buffer slot, any epoch | key + value `added` | value `replaced` (its own paid size); nothing added, key not charged, nothing read |
 | entry's chunk-blob share | — (blob charged at compaction) | entry bytes `added` at the entry's own append (plus the variable format's 4-byte per-entry prefix unless the owner declared a fixed entry size — the commitment tree and the private document store do), plus the epoch's share of the blob framing and MMR nodes (`amortized_compaction_added_bytes`, 1 byte at `chunk_power` 11) |
 | entry's part of the blob rewrite | — | entry bytes `replaced` at the entry's own append |
-| compaction blob, MMR internal nodes, persisted MMR root (`r`) | key + whole blob `added`; nodes `added`; no persisted root | prepaid: zero-byte cost information |
+| compaction blob, MMR internal nodes, persisted MMR root (`r`) | key + whole blob `added`; nodes `added`; no persisted root; one seek per put | prepaid (`KeyValueStorageCost::prepaid()`): no bytes, no key, no seek at commit — their seeks are amortized into every append (`amortized_compaction_seeks`, 1 at `chunk_power` 11) |
 | frontier rewrite | key + value `added` every save | 556 bytes `replaced` every save — the model's 554-byte frontier plus its two-byte length varint (`frontier_cost_model`), first save included |
 | buffer path record (one per append, `42 + 32·chunk_power` bytes) | — (no records) | `replaced` (its own paid size); nothing added, key not charged |
 

--- a/grovedb-bulk-append-tree/src/cost/mod.rs
+++ b/grovedb-bulk-append-tree/src/cost/mod.rs
@@ -96,6 +96,35 @@ pub fn max_amortized_compaction_hashes() -> u32 {
     amortized_compaction_hashes(1)
 }
 
+/// The most puts one compaction can issue at commit: the chunk blob, the
+/// MMR internal nodes its push creates (one per trailing one bit of the
+/// chunk index — at most 31 with 32-bit MMR keys, bounded by 32 here) and
+/// the persisted MMR root. Under the fixed model every one of them is
+/// prepaid (`KeyValueStorageCost::prepaid()`, no seek at commit) and their
+/// seeks are charged on every append as this bound over the epoch.
+pub const MAX_COMPACTION_PUTS_PER_CHUNK: u32 = 1 + 32 + 1;
+
+/// The seeks a compaction's commit-time puts cost, amortized over the epoch
+/// and charged on every append under the fixed model: the per-chunk bound
+/// over `2^chunk_power` appends, rounded up — one per append from
+/// `chunk_power` 6 (so at the shielded pool's 11), 17 at the smallest.
+/// Charged as a bound so every prefix of the tree's life stays prepaid.
+pub fn amortized_compaction_seeks(chunk_power: u8) -> u32 {
+    MAX_COMPACTION_PUTS_PER_CHUNK.div_ceil(1u32 << chunk_power.min(16) as u32)
+}
+
+/// The largest per-append compaction seek share the type permits — the
+/// smallest epoch, `chunk_power` 1.
+pub fn max_amortized_compaction_seeks() -> u32 {
+    amortized_compaction_seeks(1)
+}
+
+/// The puts a buffered append issues at commit — its slot and its path
+/// record — which a compacting append, writing neither (its puts are all
+/// prepaid), is charged all the same under the fixed model, so its seek
+/// figure is every other append's.
+pub const BUFFER_CHURN_PUTS: u32 = 2;
+
 /// The per-entry framing a variable-format chunk blob carries: a four-byte
 /// length prefix before every entry (`serialize_variable`). A tree whose
 /// entries are all one size serializes the fixed format (no per-entry

--- a/grovedb-bulk-append-tree/src/lib.rs
+++ b/grovedb-bulk-append-tree/src/lib.rs
@@ -20,9 +20,10 @@ pub mod test_utils;
 // Re-export main types
 pub use chunk::{chunk_blob_entry_bytes, deserialize_chunk_blob, serialize_chunk_blob};
 pub use cost::{
-    amortized_compaction_added_bytes, amortized_compaction_hashes, max_amortized_compaction_hashes,
+    amortized_compaction_added_bytes, amortized_compaction_hashes, amortized_compaction_seeks,
+    max_amortized_compaction_hashes, max_amortized_compaction_seeks, BUFFER_CHURN_PUTS,
     COMPACTION_OVERHEAD_BYTES_PER_EPOCH, MAX_COMPACTION_HASHES_PER_CHUNK,
-    VARIABLE_ENTRY_FRAMING_BYTES,
+    MAX_COMPACTION_PUTS_PER_CHUNK, VARIABLE_ENTRY_FRAMING_BYTES,
 };
 pub use error::BulkAppendError;
 pub use grovedb_dense_fixed_sized_merkle_tree::path_record_len;

--- a/grovedb-bulk-append-tree/src/tree/append.rs
+++ b/grovedb-bulk-append-tree/src/tree/append.rs
@@ -210,9 +210,15 @@ impl<'db, S: StorageContext<'db>> BulkAppendTree<S> {
             let model = v1_insert_model_cost(self.dense_tree.height());
             hash_count += model.hash_node_calls
                 + crate::cost::amortized_compaction_hashes(self.dense_tree.height());
+            // The model's record reads plus the compaction's commit-time
+            // puts amortized over the epoch (the puts themselves are
+            // prepaid: no seek at commit).
             storage_accounting_cost.seek_count = storage_accounting_cost
                 .seek_count
-                .saturating_add(model.seek_count);
+                .saturating_add(model.seek_count)
+                .saturating_add(crate::cost::amortized_compaction_seeks(
+                    self.dense_tree.height(),
+                ));
             storage_accounting_cost.storage_loaded_bytes = storage_accounting_cost
                 .storage_loaded_bytes
                 .saturating_add(model.storage_loaded_bytes);
@@ -225,12 +231,15 @@ impl<'db, S: StorageContext<'db>> BulkAppendTree<S> {
                 .saturating_add(u32::try_from(value.len()).unwrap_or(u32::MAX));
             if try_result.is_none() {
                 // A compacting append writes no slot and no record; it is
-                // charged their churn all the same, so its storage figure is
-                // the fixed model's.
+                // charged their churn — bytes and seeks — all the same, so
+                // its figure is the fixed model's.
                 storage_accounting_cost.storage_cost.replaced_bytes = storage_accounting_cost
                     .storage_cost
                     .replaced_bytes
                     .saturating_add(self.buffer_churn_replaced_bytes(value.len()));
+                storage_accounting_cost.seek_count = storage_accounting_cost
+                    .seek_count
+                    .saturating_add(crate::cost::BUFFER_CHURN_PUTS);
             }
         } else {
             // The hashes the insert reports: two per filled position (the
@@ -344,12 +353,21 @@ impl<'db, S: StorageContext<'db>> BulkAppendTree<S> {
             let mut model = v1_insert_model_cost(self.dense_tree.height());
             model.hash_node_calls +=
                 crate::cost::amortized_compaction_hashes(self.dense_tree.height());
+            model.seek_count =
+                model
+                    .seek_count
+                    .saturating_add(crate::cost::amortized_compaction_seeks(
+                        self.dense_tree.height(),
+                    ));
             model.storage_cost.replaced_bytes = u32::try_from(value.len()).unwrap_or(u32::MAX);
             if try_result.is_none() {
                 model.storage_cost.replaced_bytes = model
                     .storage_cost
                     .replaced_bytes
                     .saturating_add(self.buffer_churn_replaced_bytes(value.len()));
+                model.seek_count = model
+                    .seek_count
+                    .saturating_add(crate::cost::BUFFER_CHURN_PUTS);
             }
             cost += model.clone();
             storage_accounting_cost += model;
@@ -755,17 +773,11 @@ impl<'db, S: StorageContext<'db>> BulkAppendTree<S> {
     }
 
     /// Persist the chunk-MMR root under [`MMR_ROOT_KEY`] — prepaid like the
-    /// MMR nodes (zero-byte cost information), so the append that issues it
-    /// keeps the fixed model's storage figure.
+    /// MMR nodes (`KeyValueStorageCost::prepaid()`: no bytes, no seek), so
+    /// the append that issues it keeps the fixed model's figure.
     fn persist_mmr_root(&self, root: &[u8; 32]) -> Result<(), BulkAppendError> {
-        let cost_info = Some(
-            grovedb_costs::storage_cost::key_value_cost::KeyValueStorageCost {
-                key_storage_cost: Default::default(),
-                value_storage_cost: Default::default(),
-                new_node: false,
-                needs_value_verification: false,
-            },
-        );
+        let cost_info =
+            Some(grovedb_costs::storage_cost::key_value_cost::KeyValueStorageCost::prepaid());
         self.dense_tree
             .storage
             .put(MMR_ROOT_KEY, root, None, cost_info)

--- a/grovedb-bulk-append-tree/src/tree/storage_accounting_tests.rs
+++ b/grovedb-bulk-append-tree/src/tree/storage_accounting_tests.rs
@@ -171,10 +171,18 @@ fn v1_buffer_writes_are_churn_and_every_append_is_charged_the_fixed_model() {
             cost.hash_node_calls, 0,
             "append {i}: hashes go through hash_count"
         );
-        // The model, compacting appends included.
+        // The model's reads plus the compaction's commit-time puts amortized
+        // over the epoch; the compacting append, whose own puts are all
+        // prepaid, is charged the slot and record puts it does not issue.
+        let churn_seeks = if i % 4 == 3 {
+            crate::BUFFER_CHURN_PUTS
+        } else {
+            0
+        };
         assert_eq!(
-            cost.seek_count, model.record_reads,
-            "append {i}: model reads"
+            cost.seek_count,
+            model.record_reads + crate::amortized_compaction_seeks(2) + churn_seeks,
+            "append {i}: model reads + amortized compaction seeks (+ churn seeks)"
         );
         assert_eq!(
             cost.storage_loaded_bytes,
@@ -256,19 +264,16 @@ fn v1_never_reads_to_size_a_buffer_write() {
 }
 
 /// v1: the compaction blob and the MMR internal nodes are prepaid — every
-/// append charged its share over the epoch — so their puts carry zero-byte
-/// cost information: nothing added, nothing replaced, no key.
+/// append charged its share over the epoch — so their puts carry
+/// `KeyValueStorageCost::prepaid()`: nothing added, nothing replaced, no
+/// key, and no seek at commit.
 #[test]
 fn v1_commit_mmr_writes_are_prepaid() {
     let run = run(&GROVE_V4);
     let nodes = mmr_puts(&run.ctx);
     assert_eq!(nodes.len(), 4, "{nodes:?}");
-    let prepaid = KeyValueStorageCost {
-        key_storage_cost: Default::default(),
-        value_storage_cost: StorageCost::default(),
-        new_node: false,
-        needs_value_verification: false,
-    };
+    let prepaid = KeyValueStorageCost::prepaid();
+    assert!(prepaid.is_prepaid());
     assert!(
         nodes.iter().all(|n| *n == Some(prepaid.clone())),
         "every MMR put — three chunk leaves and one merge — is prepaid: {nodes:?}"
@@ -392,12 +397,8 @@ fn unknown_storage_accounting_version_is_rejected() {
 /// then on every reopen reads the key instead of the peaks' blobs.
 #[test]
 fn legacy_mmr_root_is_backfilled_once_on_the_first_v4_append() {
-    let prepaid = KeyValueStorageCost {
-        key_storage_cost: Default::default(),
-        value_storage_cost: StorageCost::default(),
-        new_node: false,
-        needs_value_verification: false,
-    };
+    let prepaid = KeyValueStorageCost::prepaid();
+    assert!(prepaid.is_prepaid());
     // Epoch 1 under the shipped accounting: chunk committed, no root key.
     let mut tree = BulkAppendTree::new(2, MemStorageContext::new()).expect("new");
     for v in &VALUES[..4] {
@@ -670,4 +671,70 @@ fn entry_framing_is_charged_unless_a_fixed_entry_size_is_declared() {
         added >= persisted,
         "mixed-size epoch: added {added} < persisted {persisted}"
     );
+}
+
+/// The per-chunk put bound holds at every chunk index the 32-bit MMR keys
+/// admit, and the amortized seek share keeps every prefix of the tree's
+/// life prepaid at every height.
+#[test]
+fn amortized_compaction_seeks_prepay_every_prefix_at_every_height() {
+    // The puts chunk `i` (0-based) issues at commit: the blob, one MMR
+    // internal node per trailing one bit of `i`, and the persisted root.
+    fn actual(i: u64) -> u32 {
+        1 + i.trailing_ones() + 1
+    }
+    for k in 0..31u32 {
+        let p = 1u64 << k;
+        for i in [p - 1, p, p + 1, 2 * p - 2, 2 * p - 1] {
+            assert!(
+                actual(i) <= crate::MAX_COMPACTION_PUTS_PER_CHUNK,
+                "chunk {i}"
+            );
+        }
+    }
+    for chunk_power in 1..=4u8 {
+        let epoch = 1u64 << chunk_power;
+        let per_chunk_charge = epoch * crate::amortized_compaction_seeks(chunk_power) as u64;
+        let (mut charged, mut performed) = (0u64, 0u64);
+        for i in 0..(1u64 << 16) {
+            charged += per_chunk_charge;
+            performed += actual(i) as u64;
+            assert!(charged >= performed, "chunk_power {chunk_power}, chunk {i}");
+        }
+    }
+    assert_eq!(crate::amortized_compaction_seeks(1), 17);
+    assert_eq!(crate::amortized_compaction_seeks(2), 9);
+    assert_eq!(crate::amortized_compaction_seeks(4), 3);
+    assert_eq!(crate::amortized_compaction_seeks(5), 2);
+    assert_eq!(crate::amortized_compaction_seeks(6), 1);
+    assert_eq!(crate::amortized_compaction_seeks(11), 1);
+    assert_eq!(crate::amortized_compaction_seeks(16), 1);
+    assert_eq!(
+        crate::max_amortized_compaction_seeks(),
+        crate::amortized_compaction_seeks(1)
+    );
+}
+
+/// Every put a compaction issues — the blob, the MMR nodes, the persisted
+/// root, and a legacy tree's backfilled root — is prepaid, so the commit
+/// path charges it no seek; the slot and record puts of a buffered append
+/// are not.
+#[test]
+fn compaction_puts_are_prepaid_and_buffer_puts_are_not() {
+    let run = run(&GROVE_V4);
+    let puts = run.ctx.puts.borrow();
+    let (prepaid, billed): (Vec<_>, Vec<_>) = puts
+        .iter()
+        .partition(|(_, c)| c.as_ref().is_some_and(|c| c.is_prepaid()));
+    assert!(
+        prepaid
+            .iter()
+            .all(|(k, _)| k.len() == 4 || k.as_slice() == crate::MMR_ROOT_KEY),
+        "prepaid puts are the MMR nodes and the persisted root: {prepaid:?}"
+    );
+    assert!(
+        billed.iter().all(|(k, _)| k.len() == 2 || k.len() == 3),
+        "billed puts are the slots and records: {billed:?}"
+    );
+    assert!(!prepaid.is_empty() && !billed.is_empty());
 }

--- a/grovedb-bulk-append-tree/src/tree/storage_accounting_tests.rs
+++ b/grovedb-bulk-append-tree/src/tree/storage_accounting_tests.rs
@@ -200,6 +200,7 @@ fn v1_buffer_writes_are_churn_and_every_append_is_charged_the_fixed_model() {
         },
         new_node: false,
         needs_value_verification: true,
+        prepaid: false,
     };
     let slots = slot_puts(&run.ctx);
     assert_eq!(slots.len(), 9, "three slots per epoch, three epochs");

--- a/grovedb-commitment-tree/src/commitment_tree/cost/mod.rs
+++ b/grovedb-commitment-tree/src/commitment_tree/cost/mod.rs
@@ -94,6 +94,7 @@ pub(crate) fn frontier_save_cost_info(
             },
             new_node: false,
             needs_value_verification: false,
+            prepaid: false,
         }));
     }
     Ok(actual)

--- a/grovedb-merkle-mountain-range/src/storage_adapter.rs
+++ b/grovedb-merkle-mountain-range/src/storage_adapter.rs
@@ -61,10 +61,10 @@ pub enum LeafValueStorageCost {
     PartlyPrepaid(fn(&[u8]) -> u32),
     /// Every node written — leaf and internal — is already paid for by the
     /// owner (the bulk-append tree charges each append its share of the
-    /// chunk blob, its framing and the MMR nodes, amortized over the epoch),
-    /// so the put carries zero-byte cost information: nothing added, nothing
-    /// replaced, no key charged. The owner bills the amortized figures
-    /// itself.
+    /// chunk blob, its framing, the MMR nodes and the commit-time puts,
+    /// amortized over the epoch), so the put carries
+    /// `KeyValueStorageCost::prepaid()`: nothing added, nothing replaced, no
+    /// key charged, no seek. The owner bills the amortized figures itself.
     Prepaid,
 }
 
@@ -108,12 +108,7 @@ impl<'a, C> MmrStore<'a, C> {
         serialized_len: u32,
     ) -> Option<KeyValueStorageCost> {
         match (self.leaf_value_storage_cost, value) {
-            (LeafValueStorageCost::Prepaid, _) => Some(KeyValueStorageCost {
-                key_storage_cost: StorageCost::default(),
-                value_storage_cost: StorageCost::default(),
-                new_node: false,
-                needs_value_verification: false,
-            }),
+            (LeafValueStorageCost::Prepaid, _) => Some(KeyValueStorageCost::prepaid()),
             (LeafValueStorageCost::New, _) | (_, None) => None,
             (LeafValueStorageCost::PartlyPrepaid(prepaid), Some(value)) => {
                 // The paid size of a stored value is its length plus the

--- a/grovedb-merkle-mountain-range/src/storage_adapter.rs
+++ b/grovedb-merkle-mountain-range/src/storage_adapter.rs
@@ -127,6 +127,7 @@ impl<'a, C> MmrStore<'a, C> {
                     },
                     new_node: true,
                     needs_value_verification: true,
+                    prepaid: false,
                 })
             }
         }

--- a/grovedb-private-document-store/src/store.rs
+++ b/grovedb-private-document-store/src/store.rs
@@ -857,11 +857,19 @@ mod atomicity_tests {
             "model + amortized compaction + bulk root + composite, got {:?}",
             compacting_cost
         );
-        // The read-back and the MMR work are not billed: the reads are the
-        // model's plus the two fixed root reads of the state root (the
-        // persisted MMR root and the last insert's record), whether or not
-        // this particular state needs them.
-        assert_eq!(compacting_cost.seek_count, model.record_reads + 2);
+        // The read-back and the MMR work are not billed: the seeks are the
+        // model's reads, the compaction's commit-time puts amortized over
+        // the epoch, the slot and record puts this append does not issue
+        // (a buffered append's are charged at commit, not here), and the
+        // two fixed root reads of the state root (the persisted MMR root and
+        // the last insert's record), whether or not this state needs them.
+        assert_eq!(
+            compacting_cost.seek_count,
+            model.record_reads
+                + grovedb_bulk_append_tree::amortized_compaction_seeks(2)
+                + grovedb_bulk_append_tree::BUFFER_CHURN_PUTS
+                + 2
+        );
         assert_eq!(
             compacting_cost.storage_loaded_bytes,
             model.record_reads as u64 * model.record_len as u64 + 32 + model.record_len as u64

--- a/grovedb-version/src/version/bulk_append_tree_versions.rs
+++ b/grovedb-version/src/version/bulk_append_tree_versions.rs
@@ -54,11 +54,14 @@ pub struct BulkAppendTreeCostVersions {
     /// included, nothing read to size them; the buffer is a fixed-size
     /// per-tree scratch area rewritten every epoch) and its own bytes again
     /// as its part of the blob rewrite; plus the buffer's fixed
-    /// root-maintenance model (`dense_tree_versions.root_maintenance`) and
-    /// one amortized compaction blake3. The compacting append writes the
-    /// blob and the MMR nodes prepaid (zero-byte cost information) and is
-    /// charged the slot / record churn it does not write, so its figure is
-    /// the same; it also persists the MMR root (key `r`, 32 bytes, prepaid)
+    /// root-maintenance model (`dense_tree_versions.root_maintenance`), the
+    /// amortized compaction blake3 and the compaction's commit-time puts
+    /// amortized as seeks (`amortized_compaction_seeks`). The compacting
+    /// append writes the blob and the MMR nodes prepaid
+    /// (`KeyValueStorageCost::prepaid()`: no bytes, no seek at commit) and
+    /// is charged the slot / record churn — bytes and seeks — it does not
+    /// write, so its figure is the same, seek count included; it also
+    /// persists the MMR root (key `r`, 32 bytes, prepaid)
     /// so a reopened tree reads it instead of bagging the peaks' blobs, and
     /// the state root's two root reads are charged as the model. A tree
     /// whose last compaction predates version 1 has no such key: its first

--- a/grovedb-version/src/version/v4.rs
+++ b/grovedb-version/src/version/v4.rs
@@ -111,12 +111,13 @@
 //!   — its buffer slot and path record (epoch 1 included, nothing read to
 //!   size them) and its own bytes again as its part of the blob rewrite —
 //!   plus the buffer's fixed root-maintenance model and the compaction's
-//!   hashes amortized as a per-chunk bound over the epoch (one blake3 per
-//!   append at `chunk_power` ≥ 7). The
+//!   hashes and commit-time puts amortized as per-chunk bounds over the
+//!   epoch (one blake3 and one seek per append at `chunk_power` ≥ 7). The
 //!   compacting append writes the blob, the MMR nodes and the persisted MMR
-//!   root (new key `r`) prepaid and is charged the same as any other
-//!   append; a reopened tree reads the persisted root instead of bagging
-//!   the peaks' blobs. V1..V3 keep issuing every data put with no cost
+//!   root (new key `r`) prepaid — `KeyValueStorageCost::prepaid()`, which
+//!   the commit path bills no bytes and no seek — and is charged the same
+//!   as any other append, seek count included; a reopened tree reads the
+//!   persisted root instead of bagging the peaks' blobs. V1..V3 keep issuing every data put with no cost
 //!   information, which bills key + value as new storage every time — ≈ 2×
 //!   the bytes that persist, with the whole ≈ 630 KB blob landing on one
 //!   append per epoch at `chunk_power` 11. Stored chunks, roots and proofs

--- a/grovedb/src/batch/estimated_costs/average_case_costs.rs
+++ b/grovedb/src/batch/estimated_costs/average_case_costs.rs
@@ -288,23 +288,21 @@ impl GroveOp {
                 // The compaction share shrinks with the epoch, so an
                 // undeclared layer takes the largest share (epoch 2), not the
                 // ceiling epoch's.
-                let (amortized_compaction_added, amortized_compaction_hashes) =
+                let (amortized_compaction_added, amortized_compaction_hashes, amortized_seeks) =
                     match append_tree_chunk_power {
                         Some(chunk_power) => (
                             grovedb_bulk_append_tree::amortized_compaction_added_bytes(
                                 1u64 << chunk_power.min(16) as u32,
                             ),
                             grovedb_bulk_append_tree::amortized_compaction_hashes(chunk_power),
+                            grovedb_bulk_append_tree::amortized_compaction_seeks(chunk_power),
                         ),
                         None => (
                             super::max_amortized_compaction_added_bytes(),
                             grovedb_bulk_append_tree::max_amortized_compaction_hashes(),
+                            grovedb_bulk_append_tree::max_amortized_compaction_seeks(),
                         ),
                     };
-                // The puts a compacting append issues at commit instead of
-                // its slot and record: the chunk blob and up to the MMR
-                // merge bound of internal nodes — bounded, once per epoch.
-                const MAX_COMPACTION_PUTS: u32 = 1 + 65;
                 // The preprocessing read of the stored element loads its
                 // caller-supplied flags too; bound them with the parent
                 // layer's declared flags size — the same metadata the
@@ -326,10 +324,11 @@ impl GroveOp {
                 item_cost.add_cost(OperationCost {
                     // The stored element read by preprocessing + 1 buffer
                     // entry write + 1 path record write + the buffer model's
-                    // record reads + the compaction's puts as a bound.
+                    // record reads + the compaction's commit-time puts
+                    // amortized over the epoch.
                     seek_count: 3u32
                         .saturating_add(buffer.cost.seek_count)
-                        .saturating_add(MAX_COMPACTION_PUTS),
+                        .saturating_add(amortized_seeks),
                     storage_cost: StorageCost {
                         // Chunk-blob share + the variable format's per-entry
                         // prefix (a generic bulk tree declares no entry

--- a/grovedb/src/batch/estimated_costs/mod.rs
+++ b/grovedb/src/batch/estimated_costs/mod.rs
@@ -203,16 +203,14 @@ pub(in crate::batch) fn commitment_tree_insert_op_cost(
         + entry_size
         + (frontier_len as u64 + PER_PUT_OVERHEAD as u64);
 
-    // The puts a compacting append issues at commit instead of its slot and
-    // record: the chunk blob and up to the MMR merge bound of internal nodes
-    // — the one position-dependent residual (bounded, once per epoch).
-    const MAX_COMPACTION_PUTS: u32 = 1 + 65;
-
     OperationCost {
         // 2 reads (CommitmentTree element, frontier) + the buffer model's
-        // record reads, and 3 writes (note entry, path record, frontier);
-        // plus the compaction's puts as a bound.
-        seek_count: 5 + buffer.cost.seek_count + MAX_COMPACTION_PUTS,
+        // record reads, 3 writes (note entry, path record, frontier), and
+        // the compaction's commit-time puts amortized over the epoch (its
+        // puts are prepaid, so this is the whole of their charge).
+        seek_count: 5
+            + buffer.cost.seek_count
+            + grovedb_bulk_append_tree::amortized_compaction_seeks(chunk_power),
         storage_cost: StorageCost {
             added_bytes: u32::try_from(added_bytes_u64).unwrap_or(u32::MAX),
             // The parent-Merk node replacement is charged by the
@@ -278,24 +276,23 @@ pub(in crate::batch) fn private_document_store_insert_op_cost(
     /// Bulk state root + composite pds_state root + the committed-config
     /// hash paid when the store is opened.
     const ROOT_AND_CONFIG_HASHES: u32 = 3;
-    /// The puts a compacting append issues at commit instead of its slot and
-    /// record: the chunk blob and up to the MMR merge bound of internal
-    /// nodes — the one position-dependent residual (bounded, once per
-    /// epoch).
-    const MAX_COMPACTION_PUTS: u32 = 1 + 65;
     // A NonCounted-wrapped store serializes one byte wider, and the apply
     // path preserves that wrapper. Neither the op nor the declared layer
     // records whether this store is wrapped, so charge the byte
     // unconditionally.
     const NON_COUNTED_WRAPPER_BYTE: u32 = 1;
     OperationCost {
-        // Reads: the stored element, the last insert's record for the state
-        // root, the buffer model's record reads; writes: the buffer entry
-        // and its path record; plus the compaction's puts as a bound.
-        seek_count: 2u32
+        // Reads: the stored element, the state root's two fixed reads (the
+        // persisted MMR root and the last insert's record), the buffer
+        // model's record reads; writes: the buffer entry and its path
+        // record; plus the compaction's commit-time puts amortized over the
+        // epoch.
+        seek_count: 3u32
             .saturating_add(buffer.cost.seek_count)
             .saturating_add(2)
-            .saturating_add(MAX_COMPACTION_PUTS),
+            .saturating_add(grovedb_bulk_append_tree::amortized_compaction_seeks(
+                chunk_power,
+            )),
         storage_cost: StorageCost {
             // The entry's chunk-blob share plus its share of the blob
             // framing and MMR nodes (GROVE_V4 accounting, issue #822), and
@@ -313,9 +310,11 @@ pub(in crate::batch) fn private_document_store_insert_op_cost(
             removed_bytes: StorageRemovedBytes::NoStorageRemoval,
         },
         // The stored element (fixed fields + Merk framing, with the flags
-        // bound), the buffer model's records and the root record.
+        // bound), the buffer model's records, the persisted MMR root and
+        // the root record.
         storage_loaded_bytes: (CT_ELEMENT_LOAD_BASE + element_flags_load_bound) as u64
             + buffer.cost.storage_loaded_bytes
+            + 32
             + buffer.record_len as u64,
         // The buffer model, the amortized compaction, and the roots — the
         // same at every position.
@@ -365,7 +364,9 @@ pub(in crate::batch) fn dense_tree_insert_op_cost(value_size: u32, height: u8) -
 /// The largest per-append share of the compaction overhead the type
 /// permits — the smallest epoch (`chunk_power` 1) — for the worst-case
 /// estimators, which have no declaration channel. The share shrinks as the
-/// epoch grows, so the ceiling epoch is NOT the bound here.
+/// epoch grows, so the ceiling epoch is NOT the bound here. (The hash and
+/// seek shares have the same property; see
+/// `grovedb_bulk_append_tree::max_amortized_compaction_{hashes,seeks}`.)
 #[cfg(feature = "minimal")]
 pub(in crate::batch) fn max_amortized_compaction_added_bytes() -> u32 {
     grovedb_bulk_append_tree::amortized_compaction_added_bytes(2)

--- a/grovedb/src/batch/estimated_costs/worst_case_costs.rs
+++ b/grovedb/src/batch/estimated_costs/worst_case_costs.rs
@@ -259,15 +259,15 @@ impl GroveOp {
                 // The compaction share shrinks with the epoch: the smallest
                 // epoch is the bound.
                 let amortized_compaction_added = super::max_amortized_compaction_added_bytes();
-                const MAX_COMPACTION_PUTS: u32 = 1 + 65;
                 const PER_PUT_KEY_AND_LENGTHS: u32 = 50;
                 let paid_value = value_size.saturating_add(5); // + the value-length varint
                 item_cost.add_cost(OperationCost {
                     // The stored element read, the slot and record writes, the
-                    // model's record reads, the compaction's puts.
+                    // model's record reads, the compaction's commit-time puts
+                    // amortized at the smallest epoch.
                     seek_count: 3u32
                         .saturating_add(buffer.cost.seek_count)
-                        .saturating_add(MAX_COMPACTION_PUTS),
+                        .saturating_add(grovedb_bulk_append_tree::max_amortized_compaction_seeks()),
                     storage_cost: StorageCost {
                         // Value + the variable format's per-entry prefix +
                         // the compaction share.

--- a/grovedb/src/tests/append_storage_accounting_tests.rs
+++ b/grovedb/src/tests/append_storage_accounting_tests.rs
@@ -85,41 +85,14 @@ fn paid(len: u32) -> u32 {
 fn frontier_len(position: u64) -> u32 {
     42 + 32 * position.count_ones()
 }
-/// Seek-count residual of the one thing the fixed model cannot flatten: a
-/// compacting append writes the chunk blob and the MMR nodes its push
-/// creates at commit (`1 + trailing_ones(leaf_count_before)`), instead of
-/// the slot and record a buffered append writes (2) — once per epoch,
-/// bounded by the merge count. `leaf_count_before` is the chunk count before
-/// the push.
-fn compaction_seek_residual(leaf_count_before: u64) -> i64 {
-    // + the 32-byte MMR root it persists.
-    1 + leaf_count_before.trailing_ones() as i64 + 1 - 2
-}
-
-/// Everything but `seek_count` must be identical; `seek_count` may differ by
-/// exactly `seek_residual`.
-fn assert_fixed(what: &str, base: &OperationCost, cost: &OperationCost, seek_residual: i64) {
+/// Every figure — storage, loaded bytes, seeks, hashes, Sinsemilla — must be
+/// identical: the fixed model, whatever the position (the compacting
+/// append's commit-time puts are prepaid and their seeks amortized into
+/// every append, so not even the seek count moves).
+fn assert_fixed(what: &str, base: &OperationCost, cost: &OperationCost) {
     assert_eq!(
-        (
-            cost.storage_cost.clone(),
-            cost.storage_loaded_bytes,
-            cost.hash_node_calls,
-            cost.sinsemilla_hash_calls
-        ),
-        (
-            base.storage_cost.clone(),
-            base.storage_loaded_bytes,
-            base.hash_node_calls,
-            base.sinsemilla_hash_calls
-        ),
-        "{what}: storage, loaded bytes, hashes and Sinsemilla must be the fixed model;\nbase \
-         {base:?}\ncost {cost:?}"
-    );
-    assert_eq!(
-        cost.seek_count as i64,
-        base.seek_count as i64 + seek_residual,
-        "{what}: seeks must be the fixed model plus the compaction residual {seek_residual};\nbase \
-         {base:?}\ncost {cost:?}"
+        cost, base,
+        "{what}: every figure must be the fixed model;\nbase {base:?}\ncost {cost:?}"
     );
 }
 
@@ -276,8 +249,8 @@ fn accounting_gates_are_locked_before_v4() {
 /// long-term footprint as added storage, the buffer slot / path record /
 /// blob-rewrite part / frontier as replaced, the buffer's fixed model and
 /// the frontier's fixed model in hashes and bytes — at every position,
-/// including the compactions at 15, 31 and 47, whose only trace is the
-/// commit-time seek residual of the blob and MMR node puts.
+/// including the compactions at 15, 31 and 47 (their blob and MMR node puts
+/// are prepaid, their seeks amortized into every append).
 #[test]
 fn commitment_tree_append_cost_is_fixed_across_positions() {
     const CHUNK_POWER: u8 = 4;
@@ -285,12 +258,7 @@ fn commitment_tree_append_cost_is_fixed_across_positions() {
     let base = ct_insert(&db, 0, &GROVE_V4);
     for position in 1..48u64 {
         let cost = ct_insert(&db, position as u32, &GROVE_V4);
-        let residual = if position % 16 == 15 {
-            compaction_seek_residual(position / 16)
-        } else {
-            0
-        };
-        assert_fixed(&format!("position {position}"), &base, &cost, residual);
+        assert_fixed(&format!("position {position}"), &base, &cost);
     }
     // What the fixed charge is made of.
     let model = buffer_model(CHUNK_POWER);
@@ -321,8 +289,7 @@ fn commitment_tree_append_cost_is_fixed_across_positions() {
 
 /// The same at chunk_power 11 — the shielded pool's scale — around the
 /// epoch boundary: the last buffered append, the compacting one and the
-/// first of the next epoch cost the same, the compaction's seek residual
-/// aside.
+/// first of the next epoch cost the same.
 #[test]
 fn commitment_tree_epoch_boundary_at_chunk_power_11_is_charged_the_fixed_model() {
     const CHUNK_POWER: u8 = 11;
@@ -335,13 +302,8 @@ fn commitment_tree_epoch_boundary_at_chunk_power_11_is_charged_the_fixed_model()
     let before = ct_insert(&db, EPOCH - 2, &GROVE_V4);
     let compacting = ct_insert(&db, EPOCH - 1, &GROVE_V4);
     let after = ct_insert(&db, EPOCH, &GROVE_V4);
-    assert_fixed(
-        "compacting append",
-        &before,
-        &compacting,
-        compaction_seek_residual(0),
-    );
-    assert_fixed("first of the next epoch", &before, &after, 0);
+    assert_fixed("compacting append", &before, &compacting);
+    assert_fixed("first of the next epoch", &before, &after);
     // No 640 KB anywhere: the blob is prepaid a share at a time.
     assert!(
         compacting.storage_cost.replaced_bytes < 4_000
@@ -360,7 +322,7 @@ fn frontier_is_charged_the_fixed_model_at_every_position() {
     let base = ct_insert(&db, 0, &GROVE_V4);
     for position in 1..34u32 {
         let cost = ct_insert(&db, position, &GROVE_V4);
-        assert_fixed(&format!("position {position}"), &base, &cost, 0);
+        assert_fixed(&format!("position {position}"), &base, &cost);
     }
     assert_eq!(base.sinsemilla_hash_calls, 33);
     // The actual frontier at position 33 is 42 + 32·2 = 106 bytes; the
@@ -429,15 +391,11 @@ fn legacy_commitment_tree_is_charged_the_fixed_model_after_one_backfill_put() {
     }
     let first = ct_insert(&db, EPOCH, &GROVE_V4);
     let base = ct_insert(&db, EPOCH + 1, &GROVE_V4);
-    assert_fixed("first V4 append (backfill put)", &base, &first, 1);
+    // The backfill put is prepaid (no seek), so even this append is the model.
+    assert_fixed("first V4 append (backfill put)", &base, &first);
     for position in EPOCH + 2..2 * EPOCH + 2 {
         let cost = ct_insert(&db, position, &GROVE_V4);
-        let residual = if position % EPOCH == EPOCH - 1 {
-            compaction_seek_residual((position / EPOCH) as u64)
-        } else {
-            0
-        };
-        assert_fixed(&format!("position {position}"), &base, &cost, residual);
+        assert_fixed(&format!("position {position}"), &base, &cost);
     }
     // The same figure as a tree that ran under V4 from the start.
     let v4_db = ct_db(CHUNK_POWER, &GROVE_V4);
@@ -448,7 +406,6 @@ fn legacy_commitment_tree_is_charged_the_fixed_model_after_one_backfill_put() {
         "V4-only tree",
         &base,
         &ct_insert(&v4_db, EPOCH + 2, &GROVE_V4),
-        0,
     );
     assert_eq!(root_hash(&db, &GROVE_V4), {
         for position in EPOCH + 3..2 * EPOCH + 2 {
@@ -525,24 +482,17 @@ fn bulk_append_tree_cost_differs_only_by_the_value_bytes() {
         normalized.storage_cost.added_bytes = normalized.storage_cost.added_bytes + 8 - len;
         normalized.storage_cost.replaced_bytes =
             normalized.storage_cost.replaced_bytes + paid(8) + 8 - paid(len) - len;
-        let residual = if position % 4 == 3 {
-            compaction_seek_residual(position as u64 / 4)
-        } else {
-            0
-        };
         assert_fixed(
             &format!("position {position} (len {len})"),
             base,
             &normalized,
-            residual,
         );
     }
     assert_verifies(&db, &GROVE_V4);
 }
 
 /// `PrivateDocumentStore` (fixed entry size): the same fixed charge on every
-/// append; the compacting append differs by the seek residual and by the
-/// bulk state root's record read (the buffer is empty right after it).
+/// append, the compacting one included.
 #[test]
 fn private_document_store_append_cost_is_fixed() {
     const CHUNK_POWER: u8 = 2; // epoch 4
@@ -565,12 +515,7 @@ fn private_document_store_append_cost_is_fixed() {
         ctx.value.expect("v4 append");
         let cost = ctx.cost;
         let base = base.get_or_insert(cost.clone());
-        let residual = if position % 4 == 3 {
-            compaction_seek_residual(position / 4)
-        } else {
-            0
-        };
-        assert_fixed(&format!("position {position}"), base, &cost, residual);
+        assert_fixed(&format!("position {position}"), base, &cost);
     }
     assert_verifies(&db, &GROVE_V4);
 }

--- a/merk/src/tree/mod.rs
+++ b/merk/src/tree/mod.rs
@@ -215,6 +215,7 @@ impl TreeNode {
             value_storage_cost,
             new_node: self.old_value.is_none(),
             needs_value_verification: self.inner.kv.value_defined_cost.is_none(),
+            prepaid: false,
         };
 
         Ok((current_value_byte_cost, key_value_storage_cost))

--- a/merk/src/tree/ops.rs
+++ b/merk/src/tree/ops.rs
@@ -679,6 +679,7 @@ where
                         },
                         new_node: false,
                         needs_value_verification: false,
+                        prepaid: false,
                     };
 
                     let maybe_tree_walker = cost_return_on_error!(

--- a/storage/src/rocksdb_storage/storage.rs
+++ b/storage/src/rocksdb_storage/storage.rs
@@ -341,7 +341,9 @@ impl RocksDbStorage {
                     cost_info,
                 } => {
                     db_batch.put_cf(cf_aux(&self.db), &key, &value);
-                    cost.seek_count += 1;
+                    if !cost_info.as_ref().is_some_and(|c| c.is_prepaid()) {
+                        cost.seek_count += 1;
+                    }
                     cost_return_on_error_no_add!(
                         cost,
                         pending_costs
@@ -360,7 +362,9 @@ impl RocksDbStorage {
                     cost_info,
                 } => {
                     db_batch.put_cf(cf_roots(&self.db), &key, &value);
-                    cost.seek_count += 1;
+                    if !cost_info.as_ref().is_some_and(|c| c.is_prepaid()) {
+                        cost.seek_count += 1;
+                    }
                     // We only add costs for put root if they are set, otherwise it is free
                     if cost_info.is_some() {
                         cost_return_on_error_no_add!(
@@ -382,7 +386,9 @@ impl RocksDbStorage {
                     cost_info,
                 } => {
                     db_batch.put_cf(cf_meta(&self.db), &key, &value);
-                    cost.seek_count += 1;
+                    if !cost_info.as_ref().is_some_and(|c| c.is_prepaid()) {
+                        cost.seek_count += 1;
+                    }
                     cost_return_on_error_no_add!(
                         cost,
                         pending_costs

--- a/storage/src/rocksdb_storage/storage.rs
+++ b/storage/src/rocksdb_storage/storage.rs
@@ -316,7 +316,13 @@ impl RocksDbStorage {
                     cost_info,
                 } => {
                     db_batch.put(&key, &value);
-                    cost.seek_count += 1;
+                    // A fully prepaid put (`KeyValueStorageCost::prepaid`)
+                    // was billed by its owner in advance, the write
+                    // included: no seek here. Only the append-only family's
+                    // GROVE_V4 accounting issues such puts.
+                    if !cost_info.as_ref().is_some_and(|c| c.is_prepaid()) {
+                        cost.seek_count += 1;
+                    }
                     cost_return_on_error_no_add!(
                         cost,
                         pending_costs

--- a/storage/src/rocksdb_storage/storage_context/batch.rs
+++ b/storage/src/rocksdb_storage/storage_context/batch.rs
@@ -77,7 +77,9 @@ impl Batch for PrefixedRocksDbBatch<'_> {
     ) -> Result<(), grovedb_costs::error::Error> {
         let prefixed_key = make_prefixed_key(&self.prefix, key);
 
-        self.cost_acc.seek_count += 1;
+        if !cost_info.as_ref().is_some_and(|c| c.is_prepaid()) {
+            self.cost_acc.seek_count += 1;
+        }
         self.cost_acc.add_key_value_storage_costs(
             prefixed_key.len() as u32,
             value.len() as u32,
@@ -97,7 +99,9 @@ impl Batch for PrefixedRocksDbBatch<'_> {
     ) -> Result<(), grovedb_costs::error::Error> {
         let prefixed_key = make_prefixed_key(&self.prefix, key);
 
-        self.cost_acc.seek_count += 1;
+        if !cost_info.as_ref().is_some_and(|c| c.is_prepaid()) {
+            self.cost_acc.seek_count += 1;
+        }
         // put root only pays if cost info is set
         if cost_info.is_some() {
             self.cost_acc.add_key_value_storage_costs(

--- a/storage/src/rocksdb_storage/storage_context/batch.rs
+++ b/storage/src/rocksdb_storage/storage_context/batch.rs
@@ -53,7 +53,11 @@ impl Batch for PrefixedRocksDbBatch<'_> {
             key_value_storage_cost
         });
 
-        self.cost_acc.seek_count += 1;
+        // A fully prepaid put (`KeyValueStorageCost::prepaid`) was billed by
+        // its owner in advance, the write included: no seek.
+        if !updated_cost_info.as_ref().is_some_and(|c| c.is_prepaid()) {
+            self.cost_acc.seek_count += 1;
+        }
         self.cost_acc.add_key_value_storage_costs(
             prefixed_key.len() as u32,
             value.len() as u32,

--- a/storage/src/rocksdb_storage/tests.rs
+++ b/storage/src/rocksdb_storage/tests.rs
@@ -1055,6 +1055,125 @@ mod batch_transaction {
         );
     }
 
+    /// Every costed put variant honours the marker, on both commit paths:
+    /// the `StorageBatch` committed through `continue_write_batch` (data,
+    /// aux, roots, meta) and the direct `PrefixedRocksDbBatch` of an
+    /// immediate context (data, aux, roots). Prepaid puts seek nothing;
+    /// the ordinary puts beside them seek once each.
+    #[test]
+    fn test_prepaid_puts_of_every_variant_are_charged_no_seek() {
+        use grovedb_costs::storage_cost::key_value_cost::KeyValueStorageCost;
+
+        // StorageBatch path.
+        let storage = TempStorage::new();
+        let transaction = storage.start_transaction();
+        let batch = StorageBatch::new();
+        let context = storage
+            .get_transactional_storage_context(
+                [b"ayya"].as_ref().into(),
+                Some(&batch),
+                &transaction,
+            )
+            .unwrap();
+        let prepaid = || Some(KeyValueStorageCost::prepaid());
+        context
+            .put(b"d", &[1u8; 10], None, prepaid())
+            .unwrap()
+            .expect("put");
+        context
+            .put_aux(b"a", &[2u8; 10], prepaid())
+            .unwrap()
+            .expect("put_aux");
+        context
+            .put_root(b"r", &[3u8; 10], prepaid())
+            .unwrap()
+            .expect("put_root");
+        context
+            .put_meta(b"m", &[4u8; 10], prepaid())
+            .unwrap()
+            .expect("put_meta");
+        context
+            .put(b"d2", &[5u8; 10], None, None)
+            .unwrap()
+            .expect("put");
+        context
+            .put_aux(b"a2", &[6u8; 10], None)
+            .unwrap()
+            .expect("put_aux");
+        context
+            .put_root(b"r2", &[7u8; 10], None)
+            .unwrap()
+            .expect("put_root");
+        context
+            .put_meta(b"m2", &[8u8; 10], None)
+            .unwrap()
+            .expect("put_meta");
+        let commit = storage.commit_multi_context_batch(batch, Some(&transaction));
+        commit.value.expect("commit");
+        assert_eq!(
+            commit.cost.seek_count, 4,
+            "one seek per ordinary put, none for the prepaid ones: {:?}",
+            commit.cost
+        );
+        let ctx = storage
+            .get_transactional_storage_context([b"ayya"].as_ref().into(), None, &transaction)
+            .unwrap();
+        assert_eq!(ctx.get(b"d").unwrap().expect("get"), Some(vec![1u8; 10]));
+        assert_eq!(
+            ctx.get_aux(b"a").unwrap().expect("get_aux"),
+            Some(vec![2u8; 10])
+        );
+        assert_eq!(
+            ctx.get_root(b"r").unwrap().expect("get_root"),
+            Some(vec![3u8; 10])
+        );
+        assert_eq!(
+            ctx.get_meta(b"m").unwrap().expect("get_meta"),
+            Some(vec![4u8; 10])
+        );
+
+        // Direct batch path of an immediate context.
+        let storage = TempStorage::new();
+        let tx = storage.start_transaction();
+        let context = storage
+            .get_immediate_storage_context([b"ayya"].as_ref().into(), &tx)
+            .unwrap();
+        let mut db_batch = context.new_batch();
+        db_batch
+            .put(b"d", &[1u8; 10], None, prepaid())
+            .expect("put");
+        db_batch
+            .put_aux(b"a", &[2u8; 10], prepaid())
+            .expect("put_aux");
+        db_batch
+            .put_root(b"r", &[3u8; 10], prepaid())
+            .expect("put_root");
+        db_batch.put(b"d2", &[5u8; 10], None, None).expect("put");
+        db_batch.put_aux(b"a2", &[6u8; 10], None).expect("put_aux");
+        db_batch
+            .put_root(b"r2", &[7u8; 10], None)
+            .expect("put_root");
+        let commit = context.commit_batch(db_batch);
+        commit.value.expect("commit");
+        assert_eq!(
+            commit.cost.seek_count, 3,
+            "one seek per ordinary put, none for the prepaid ones: {:?}",
+            commit.cost
+        );
+        assert_eq!(
+            context.get(b"d").unwrap().expect("get"),
+            Some(vec![1u8; 10])
+        );
+        assert_eq!(
+            context.get_aux(b"a").unwrap().expect("get_aux"),
+            Some(vec![2u8; 10])
+        );
+        assert_eq!(
+            context.get_root(b"r").unwrap().expect("get_root"),
+            Some(vec![3u8; 10])
+        );
+    }
+
     #[test]
     fn test_transactional_put_completes_new_node_key_cost() {
         use grovedb_costs::storage_cost::{

--- a/storage/src/rocksdb_storage/tests.rs
+++ b/storage/src/rocksdb_storage/tests.rs
@@ -1019,10 +1019,24 @@ mod batch_transaction {
             .put(b"ordinary", &[2u8; 100], None, None)
             .unwrap()
             .expect("put ordinary");
+        // A zero-cost DEFAULT is not prepaid: it pays its seek like any put
+        // (Merk passes one for writes it charges no bytes for).
+        context
+            .put(
+                b"default",
+                &[3u8; 100],
+                None,
+                Some(KeyValueStorageCost::default()),
+            )
+            .unwrap()
+            .expect("put default");
         let commit = storage.commit_multi_context_batch(batch, Some(&transaction));
         commit.value.expect("commit");
         let cost = commit.cost;
-        assert_eq!(cost.seek_count, 1, "only the ordinary put seeks: {cost:?}");
+        assert_eq!(
+            cost.seek_count, 2,
+            "the ordinary and the default-cost puts seek, the prepaid one does not: {cost:?}"
+        );
         // The ordinary put's bytes (prefixed key + value, each with its
         // length varint) are the whole storage figure.
         assert_eq!(
@@ -1078,6 +1092,7 @@ mod batch_transaction {
                     },
                     new_node: true,
                     needs_value_verification: true,
+                    prepaid: false,
                 }),
             )
             .unwrap()
@@ -1098,6 +1113,7 @@ mod batch_transaction {
                     },
                     new_node: false,
                     needs_value_verification: true,
+                    prepaid: false,
                 }),
             )
             .unwrap()

--- a/storage/src/rocksdb_storage/tests.rs
+++ b/storage/src/rocksdb_storage/tests.rs
@@ -989,6 +989,58 @@ mod batch_transaction {
     /// context — the caller cannot know the prefix — exactly as the `Batch`
     /// implementations do. An update (`new_node: false`) is passed through
     /// unchanged. Both must then survive the commit-time verification.
+    /// A fully prepaid put (`KeyValueStorageCost::prepaid`) is billed
+    /// nothing at commit — no bytes, no key, no value verification and no
+    /// seek — while an ordinary put beside it is still charged its seek.
+    #[test]
+    fn test_prepaid_put_is_charged_no_seek_at_commit() {
+        use grovedb_costs::storage_cost::key_value_cost::KeyValueStorageCost;
+
+        let storage = TempStorage::new();
+        let transaction = storage.start_transaction();
+        let batch = StorageBatch::new();
+        let context = storage
+            .get_transactional_storage_context(
+                [b"ayya"].as_ref().into(),
+                Some(&batch),
+                &transaction,
+            )
+            .unwrap();
+        context
+            .put(
+                b"prepaid",
+                &[1u8; 100],
+                None,
+                Some(KeyValueStorageCost::prepaid()),
+            )
+            .unwrap()
+            .expect("put prepaid");
+        context
+            .put(b"ordinary", &[2u8; 100], None, None)
+            .unwrap()
+            .expect("put ordinary");
+        let commit = storage.commit_multi_context_batch(batch, Some(&transaction));
+        commit.value.expect("commit");
+        let cost = commit.cost;
+        assert_eq!(cost.seek_count, 1, "only the ordinary put seeks: {cost:?}");
+        // The ordinary put's bytes (prefixed key + value, each with its
+        // length varint) are the whole storage figure.
+        assert_eq!(
+            cost.storage_cost.added_bytes,
+            (32 + 8 + 1) + (100 + 1),
+            "{cost:?}"
+        );
+        assert_eq!(cost.storage_cost.replaced_bytes, 0);
+        let tx_ctx = storage
+            .get_transactional_storage_context([b"ayya"].as_ref().into(), None, &transaction)
+            .unwrap();
+        assert_eq!(
+            tx_ctx.get(b"prepaid").unwrap().expect("get"),
+            Some(vec![1u8; 100]),
+            "the prepaid put is written all the same"
+        );
+    }
+
     #[test]
     fn test_transactional_put_completes_new_node_key_cost() {
         use grovedb_costs::storage_cost::{

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -678,6 +678,7 @@ mod tests {
             value_storage_cost: StorageCost::default(),
             new_node: false,
             needs_value_verification: false,
+            prepaid: false,
         }
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #829 (now merged). After #829 the one figure a `CommitmentTreeInsert` / bulk-append / `PrivateDocumentStore` append still varied by position was the **commit-time seek count of the compacting append**: the storage batch charges one seek per put, and that append writes the chunk blob + `trailing_ones(chunks)` MMR nodes + the persisted root instead of its slot and record. This PR removes that residual, so the whole charge is now position-independent.

1. **Prepaid puts carry no seek.** `KeyValueStorageCost` gains an explicit `prepaid: bool` marker (set only by the new `KeyValueStorageCost::prepaid()` constructor, read by `is_prepaid()`) for a put whose owner billed everything about it in advance — bytes, key, and the write itself. A zero-cost `Default` is NOT prepaid and keeps paying its seek (Merk passes `Some(Default::default())` for writes it charges no bytes for). The RocksDB commit path (`continue_write_batch`: data, aux, roots and meta puts) and the direct `PrefixedRocksDbBatch` puts (data, aux, roots) charge a prepaid put **no seek**. Downstream: struct-literal constructions of `KeyValueStorageCost` need the new field (`prepaid: false`, or `..Default::default()`). Only the append-only family's GROVE_V4 accounting issues prepaid puts (the MMR store's `LeafValueStorageCost::Prepaid`, the persisted MMR root, its legacy backfill), so no shipped cost moves.

2. **The compaction's puts are amortized as a seek share.** `amortized_compaction_seeks(chunk_power) = ⌈MAX_COMPACTION_PUTS_PER_CHUNK / 2^chunk_power⌉` with `MAX_COMPACTION_PUTS_PER_CHUNK = 1 + 32 + 1` (blob, ≤ 32 MMR merges with 32-bit MMR keys, persisted root) — 1 seek per append from `chunk_power` 6 (so at the shielded pool's 11), 17 at `chunk_power` 1 — charged on every append under the fixed model, as a per-chunk bound so every prefix of the tree's life stays prepaid. The compacting append, whose own puts are all prepaid, is charged the slot + record seeks it does not issue (`BUFFER_CHURN_PUTS = 2`), exactly as it already carries their byte churn. Its seek count is therefore every other append's.

3. **Estimators** replace the 66-seek `MAX_COMPACTION_PUTS` reservation with the amortized share (`max_amortized_compaction_seeks()` — the `chunk_power` 1 figure — on the worst-case and undeclared-layer arms), so the seek estimate is tight; the PDS model now counts both fixed state-root reads (persisted MMR root + last record), an under-count the old slack had hidden.

### What this means for a `CommitmentTreeInsert` under GROVE_V4

Every figure — seeks, loaded bytes, added/replaced bytes, blake3, Sinsemilla — is identical at every position of the tree, the compacting append and a legacy tree's MMR-root backfill included. Nothing position-dependent remains.

### Tests

- costs: `prepaid()` is prepaid, `Default` / every other constructor is not, a sum with an unprepaid part is not.
- storage: a prepaid put beside an ordinary and a `Some(Default::default())` put at commit charges exactly two seeks (theirs) and is written all the same; every costed put variant (data / aux / roots / meta on the `StorageBatch` path, data / aux / roots on the direct batch path) honours the marker.
- bulk crate: seek share bound at every chunk index around each power of two up to 2^31 and exhaustive prefix sums at heights 1..4; the compaction's puts (MMR nodes, persisted root) are the prepaid ones and the slot/record puts are not; every append charged `model reads + share` (+ the churn seeks on the compacting one).
- grovedb: `assert_fixed` now requires full `OperationCost` equality (seeks included) across positions for CT (cp 4, cp 11 epoch boundary), bulk, PDS, a legacy (V3-seeded) CT's first V4 append, and the in-batch epoch boundary; estimate ≥ actual sweeps unchanged and tighter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
