### PR TITLE
feat: snapshot-pinned read transactions

### DIFF
--- a/grovedb/src/lib.rs
+++ b/grovedb/src/lib.rs
@@ -1874,6 +1874,29 @@ impl GroveDb {
         self.db.start_transaction()
     }
 
+    /// Begin a transaction whose reads are **pinned to the committed
+    /// state as of this call**: every get and iterator routed through it
+    /// reads the same RocksDB snapshot, however many operations the
+    /// caller spreads over the transaction.
+    ///
+    /// This is the read-consistency primitive a multi-operation read
+    /// needs. A plain [`GroveDb::start_transaction`] transaction — and a
+    /// `None` transaction argument — reads the *latest* committed state
+    /// on every operation, so a concurrent commit landing between two
+    /// operations can make one logical read observe two different
+    /// committed states. Under this transaction it cannot: the branched
+    /// axis read's per-branch probes and walks, for example, all see one
+    /// state.
+    ///
+    /// Read-only by intent. `set_snapshot` also arms commit-time
+    /// conflict detection against the snapshot, so committing writes
+    /// made through this transaction can fail with `Busy` where a plain
+    /// transaction's commit would not; take a plain transaction to
+    /// write.
+    pub fn start_snapshot_read_transaction(&self) -> Transaction<'_> {
+        self.db.start_snapshot_read_transaction()
+    }
+
     /// Consumes and commits a previously started transaction.
     ///
     /// On success the transaction's writes become visible to subsequent

--- a/grovedb/src/operations/proof/generate.rs
+++ b/grovedb/src/operations/proof/generate.rs
@@ -563,6 +563,15 @@ impl GroveDb {
         // ONE snapshot for the entire recursive generation — see the V1
         // entry for the rationale.
         let snapshot_transaction = self.start_snapshot_read_transaction();
+        // Test-only seam: lets a regression test land a commit
+        // deterministically inside the generation window — after the
+        // snapshot, before any layer is generated.
+        #[cfg(test)]
+        super::prove_test_hooks::AFTER_PROOF_SNAPSHOT.with(|hook| {
+            if let Some(hook) = hook.borrow_mut().as_mut() {
+                hook();
+            }
+        });
 
         if path_query.query.offset.is_some() && path_query.query.offset != Some(0) {
             return Err(Error::InvalidQuery(
@@ -1569,6 +1578,15 @@ impl GroveDb {
         // state, so a concurrent commit cannot yield a proof whose
         // layers do not hash-chain.
         let snapshot_transaction = self.start_snapshot_read_transaction();
+        // Test-only seam: lets a regression test land a commit
+        // deterministically inside the generation window — after the
+        // snapshot, before any layer is generated.
+        #[cfg(test)]
+        super::prove_test_hooks::AFTER_PROOF_SNAPSHOT.with(|hook| {
+            if let Some(hook) = hook.borrow_mut().as_mut() {
+                hook();
+            }
+        });
 
         if path_query.query.offset.is_some() && path_query.query.offset != Some(0) {
             // A non-zero offset is honored *only* if the surrounding

--- a/grovedb/src/operations/proof/generate.rs
+++ b/grovedb/src/operations/proof/generate.rs
@@ -488,17 +488,17 @@ impl GroveDb {
 
     fn check_count_offset_target_tree_type(
         &self,
+        transaction: &Transaction,
         path_query: &PathQuery,
         grove_version: &GroveVersion,
     ) -> CostResult<(), Error> {
         use grovedb_merk::TreeType as MerkTreeType;
         let mut cost = OperationCost::default();
-        let tx = self.start_transaction();
         let path_slices: Vec<&[u8]> = path_query.path.iter().map(|p| p.as_slice()).collect();
         let open_result = self
             .open_transactional_merk_at_path(
                 path_slices.as_slice().into(),
-                &tx,
+                transaction,
                 None,
                 grove_version,
             )
@@ -560,6 +560,9 @@ impl GroveDb {
         let mut cost = OperationCost::default();
 
         let prove_options = prove_options.unwrap_or_default();
+        // ONE snapshot for the entire recursive generation — see the V1
+        // entry for the rationale.
+        let snapshot_transaction = self.start_snapshot_read_transaction();
 
         if path_query.query.offset.is_some() && path_query.query.offset != Some(0) {
             return Err(Error::InvalidQuery(
@@ -625,6 +628,7 @@ impl GroveDb {
         let root_layer = cost_return_on_error!(
             &mut cost,
             self.prove_subqueries(
+                &snapshot_transaction,
                 vec![],
                 path_query,
                 &mut limit,
@@ -657,6 +661,7 @@ impl GroveDb {
     /// ╚══════════════════════════════════════════════════════════════════╝
     pub(crate) fn prove_subqueries(
         &self,
+        transaction: &Transaction,
         path: Vec<&[u8]>,
         path_query: &PathQuery,
         overall_limit: &mut Option<u16>,
@@ -672,8 +677,6 @@ impl GroveDb {
             ))
             .wrap_with_cost(cost);
         }
-
-        let tx = self.start_transaction();
 
         let query = cost_return_on_error_no_add!(
             cost,
@@ -693,7 +696,12 @@ impl GroveDb {
 
         let subtree = cost_return_on_error!(
             &mut cost,
-            self.open_transactional_merk_at_path(path.as_slice().into(), &tx, None, grove_version)
+            self.open_transactional_merk_at_path(
+                path.as_slice().into(),
+                transaction,
+                None,
+                grove_version
+            )
         );
 
         // V0 proofs are LOCKED to the wire format shipped with grove
@@ -1044,6 +1052,7 @@ impl GroveDb {
                                 let layer_proof = cost_return_on_error!(
                                     &mut cost,
                                     self.prove_subqueries(
+                                        transaction,
                                         lower_path,
                                         path_query,
                                         overall_limit,
@@ -1555,6 +1564,11 @@ impl GroveDb {
     ) -> CostResult<GroveDBProof, Error> {
         let mut cost = OperationCost::default();
         let prove_options = prove_options.unwrap_or_default();
+        // ONE snapshot for the entire recursive generation: every layer
+        // (and the count-offset target check) reads the same committed
+        // state, so a concurrent commit cannot yield a proof whose
+        // layers do not hash-chain.
+        let snapshot_transaction = self.start_snapshot_read_transaction();
 
         if path_query.query.offset.is_some() && path_query.query.offset != Some(0) {
             // A non-zero offset is honored *only* if the surrounding
@@ -1581,7 +1595,11 @@ impl GroveDb {
             }
             cost_return_on_error!(
                 &mut cost,
-                self.check_count_offset_target_tree_type(path_query, grove_version)
+                self.check_count_offset_target_tree_type(
+                    &snapshot_transaction,
+                    path_query,
+                    grove_version
+                )
             );
         }
         if path_query.query.limit == Some(0) {
@@ -1596,6 +1614,7 @@ impl GroveDb {
         let root_layer = cost_return_on_error!(
             &mut cost,
             self.prove_subqueries_v1(
+                &snapshot_transaction,
                 vec![],
                 path_query,
                 &mut limit,
@@ -1740,6 +1759,7 @@ impl GroveDb {
     /// MmrTree/BulkAppendTree elements with type-specific proofs.
     pub(crate) fn prove_subqueries_v1(
         &self,
+        transaction: &Transaction,
         path: Vec<&[u8]>,
         path_query: &PathQuery,
         overall_limit: &mut Option<u16>,
@@ -1755,8 +1775,6 @@ impl GroveDb {
             ))
             .wrap_with_cost(cost);
         }
-
-        let tx = self.start_transaction();
 
         let query = cost_return_on_error_no_add!(
             cost,
@@ -1776,7 +1794,12 @@ impl GroveDb {
 
         let subtree = cost_return_on_error!(
             &mut cost,
-            self.open_transactional_merk_at_path(path.as_slice().into(), &tx, None, grove_version)
+            self.open_transactional_merk_at_path(
+                path.as_slice().into(),
+                transaction,
+                None,
+                grove_version
+            )
         );
 
         let limit = if path.len() < path_query.path.len() {
@@ -2299,7 +2322,7 @@ impl GroveDb {
                                     self.build_sum_budget_window_payload(
                                         &lower_path,
                                         path_query,
-                                        &tx,
+                                        transaction,
                                         grove_version,
                                     )
                                 );
@@ -2334,7 +2357,7 @@ impl GroveDb {
                                         path_query,
                                         mmr_size,
                                         overall_limit,
-                                        &tx,
+                                        transaction,
                                         grove_version,
                                     )
                                 );
@@ -2361,7 +2384,7 @@ impl GroveDb {
                                         total_count,
                                         chunk_power,
                                         overall_limit,
-                                        &tx,
+                                        transaction,
                                         grove_version,
                                     )
                                 );
@@ -2390,7 +2413,7 @@ impl GroveDb {
                                         dense_count,
                                         dense_height,
                                         overall_limit,
-                                        &tx,
+                                        transaction,
                                         grove_version,
                                     )
                                 );
@@ -2416,7 +2439,7 @@ impl GroveDb {
                                         total_count,
                                         chunk_power,
                                         overall_limit,
-                                        &tx,
+                                        transaction,
                                         grove_version,
                                     )
                                 );
@@ -2499,7 +2522,7 @@ impl GroveDb {
                                     self.build_axis_descent_payload(
                                         lower_subtree_path,
                                         axis_query,
-                                        &tx,
+                                        transaction,
                                         &payload_batch,
                                         grove_version,
                                     )
@@ -2575,7 +2598,7 @@ impl GroveDb {
 
                                 let mut layer_proof = cost_return_on_error!(
                                     &mut cost,
-                                    self.prove_subqueries_v1(
+                                    self.prove_subqueries_v1(transaction,
                                         lower_path.clone(),
                                         path_query,
                                         overall_limit,
@@ -2604,7 +2627,7 @@ impl GroveDb {
                                         cidx_subtree_path,
                                         grovedb_element::indexed::IndexAxis::Count,
                                         secondary_root_key,
-                                        &tx,
+                                        transaction,
                                         None,
                                         grove_version,
                                     )
@@ -2687,7 +2710,7 @@ impl GroveDb {
 
                                 let mut layer_proof = cost_return_on_error!(
                                     &mut cost,
-                                    self.prove_subqueries_v1(
+                                    self.prove_subqueries_v1(transaction,
                                         lower_path.clone(),
                                         path_query,
                                         overall_limit,
@@ -2716,7 +2739,7 @@ impl GroveDb {
                                         sidx_subtree_path,
                                         grovedb_element::indexed::IndexAxis::Sum,
                                         secondary_root_key,
-                                        &tx,
+                                        transaction,
                                         None,
                                         grove_version,
                                     )
@@ -2791,7 +2814,7 @@ impl GroveDb {
 
                                 let mut layer_proof = cost_return_on_error!(
                                     &mut cost,
-                                    self.prove_subqueries_v1(
+                                    self.prove_subqueries_v1(transaction,
                                         lower_path.clone(),
                                         path_query,
                                         overall_limit,
@@ -2832,7 +2855,7 @@ impl GroveDb {
                                             pcpsit_subtree_path,
                                             axis,
                                             sec_root_key.clone(),
-                                            &tx,
+                                            transaction,
                                             None,
                                             grove_version,
                                         )
@@ -2890,7 +2913,7 @@ impl GroveDb {
 
                                 let layer_proof = cost_return_on_error!(
                                     &mut cost,
-                                    self.prove_subqueries_v1(
+                                    self.prove_subqueries_v1(transaction,
                                         lower_path,
                                         path_query,
                                         overall_limit,
@@ -2943,7 +2966,7 @@ impl GroveDb {
                                         node,
                                         non_merk_elem,
                                         &path,
-                                        &tx,
+                                        transaction,
                                         grove_version,
                                     )
                                 );
@@ -2973,7 +2996,7 @@ impl GroveDb {
                                     &mut cost,
                                     self.open_transactional_merk_at_path(
                                         child_path.as_slice().into(),
-                                        &tx,
+                                        transaction,
                                         None,
                                         grove_version
                                     )
@@ -3038,7 +3061,7 @@ impl GroveDb {
                                     &mut cost,
                                     self.open_transactional_merk_at_path(
                                         indexed_path.as_slice().into(),
-                                        &tx,
+                                        transaction,
                                         None,
                                         grove_version
                                     )
@@ -3051,7 +3074,7 @@ impl GroveDb {
                                     self.indexed_secondary_attestation(
                                         indexed_elem,
                                         indexed_path.as_slice(),
-                                        &tx,
+                                        transaction,
                                         grove_version,
                                     )
                                 );
@@ -3097,7 +3120,7 @@ impl GroveDb {
 
                                 let layer_proof = cost_return_on_error!(
                                     &mut cost,
-                                    self.prove_subqueries_v1(
+                                    self.prove_subqueries_v1(transaction,
                                         lower_path,
                                         path_query,
                                         overall_limit,
@@ -3134,7 +3157,7 @@ impl GroveDb {
 
                                 let layer_proof = cost_return_on_error!(
                                     &mut cost,
-                                    self.prove_subqueries_v1(
+                                    self.prove_subqueries_v1(transaction,
                                         lower_path,
                                         path_query,
                                         overall_limit,
@@ -3166,7 +3189,7 @@ impl GroveDb {
 
                                 let layer_proof = cost_return_on_error!(
                                     &mut cost,
-                                    self.prove_subqueries_v1(
+                                    self.prove_subqueries_v1(transaction,
                                         lower_path,
                                         path_query,
                                         overall_limit,

--- a/grovedb/src/operations/proof/mod.rs
+++ b/grovedb/src/operations/proof/mod.rs
@@ -1223,3 +1223,17 @@ fn decode_dense_proof(bytes: &[u8]) -> String {
         Err(e) => format!("Error decoding DenseTree proof: {}", e),
     }
 }
+
+/// Test-only seam: fired by both `prove_query` entry points (V0 and V1)
+/// right after the generation snapshot is taken and before any layer is
+/// generated, so a test can land a commit deterministically inside the
+/// generation window and prove the whole recursive generation reads that
+/// snapshot.
+#[cfg(test)]
+pub(crate) mod prove_test_hooks {
+    use std::cell::RefCell;
+    thread_local! {
+        pub(crate) static AFTER_PROOF_SNAPSHOT: RefCell<Option<Box<dyn FnMut()>>> =
+            const { RefCell::new(None) };
+    }
+}

--- a/grovedb/src/tests/axis_descent_proof_tests.rs
+++ b/grovedb/src/tests/axis_descent_proof_tests.rs
@@ -423,6 +423,127 @@ mod tests {
         }
     }
 
+    /// Proof generation reads ONE snapshot across every recursive
+    /// layer. The test-only seam
+    /// (`operations::proof::prove_test_hooks::AFTER_PROOF_SNAPSHOT`)
+    /// fires after `prove_query` takes its generation snapshot; a scoped
+    /// writer thread lands a commit deterministically inside that window
+    /// (a new branch springs into existence and an existing page
+    /// changes), and the resulting envelope must still verify — against
+    /// the PRE-commit root, with the pre-commit content, absence
+    /// included. If generation regressed to opening an independent view
+    /// per layer, the proof would be built from post-commit state and
+    /// the root assertion fails. The branched shape exercised here is
+    /// the common primitive both of Drive's `IN`-pinned surfaces prove
+    /// through.
+    #[test]
+    fn proof_generation_is_pinned_to_one_snapshot_across_a_concurrent_commit() {
+        use std::time::Duration;
+
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+        build_branched_psits(
+            &db,
+            grove_version,
+            &[
+                (b"alice", &[(b"m1", 10), (b"m2", 30)]),
+                (b"carol", &[(b"m1", 7)]),
+            ],
+        );
+        let root_before = root_hash(&db, grove_version);
+        let alice_before = db
+            .indexed_sum_top_k_paginated(
+                [TEST_LEAF, b"alice".as_slice(), b"scores".as_slice()].as_ref(),
+                2,
+                0,
+                true,
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("alice pre-commit page")
+            .entries;
+
+        // Rendezvous: when the generation snapshot exists, wake the
+        // writer, wait for its commit to land, then let the layers
+        // generate.
+        let (enter_window_tx, enter_window_rx) = std::sync::mpsc::channel::<()>();
+        let (commit_done_tx, commit_done_rx) = std::sync::mpsc::channel::<()>();
+        crate::operations::proof::prove_test_hooks::AFTER_PROOF_SNAPSHOT.with(|hook| {
+            *hook.borrow_mut() = Some(Box::new(move || {
+                let _ = enter_window_tx.send(());
+                let _ = commit_done_rx.recv_timeout(Duration::from_secs(20));
+            }));
+        });
+
+        let pq = PathQuery::new_branched_axis(
+            vec![TEST_LEAF.to_vec()],
+            vec![b"alice".to_vec(), b"bob".to_vec(), b"carol".to_vec()],
+            vec![b"scores".to_vec()],
+            AxisQuery::top_k(IndexAxis::Sum, 2, 0, true),
+        );
+        let proof = std::thread::scope(|scope| {
+            let db = &db;
+            scope.spawn(move || {
+                if enter_window_rx
+                    .recv_timeout(Duration::from_secs(20))
+                    .is_ok()
+                {
+                    build_branched_psits(db, grove_version, &[(b"bob", &[(b"m1", 99)])]);
+                    db.insert_into_provable_sum_indexed_tree(
+                        [TEST_LEAF, b"alice".as_slice(), b"scores".as_slice()].as_ref(),
+                        b"m3",
+                        Element::new_sum_item(100),
+                        None,
+                        grove_version,
+                    )
+                    .unwrap()
+                    .expect("insert mid-window alice entry");
+                    let _ = commit_done_tx.send(());
+                }
+            });
+            prove(db, &pq, grove_version)
+        });
+        crate::operations::proof::prove_test_hooks::AFTER_PROOF_SNAPSHOT.with(|hook| {
+            *hook.borrow_mut() = None;
+        });
+        assert_ne!(
+            root_hash(&db, grove_version),
+            root_before,
+            "the mid-window commit landed"
+        );
+
+        match GroveDb::verify_path_query(&proof, &pq, grove_version)
+            .expect("the snapshot-pinned proof verifies despite the mid-window commit")
+        {
+            VerifiedPathQuery::BranchedAxisEntries {
+                root_hash,
+                branches,
+            } => {
+                assert_eq!(
+                    root_hash, root_before,
+                    "every layer was generated from the pre-commit snapshot"
+                );
+                assert_eq!(branches.len(), 3);
+                for (branch_key, entries) in &branches {
+                    match branch_key.as_slice() {
+                        b"bob" => assert!(
+                            entries.is_none(),
+                            "bob stays proven absent under the snapshot"
+                        ),
+                        b"alice" => assert_eq!(
+                            entries_as_sum(entries.as_ref().expect("alice present")),
+                            alice_before.as_slice(),
+                            "alice's page is her pre-commit top-k"
+                        ),
+                        _ => assert!(entries.is_some(), "carol stays present"),
+                    }
+                }
+            }
+            other => panic!("expected BranchedAxisEntries, got {other:?}"),
+        }
+    }
+
     // -----------------------------------------------------------------
     // Forgeries
     // -----------------------------------------------------------------

--- a/grovedb/src/tests/proof_depth_limit_tests.rs
+++ b/grovedb/src/tests/proof_depth_limit_tests.rs
@@ -194,6 +194,7 @@ mod tests {
         // Call with depth already past the limit
         let result = db
             .prove_subqueries(
+                &db.start_transaction(),
                 vec![b"deep".as_slice()],
                 &path_query,
                 &mut limit,
@@ -229,6 +230,7 @@ mod tests {
         // Call with depth already past the limit
         let result = db
             .prove_subqueries_v1(
+                &db.start_transaction(),
                 vec![b"deep".as_slice()],
                 &path_query,
                 &mut limit,

--- a/grovedb/src/tests/run_path_query_tests.rs
+++ b/grovedb/src/tests/run_path_query_tests.rs
@@ -484,6 +484,110 @@ mod tests {
         }
     }
 
+    /// A snapshot read transaction pins the ENTIRE branched read — every
+    /// per-branch absence probe and every axis walk — to the committed
+    /// state at the transaction's creation: commits landing afterwards
+    /// are invisible through it, while a plain transaction and a `None`
+    /// read see them. This is the primitive a caller uses to make a
+    /// multi-operation read observe exactly one committed state.
+    #[test]
+    fn snapshot_read_transaction_pins_a_branched_read_to_one_committed_state() {
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+        build_branched_psits(
+            &db,
+            grove_version,
+            &[
+                (b"alice", &[(b"m1", 10), (b"m2", 30)]),
+                (b"carol", &[(b"m1", 7)]),
+            ],
+        );
+        let alice_path = [TEST_LEAF, b"alice".as_slice(), b"scores".as_slice()];
+        let alice_before = db
+            .indexed_sum_top_k_paginated(alice_path.as_ref(), 2, 0, true, None, grove_version)
+            .unwrap()
+            .expect("alice pre-commit page")
+            .entries;
+
+        let snapshot_transaction = db.start_snapshot_read_transaction();
+        let plain_transaction = db.start_transaction();
+
+        // A "concurrent block commit" lands after both transactions
+        // began: bob's branch springs into existence and alice gains a
+        // row that changes her top-k.
+        build_branched_psits(&db, grove_version, &[(b"bob", &[(b"m1", 99)])]);
+        db.insert_into_provable_sum_indexed_tree(
+            alice_path.as_ref(),
+            b"m3",
+            Element::new_sum_item(100),
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert post-snapshot alice entry");
+        let alice_after = db
+            .indexed_sum_top_k_paginated(alice_path.as_ref(), 2, 0, true, None, grove_version)
+            .unwrap()
+            .expect("alice post-commit page")
+            .entries;
+        assert_ne!(alice_before, alice_after, "the commit changed alice's page");
+
+        let axis_query = AxisQuery::top_k(IndexAxis::Sum, 2, 0, true);
+        let path_query = PathQuery::new_branched_axis(
+            vec![TEST_LEAF.to_vec()],
+            vec![b"alice".to_vec(), b"bob".to_vec(), b"carol".to_vec()],
+            vec![b"scores".to_vec()],
+            axis_query,
+        );
+        let read = |transaction| {
+            let run = db
+                .run_path_query(
+                    &path_query,
+                    true,
+                    true,
+                    true,
+                    QueryResultType::QueryKeyElementPairResultType,
+                    transaction,
+                    grove_version,
+                )
+                .unwrap()
+                .expect("branched read");
+            let PathQueryRun::BranchedAxisEntries(branches) = run else {
+                panic!("expected BranchedAxisEntries");
+            };
+            branches
+        };
+
+        // Under the snapshot: bob is still absent and alice's page is
+        // her pre-commit top-k — the whole union, absence probes
+        // included, reads the snapshot's state.
+        let pinned = read(Some(&snapshot_transaction));
+        assert!(
+            pinned[1].1.is_none(),
+            "bob must stay absent under the snapshot"
+        );
+        assert_eq!(
+            pinned[0].1.as_ref().expect("alice present"),
+            &AxisEntries::Sum(alice_before),
+            "alice's page under the snapshot is her pre-commit top-k"
+        );
+
+        // A plain transaction started at the same moment reads LATEST
+        // committed state on each operation — the exact gap the
+        // snapshot transaction closes.
+        let unpinned = read(Some(&plain_transaction));
+        assert!(unpinned[1].1.is_some(), "a plain transaction sees bob");
+
+        // A `None` read sees the new state too.
+        let fresh = read(None);
+        assert!(fresh[1].1.is_some(), "a committed read sees bob");
+        assert_eq!(
+            fresh[0].1.as_ref().expect("alice present"),
+            &AxisEntries::Sum(alice_after),
+            "the committed read reflects the new row"
+        );
+    }
+
     // -----------------------------------------------------------------
     // Sum budget
     // -----------------------------------------------------------------

--- a/storage/src/rocksdb_storage/storage.rs
+++ b/storage/src/rocksdb_storage/storage.rs
@@ -43,7 +43,8 @@ use lazy_static::lazy_static;
 use rocksdb::IngestExternalFileOptions;
 use rocksdb::{
     checkpoint::Checkpoint, ColumnFamily, ColumnFamilyDescriptor, FlushOptions,
-    OptimisticTransactionDB, Transaction, WriteBatchWithTransaction, DEFAULT_COLUMN_FAMILY_NAME,
+    OptimisticTransactionDB, OptimisticTransactionOptions, Transaction, WriteBatchWithTransaction,
+    WriteOptions, DEFAULT_COLUMN_FAMILY_NAME,
 };
 
 use super::{PrefixedRocksDbImmediateStorageContext, PrefixedRocksDbTransactionContext};
@@ -586,6 +587,32 @@ impl RocksDbStorage {
                     sst_path.display()
                 ))
             })
+    }
+
+    /// Start a transaction whose reads are **pinned to the committed
+    /// state as of this call** when routed through the transactional
+    /// storage contexts.
+    ///
+    /// A plain [`Storage::start_transaction`] transaction reads the
+    /// latest committed state on every operation: RocksDB transactions
+    /// do not read from a snapshot unless one is requested at creation
+    /// and injected into each read's options. This constructor requests
+    /// the snapshot; the contexts inject it (`read_options` on the
+    /// prefixed transaction contexts), so every get and iterator through
+    /// this transaction observes one consistent committed state, however
+    /// many operations the caller spreads over it.
+    ///
+    /// Intended for multi-operation READS that must not tear across a
+    /// concurrent commit — e.g. a branched axis read probing and walking
+    /// several subtrees. Writing through it is not the intended use:
+    /// `set_snapshot` also arms commit-time conflict detection against
+    /// the snapshot, so commits of such a transaction can fail with
+    /// `Busy` where a plain transaction's would not.
+    pub fn start_snapshot_read_transaction(&self) -> Tx<'_> {
+        let mut transaction_options = OptimisticTransactionOptions::default();
+        transaction_options.set_snapshot(true);
+        self.db
+            .transaction_opt(&WriteOptions::default(), &transaction_options)
     }
 
     /// Clears all data from the database using range deletion on each

--- a/storage/src/rocksdb_storage/storage_context/context_immediate.rs
+++ b/storage/src/rocksdb_storage/storage_context/context_immediate.rs
@@ -33,7 +33,7 @@ use grovedb_costs::{
     storage_cost::key_value_cost::KeyValueStorageCost, ChildrenSizesWithIsSumTree, CostResult,
     CostsExt,
 };
-use rocksdb::{ColumnFamily, DBRawIteratorWithThreadMode, WriteBatchWithTransaction};
+use rocksdb::{ColumnFamily, DBRawIteratorWithThreadMode, ReadOptions, WriteBatchWithTransaction};
 
 use super::{make_prefixed_key, PrefixedRocksDbBatch, PrefixedRocksDbRawIterator};
 use crate::{
@@ -63,6 +63,18 @@ impl<'db> PrefixedRocksDbImmediateStorageContext<'db> {
 }
 
 impl<'db> PrefixedRocksDbImmediateStorageContext<'db> {
+    /// Read options honoring the transaction's snapshot, when one was
+    /// requested at creation — see the twin helper on
+    /// `PrefixedRocksDbTransactionContext` for the full contract. A
+    /// plain transaction's snapshot handle is null and leaves reads on
+    /// the latest committed state, so this is a no-op for every
+    /// non-snapshot caller.
+    fn read_options(&self) -> ReadOptions {
+        let mut read_options = ReadOptions::default();
+        read_options.set_snapshot(&self.transaction.snapshot());
+        read_options
+    }
+
     /// Get auxiliary data column family
     fn cf_aux(&self) -> &'db ColumnFamily {
         self.storage
@@ -188,28 +200,40 @@ impl<'db> StorageContext<'db> for PrefixedRocksDbImmediateStorageContext<'db> {
 
     fn get<K: AsRef<[u8]>>(&self, key: K) -> CostResult<Option<Vec<u8>>, Error> {
         self.transaction
-            .get(make_prefixed_key(&self.prefix, key))
+            .get_opt(make_prefixed_key(&self.prefix, key), &self.read_options())
             .map_err(RocksDBError)
             .wrap_with_cost(Default::default())
     }
 
     fn get_aux<K: AsRef<[u8]>>(&self, key: K) -> CostResult<Option<Vec<u8>>, Error> {
         self.transaction
-            .get_cf(self.cf_aux(), make_prefixed_key(&self.prefix, key))
+            .get_cf_opt(
+                self.cf_aux(),
+                make_prefixed_key(&self.prefix, key),
+                &self.read_options(),
+            )
             .map_err(RocksDBError)
             .wrap_with_cost(Default::default())
     }
 
     fn get_root<K: AsRef<[u8]>>(&self, key: K) -> CostResult<Option<Vec<u8>>, Error> {
         self.transaction
-            .get_cf(self.cf_roots(), make_prefixed_key(&self.prefix, key))
+            .get_cf_opt(
+                self.cf_roots(),
+                make_prefixed_key(&self.prefix, key),
+                &self.read_options(),
+            )
             .map_err(RocksDBError)
             .wrap_with_cost(Default::default())
     }
 
     fn get_meta<K: AsRef<[u8]>>(&self, key: K) -> CostResult<Option<Vec<u8>>, Error> {
         self.transaction
-            .get_cf(self.cf_meta(), make_prefixed_key(&self.prefix, key))
+            .get_cf_opt(
+                self.cf_meta(),
+                make_prefixed_key(&self.prefix, key),
+                &self.read_options(),
+            )
             .map_err(RocksDBError)
             .wrap_with_cost(Default::default())
     }
@@ -234,7 +258,7 @@ impl<'db> StorageContext<'db> for PrefixedRocksDbImmediateStorageContext<'db> {
     fn raw_iter(&self) -> Self::RawIterator {
         PrefixedRocksDbRawIterator {
             prefix: self.prefix,
-            raw_iterator: self.transaction.raw_iterator(),
+            raw_iterator: self.transaction.raw_iterator_opt(self.read_options()),
         }
     }
 }

--- a/storage/src/rocksdb_storage/storage_context/context_tx.rs
+++ b/storage/src/rocksdb_storage/storage_context/context_tx.rs
@@ -34,7 +34,7 @@ use grovedb_costs::{
     ChildrenSizesWithIsSumTree, CostResult, CostsExt, OperationCost,
 };
 use integer_encoding::VarInt;
-use rocksdb::{ColumnFamily, DBRawIteratorWithThreadMode};
+use rocksdb::{ColumnFamily, DBRawIteratorWithThreadMode, ReadOptions};
 
 use super::{batch::PrefixedMultiContextBatchPart, make_prefixed_key, PrefixedRocksDbRawIterator};
 use crate::{
@@ -95,6 +95,23 @@ impl<'db> PrefixedRocksDbTransactionContext<'db> {
 }
 
 impl<'db> PrefixedRocksDbTransactionContext<'db> {
+    /// Read options honoring the transaction's snapshot, when one was
+    /// requested at creation
+    /// ([`RocksDbStorage::start_snapshot_read_transaction`](crate::rocksdb_storage::RocksDbStorage::start_snapshot_read_transaction)).
+    ///
+    /// RocksDB transactions do NOT read from their snapshot by default —
+    /// the snapshot must be injected into every read's options. A plain
+    /// transaction's snapshot handle is null, which leaves these options
+    /// reading the latest committed state, so this is a no-op for every
+    /// non-snapshot caller. The handle stored into the options is owned
+    /// by the transaction (which outlives this context); the temporary
+    /// wrapper only frees its C shell on drop.
+    fn read_options(&self) -> ReadOptions {
+        let mut read_options = ReadOptions::default();
+        read_options.set_snapshot(&self.transaction.snapshot());
+        read_options
+    }
+
     /// Get auxiliary data column family
     fn cf_aux(&self) -> &'db ColumnFamily {
         self.storage
@@ -307,7 +324,7 @@ impl<'db> StorageContext<'db> for PrefixedRocksDbTransactionContext<'db> {
 
     fn get<K: AsRef<[u8]>>(&self, key: K) -> CostResult<Option<Vec<u8>>, Error> {
         self.transaction
-            .get(make_prefixed_key(&self.prefix, key))
+            .get_opt(make_prefixed_key(&self.prefix, key), &self.read_options())
             .map_err(RocksDBError)
             .wrap_fn_cost(|value| OperationCost {
                 seek_count: 1,
@@ -323,7 +340,11 @@ impl<'db> StorageContext<'db> for PrefixedRocksDbTransactionContext<'db> {
 
     fn get_aux<K: AsRef<[u8]>>(&self, key: K) -> CostResult<Option<Vec<u8>>, Error> {
         self.transaction
-            .get_cf(self.cf_aux(), make_prefixed_key(&self.prefix, key))
+            .get_cf_opt(
+                self.cf_aux(),
+                make_prefixed_key(&self.prefix, key),
+                &self.read_options(),
+            )
             .map_err(RocksDBError)
             .wrap_fn_cost(|value| OperationCost {
                 seek_count: 1,
@@ -339,7 +360,11 @@ impl<'db> StorageContext<'db> for PrefixedRocksDbTransactionContext<'db> {
 
     fn get_root<K: AsRef<[u8]>>(&self, key: K) -> CostResult<Option<Vec<u8>>, Error> {
         self.transaction
-            .get_cf(self.cf_roots(), make_prefixed_key(&self.prefix, key))
+            .get_cf_opt(
+                self.cf_roots(),
+                make_prefixed_key(&self.prefix, key),
+                &self.read_options(),
+            )
             .map_err(RocksDBError)
             .wrap_fn_cost(|value| OperationCost {
                 seek_count: 1,
@@ -355,7 +380,11 @@ impl<'db> StorageContext<'db> for PrefixedRocksDbTransactionContext<'db> {
 
     fn get_meta<K: AsRef<[u8]>>(&self, key: K) -> CostResult<Option<Vec<u8>>, Error> {
         self.transaction
-            .get_cf(self.cf_meta(), make_prefixed_key(&self.prefix, key))
+            .get_cf_opt(
+                self.cf_meta(),
+                make_prefixed_key(&self.prefix, key),
+                &self.read_options(),
+            )
             .map_err(RocksDBError)
             .wrap_fn_cost(|value| OperationCost {
                 seek_count: 1,
@@ -394,7 +423,7 @@ impl<'db> StorageContext<'db> for PrefixedRocksDbTransactionContext<'db> {
     fn raw_iter(&self) -> Self::RawIterator {
         PrefixedRocksDbRawIterator {
             prefix: self.prefix,
-            raw_iterator: self.transaction.raw_iterator(),
+            raw_iterator: self.transaction.raw_iterator_opt(self.read_options()),
         }
     }
 }


### PR DESCRIPTION
## What

`GroveDb::start_snapshot_read_transaction()` — a transaction whose reads are pinned to the committed state as of its creation. Both prefixed transaction contexts now route every get and raw iterator through `ReadOptions` carrying the transaction's snapshot.

## Why

RocksDB optimistic transactions read the **latest** committed state on every operation — the snapshot requested at creation is not consulted unless injected into each read's options. A multi-operation read under one transaction (or under `None`) can therefore observe two committed states when a commit lands between its operations. The acute case is the branched axis read (`run_path_query`'s `BranchedAxisRead` arm): its per-branch absence probes and axis walks could merge branch pages that never coexisted in any committed state. dashpay/platform#4401's `IN`-pinned ranked / having-range reads need exactly this primitive.

## Compatibility

A plain transaction's snapshot handle is null, which RocksDB documents as leaving reads on the latest committed state — existing callers are byte-for-byte unaffected; pinning activates only through the new constructor. Read-only by intent: `set_snapshot` also arms commit-time conflict detection, so writes through a snapshot transaction may fail to commit where a plain transaction's would not.

## Testing

`snapshot_read_transaction_pins_a_branched_read_to_one_committed_state`: runs the branched axis read under a snapshot transaction while a commit creates a new branch and changes an existing page — the snapshot read returns the creation-time state (absence included), while a plain transaction and a `None` read see the new state. Full grovedb (2915) + storage (36) suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added snapshot read transactions that provide a consistent view of the committed database state when a transaction begins.
  * Snapshot-based reads, iterations, queries, and proof generation now remain stable across subsequent commits.
  * Standard transactions and fresh reads continue to reflect the latest committed data.

* **Bug Fixes**
  * Improved consistency for branched and axis-based queries and database proofs performed within snapshot transactions.
  * Proofs now reliably validate against the database state captured at generation time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->