### PR TITLE
feat: harden snapshot read transactions — refuse writes, expose lifetime, conformance-test the ReadOptions funnel

### DIFF
--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -545,7 +545,7 @@ impl GroveOp {
         }
     }
 
-    /// True iff this op, when applied at a cidx primary's path, can
+    /// True if and only if this op, when applied at a cidx primary's path, can
     /// change the `count_value` (or absence) of the element at the
     /// op's key — and therefore requires the cidx primary's secondary
     /// mirror to be updated for that key.

--- a/grovedb/src/lib.rs
+++ b/grovedb/src/lib.rs
@@ -1888,11 +1888,23 @@ impl GroveDb {
     /// axis read's per-branch probes and walks, for example, all see one
     /// state.
     ///
-    /// Read-only by intent. `set_snapshot` also arms commit-time
-    /// conflict detection against the snapshot, so committing writes
-    /// made through this transaction can fail with `Busy` where a plain
-    /// transaction's commit would not; take a plain transaction to
-    /// write.
+    /// Read-only **enforced**: `set_snapshot` also arms commit-time
+    /// conflict detection against the snapshot, so writes through this
+    /// transaction could fail with `Busy` where a plain transaction's
+    /// commit would not — instead of leaving that timing-dependent trap
+    /// open, every write entry point and [`GroveDb::commit_transaction`]
+    /// refuse a snapshot read transaction with a typed
+    /// `SnapshotReadOnlyTransaction` storage error. Take a plain
+    /// transaction to write.
+    ///
+    /// The snapshot is O(1) to take but pins every post-snapshot
+    /// RocksDB version while held — a transaction kept across a client
+    /// session, or leaked on an error path, silently becomes compaction
+    /// debt and write amplification. Scope it to a single
+    /// multi-operation read and drop it promptly. `snapshot_age()` on
+    /// the returned transaction exposes the hold time, and debug builds
+    /// log loudly when a read executes on a snapshot held longer than a
+    /// second.
     pub fn start_snapshot_read_transaction(&self) -> Transaction<'_> {
         self.db.start_snapshot_read_transaction()
     }

--- a/grovedb/src/operations/indexed_tree.rs
+++ b/grovedb/src/operations/indexed_tree.rs
@@ -2761,11 +2761,11 @@ impl GroveDb {
     /// Axis-compatibility rules:
     /// - [`IndexAxis::Count`] accepts
     ///   [`Element::ProvableCountIndexedTree`] (single-axis, always count)
-    ///   or [`Element::ProvableCountProvableSumIndexedTree`] (PCPSIT) iff
+    ///   or [`Element::ProvableCountProvableSumIndexedTree`] (PCPSIT) if and only if
     ///   its TLV contains the count axis.
     /// - [`IndexAxis::Sum`] accepts
     ///   [`Element::ProvableSumIndexedTree`] (single-axis, always sum) or
-    ///   PCPSIT iff its TLV contains the sum axis.
+    ///   PCPSIT if and only if its TLV contains the sum axis.
     /// - [`IndexAxis::Avg`] only accepts PCPSIT, and only if its TLV
     ///   contains the avg axis.
     ///

--- a/grovedb/src/operations/proof/indexed_axis/envelope.rs
+++ b/grovedb/src/operations/proof/indexed_axis/envelope.rs
@@ -158,7 +158,7 @@ pub struct IndexedAxisRangeProof {
     /// Encoded canonically per the PCPSIT TLV rules (sorted by tag,
     /// no duplicates, 0..=2 entries — the queried axis is removed).
     pub other_axes_root_hashes: Vec<(u8, [u8; 32])>,
-    /// Discriminator: `true` iff the queried target is a PCPSIT (the
+    /// Discriminator: `true` if and only if the queried target is a PCPSIT (the
     /// deepest-layer composition uses `axes_digest(...)` even when only
     /// the queried axis is in the TLV). For PCIT and PSIT this is
     /// `false` and the composition uses the single-secondary root hash

--- a/grovedb/src/operations/proof/indexed_axis/generate.rs
+++ b/grovedb/src/operations/proof/indexed_axis/generate.rs
@@ -455,10 +455,10 @@ impl GroveDb {
     /// the requested axis:
     /// - [`IndexAxis::Count`] supports
     ///   [`Element::ProvableCountIndexedTree`] (PCIT) or
-    ///   [`Element::ProvableCountProvableSumIndexedTree`] (PCPSIT) iff
+    ///   [`Element::ProvableCountProvableSumIndexedTree`] (PCPSIT) if and only if
     ///   the count axis is in the PCPSIT's TLV.
     /// - [`IndexAxis::Sum`] supports
-    ///   [`Element::ProvableSumIndexedTree`] (PSIT) or PCPSIT iff the
+    ///   [`Element::ProvableSumIndexedTree`] (PSIT) or PCPSIT if and only if the
     ///   sum axis is in the TLV.
     /// - [`IndexAxis::Avg`] supports PCPSIT only, and only if the avg
     ///   axis is in the TLV.

--- a/grovedb/src/operations/proof/mod.rs
+++ b/grovedb/src/operations/proof/mod.rs
@@ -377,7 +377,7 @@ impl SumBudgetWindowProof {
 ///   `other_axes_root_hashes` + the recomputed queried-axis root for
 ///   PCPSIT), which must equal the parent-committed `value_hash` — any
 ///   forgery fails that comparison.
-/// - `rank` is present iff the traversal is `RankOfKey`: the verifier
+/// - `rank` is present if and only if the traversal is `RankOfKey`: the verifier
 ///   needs the claimed rank to drive the count-offset verification
 ///   walk, whose counted commitments then attest it (a wrong claim
 ///   fails verification), and the single yielded entry must be the

--- a/grovedb/src/operations/proof/verify.rs
+++ b/grovedb/src/operations/proof/verify.rs
@@ -222,7 +222,7 @@ impl GroveDb {
         // Offset gate centralized in `apply_count_offset_envelope_gate`:
         // V0 envelopes reject any non-zero offset (V0 is a shipped
         // wire format that never supported `SizedQuery::offset`);
-        // V1 envelopes honor a non-zero offset iff the query
+        // V1 envelopes honor a non-zero offset if and only if the query
         // validates as offset-paginated. The tree-type check
         // (ProvableCountTree / ProvableCountSumTree) happens at
         // leaf-dispatch time inside `run_count_offset_layer_dispatch`.

--- a/grovedb/src/tests/mod.rs
+++ b/grovedb/src/tests/mod.rs
@@ -101,6 +101,7 @@ mod reference_with_sum_item_tests;
 mod replication_session_tests;
 mod replication_utils_tests;
 mod run_path_query_tests;
+mod snapshot_read_transaction_tests;
 mod succinctness_gap_test;
 mod sum_budget_proof_tests;
 mod test_compaction_sizes;

--- a/grovedb/src/tests/snapshot_read_transaction_tests.rs
+++ b/grovedb/src/tests/snapshot_read_transaction_tests.rs
@@ -1,0 +1,125 @@
+//! Snapshot read transactions are read-only by construction (issue #832).
+//!
+//! `start_snapshot_read_transaction` exists to pin a multi-operation READ
+//! to one committed state (pinning itself is covered in
+//! `run_path_query_tests`). These tests pin the hardening around the
+//! primitive: every write entry point and `commit_transaction` refuse a
+//! snapshot read transaction with the typed
+//! `SnapshotReadOnlyTransaction` storage error, reads through it keep
+//! working after a refusal, and the snapshot's lifetime is observable.
+
+#[cfg(test)]
+mod tests {
+    use grovedb_version::version::GroveVersion;
+
+    use crate::{
+        tests::{make_test_grovedb, TEST_LEAF},
+        Element, Error,
+    };
+
+    fn assert_refused(result: Result<(), Error>) {
+        assert!(
+            matches!(
+                result,
+                Err(Error::StorageError(
+                    grovedb_storage::Error::SnapshotReadOnlyTransaction(_)
+                ))
+            ),
+            "expected the typed snapshot-read-only refusal, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn snapshot_read_transaction_refuses_writes_but_keeps_reading() {
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"key",
+            Element::new_item(b"committed".to_vec()),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("seed insert");
+
+        let snapshot_transaction = db.start_snapshot_read_transaction();
+
+        // Inserting through the snapshot transaction is refused with the
+        // typed error when the operation's batch is applied...
+        assert_refused(
+            db.insert(
+                [TEST_LEAF].as_ref(),
+                b"smuggled",
+                Element::new_item(b"nope".to_vec()),
+                None,
+                Some(&snapshot_transaction),
+                grove_version,
+            )
+            .unwrap(),
+        );
+        // ...and so is deleting.
+        assert_refused(
+            db.delete(
+                [TEST_LEAF].as_ref(),
+                b"key",
+                None,
+                Some(&snapshot_transaction),
+                grove_version,
+            )
+            .unwrap(),
+        );
+
+        // The refusals poison nothing: the same transaction still serves
+        // reads, pinned to its creation-time state.
+        let element = db
+            .get(
+                [TEST_LEAF].as_ref(),
+                b"key",
+                Some(&snapshot_transaction),
+                grove_version,
+            )
+            .unwrap()
+            .expect("read through the snapshot transaction after refusals");
+        assert_eq!(element, Element::new_item(b"committed".to_vec()));
+
+        // Committing the snapshot transaction is refused too; rollback
+        // (the harmless cleanup path) is allowed.
+        db.rollback_transaction(&snapshot_transaction)
+            .expect("rollback is a harmless no-op on a snapshot read transaction");
+        assert_refused(db.commit_transaction(snapshot_transaction).unwrap());
+
+        // Nothing leaked into committed state.
+        assert_eq!(
+            db.get([TEST_LEAF].as_ref(), b"key", None, grove_version)
+                .unwrap()
+                .expect("seeded key still present"),
+            Element::new_item(b"committed".to_vec())
+        );
+        assert!(db
+            .get([TEST_LEAF].as_ref(), b"smuggled", None, grove_version)
+            .unwrap()
+            .is_err());
+    }
+
+    #[test]
+    fn snapshot_lifetime_is_observable() {
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+
+        let plain_transaction = db.start_transaction();
+        assert!(!plain_transaction.is_snapshot_read());
+        assert_eq!(plain_transaction.snapshot_age(), None);
+
+        let snapshot_transaction = db.start_snapshot_read_transaction();
+        assert!(snapshot_transaction.is_snapshot_read());
+        let first = snapshot_transaction
+            .snapshot_age()
+            .expect("snapshot transactions report their hold time");
+        let second = snapshot_transaction
+            .snapshot_age()
+            .expect("snapshot transactions report their hold time");
+        assert!(second >= first, "hold time must not run backwards");
+    }
+}

--- a/grovedb/src/util.rs
+++ b/grovedb/src/util.rs
@@ -21,9 +21,7 @@ impl<'a, 'db> TxRef<'a, 'db> {
     /// Commit the transaction if it wasn't received from outside
     pub(crate) fn commit_local(self) -> Result<(), Error> {
         match self {
-            TxRef::Owned(tx) => tx
-                .commit()
-                .map_err(|e| grovedb_storage::Error::from(e).into()),
+            TxRef::Owned(tx) => tx.commit().map_err(Into::into),
             TxRef::Borrowed(_) => Ok(()),
         }
     }

--- a/merk/src/proofs/query/aggregate_count/emit.rs
+++ b/merk/src/proofs/query/aggregate_count/emit.rs
@@ -13,7 +13,7 @@
 //! - **Boundary** → emit `KVDigestCount(key, value_hash, node_count)`
 //!   for the current node, recurse into both children for descent, and
 //!   add `own_count = node_count − left_struct − right_struct` to the
-//!   running total iff the node's key is itself in range. This is what
+//!   running total if and only if the node's key is itself in range. This is what
 //!   makes `NonCounted`-wrapped entries fall out of the in-range total
 //!   automatically (their node_count is 0).
 

--- a/merk/src/proofs/query/aggregate_count_and_sum/emit.rs
+++ b/merk/src/proofs/query/aggregate_count_and_sum/emit.rs
@@ -19,7 +19,7 @@
 //!   `own_count` / `own_sum` later.)
 //! - **Boundary** → emit `KVDigestCountSum(key, value_hash, node_count,
 //!   node_sum)` for the current node, recurse into both children, and
-//!   add `own_count` / `own_sum` to the running totals iff the node's
+//!   add `own_count` / `own_sum` to the running totals if and only if the node's
 //!   key is itself in range.
 
 use std::collections::LinkedList;

--- a/merk/src/proofs/query/aggregate_sum/emit.rs
+++ b/merk/src/proofs/query/aggregate_sum/emit.rs
@@ -13,7 +13,7 @@
 //! - **Boundary** → emit `KVDigestSum(key, value_hash, node_sum)` for
 //!   the current node, recurse into both children for descent, and add
 //!   `own_sum = node_sum − left_struct − right_struct` to the running
-//!   total iff the node's key is itself in range.
+//!   total if and only if the node's key is itself in range.
 
 use std::collections::LinkedList;
 

--- a/merk/src/proofs/query/count_offset/verify.rs
+++ b/merk/src/proofs/query/count_offset/verify.rs
@@ -14,7 +14,7 @@
 //!    independently re-derive:
 //!    - `skipped` — number of in-range items the prover claims to have
 //!      skipped via offset. Must equal the requested offset (or be ≤
-//!      it iff the in-range population was smaller, see "Truncated
+//!      it if and only if the in-range population was smaller, see "Truncated
 //!      offset" below).
 //!    - `returned_items` — the actual values the verifier reconstructs
 //!      from value-bearing nodes inside the limit window.

--- a/merk/src/tree_type/mod.rs
+++ b/merk/src/tree_type/mod.rs
@@ -627,7 +627,7 @@ mod tests {
         // children are accepted.
         assert!(TreeType::ProvableCountProvableSumTree.is_count_and_sum_bearing());
 
-        // Equivalence: is_count_and_sum_bearing iff both is_count_bearing
+        // Equivalence: is_count_and_sum_bearing if and only if both is_count_bearing
         // and is_sum_bearing.
         for tt in [
             TreeType::NormalTree,

--- a/storage/src/error.rs
+++ b/storage/src/error.rs
@@ -37,6 +37,15 @@ pub enum Error {
     /// Cost Error
     #[error("cost error: {0}")]
     CostError(grovedb_costs::error::Error),
+    /// A write or commit was attempted through a snapshot read
+    /// transaction. Snapshot read transactions
+    /// (`start_snapshot_read_transaction`) exist to pin multi-operation
+    /// READS to one committed state; writing through one is refused
+    /// because `set_snapshot` arms commit-time conflict detection, which
+    /// can fail such a commit with `Busy` where a plain transaction's
+    /// would have succeeded. The payload names the refused operation.
+    #[error("snapshot read transaction is read-only: refused {0}")]
+    SnapshotReadOnlyTransaction(&'static str),
     /// Rocks DB error
     #[error("rocksDB error: {0}")]
     #[cfg(feature = "rocksdb_storage")]

--- a/storage/src/rocksdb_storage.rs
+++ b/storage/src/rocksdb_storage.rs
@@ -39,4 +39,4 @@ pub use storage_context::{
     PrefixedRocksDbTransactionContext,
 };
 
-pub use self::storage::RocksDbStorage;
+pub use self::storage::{RocksDbStorage, Tx};

--- a/storage/src/rocksdb_storage/storage.rs
+++ b/storage/src/rocksdb_storage/storage.rs
@@ -324,6 +324,27 @@ impl<'db> Tx<'db> {
     pub fn rollback(&self) -> Result<(), Error> {
         self.tx.rollback().map_err(RocksDBError)
     }
+
+    /// Set a savepoint: a later [`Tx::rollback_to_savepoint`] undoes
+    /// every operation in this transaction since this call. Used by
+    /// callers that interleave many independent write groups in one
+    /// transaction (e.g. per-state-transition savepoints in block
+    /// processing) to unwind one failed group without discarding the
+    /// transaction. Allowed on a snapshot read transaction — like
+    /// [`Tx::rollback`], the savepoint family only ever *unwinds*
+    /// writes (which a snapshot read transaction cannot accumulate),
+    /// so there is nothing to refuse.
+    pub fn set_savepoint(&self) {
+        self.tx.set_savepoint()
+    }
+
+    /// Undo all operations in this transaction since the most recent
+    /// [`Tx::set_savepoint`], popping that savepoint. See
+    /// [`Tx::set_savepoint`] for the intended use and the
+    /// snapshot-read policy.
+    pub fn rollback_to_savepoint(&self) -> Result<(), Error> {
+        self.tx.rollback_to_savepoint().map_err(RocksDBError)
+    }
 }
 
 /// Storage which uses RocksDB as its backend.

--- a/storage/src/rocksdb_storage/storage.rs
+++ b/storage/src/rocksdb_storage/storage.rs
@@ -28,7 +28,11 @@
 
 //! Implementation for a storage abstraction over RocksDB.
 
-use std::path::Path;
+use std::{
+    path::Path,
+    sync::atomic::AtomicBool,
+    time::{Duration, Instant},
+};
 
 use error::Error;
 use grovedb_costs::{
@@ -42,9 +46,9 @@ use lazy_static::lazy_static;
 #[cfg(feature = "unsafe-dump-load")]
 use rocksdb::IngestExternalFileOptions;
 use rocksdb::{
-    checkpoint::Checkpoint, ColumnFamily, ColumnFamilyDescriptor, FlushOptions,
-    OptimisticTransactionDB, OptimisticTransactionOptions, Transaction, WriteBatchWithTransaction,
-    WriteOptions, DEFAULT_COLUMN_FAMILY_NAME,
+    checkpoint::Checkpoint, ColumnFamily, ColumnFamilyDescriptor, DBRawIteratorWithThreadMode,
+    FlushOptions, OptimisticTransactionDB, OptimisticTransactionOptions, ReadOptions, Transaction,
+    WriteBatchWithTransaction, WriteOptions, DEFAULT_COLUMN_FAMILY_NAME,
 };
 
 use super::{PrefixedRocksDbImmediateStorageContext, PrefixedRocksDbTransactionContext};
@@ -112,8 +116,215 @@ lazy_static! {
 /// Type alias for a database
 pub(crate) type Db = OptimisticTransactionDB;
 
-/// Type alias for a transaction
-pub(crate) type Tx<'db> = Transaction<'db, Db>;
+/// Type alias for the raw RocksDB transaction. Private to this module:
+/// every read and write the storage layer performs through a transaction
+/// must go through the [`Tx`] wrapper's methods, never the raw handle.
+pub(crate) type RawTx<'db> = Transaction<'db, Db>;
+
+/// Reads executing on a snapshot held longer than this trip a loud
+/// debug-build warning. A snapshot is O(1) to take but pins every
+/// post-snapshot version while held, so a leaked or session-scoped
+/// snapshot transaction silently turns into compaction debt and write
+/// amplification. The intended holders are millisecond-scoped
+/// multi-operation reads; one second is three orders of magnitude above
+/// that, so a trip is a bug in the caller, not load jitter.
+#[cfg(debug_assertions)]
+const SNAPSHOT_AGE_WARN_THRESHOLD: Duration = Duration::from_secs(1);
+
+/// A started storage transaction.
+///
+/// Wraps the raw RocksDB optimistic transaction together with the
+/// snapshot-read marker set by
+/// [`RocksDbStorage::start_snapshot_read_transaction`]. The wrapper is
+/// the single funnel for everything the storage layer does through a
+/// transaction:
+///
+/// - **Reads** ([`Tx::get`], [`Tx::get_cf`], [`Tx::raw_iterator`])
+///   inject the transaction's snapshot into every read's options.
+///   RocksDB transactions do NOT read from their snapshot by default,
+///   so a read added later that bypassed this funnel would silently
+///   revert to latest-committed reads; keeping the raw un-optioned
+///   accessors private makes that bypass impossible outside this
+///   module.
+/// - **Writes and commit** ([`Tx::put`], [`Tx::delete`],
+///   [`Tx::rebuild_from_writebatch`], [`Tx::commit`], and their `_cf`
+///   variants) refuse a snapshot read transaction with
+///   [`Error::SnapshotReadOnlyTransaction`]: `set_snapshot` arms
+///   commit-time conflict detection, so writes through one may fail
+///   with `Busy`/`TryAgain` where a plain transaction's would have
+///   committed. Refusing up front turns that timing-dependent trap
+///   into a deterministic typed error.
+pub struct Tx<'db> {
+    tx: RawTx<'db>,
+    /// `Some(creation time)` iff this transaction was created via
+    /// `start_snapshot_read_transaction`. Doubles as the read-only
+    /// marker and the age baseline for [`Tx::snapshot_age`].
+    snapshot_read_since: Option<Instant>,
+    /// Debug builds warn once per transaction on a long-held snapshot;
+    /// this remembers that the warning already fired.
+    #[cfg_attr(not(debug_assertions), allow(dead_code))]
+    age_warned: AtomicBool,
+}
+
+impl<'db> Tx<'db> {
+    /// Wrap a plain transaction (reads latest committed state).
+    pub(crate) fn new_plain(tx: RawTx<'db>) -> Self {
+        Tx {
+            tx,
+            snapshot_read_since: None,
+            age_warned: AtomicBool::new(false),
+        }
+    }
+
+    /// Wrap a snapshot read transaction (reads pinned to creation-time
+    /// committed state; writes and commit refused).
+    pub(crate) fn new_snapshot_read(tx: RawTx<'db>) -> Self {
+        Tx {
+            tx,
+            snapshot_read_since: Some(Instant::now()),
+            age_warned: AtomicBool::new(false),
+        }
+    }
+
+    /// Whether this transaction was created via
+    /// `start_snapshot_read_transaction`: reads are pinned to its
+    /// creation-time committed state and writes/commit are refused.
+    pub fn is_snapshot_read(&self) -> bool {
+        self.snapshot_read_since.is_some()
+    }
+
+    /// How long this transaction's snapshot has been held, or `None`
+    /// for a plain transaction. While held, the snapshot pins every
+    /// post-snapshot version in RocksDB — intended holds are
+    /// millisecond-scoped, and debug builds log loudly when a read
+    /// executes on a snapshot older than one second.
+    pub fn snapshot_age(&self) -> Option<Duration> {
+        self.snapshot_read_since.map(|since| since.elapsed())
+    }
+
+    /// The typed refusal for write operations on a snapshot read
+    /// transaction, `Ok(())` on a plain transaction.
+    fn refuse_snapshot_write(&self, operation: &'static str) -> Result<(), Error> {
+        if self.is_snapshot_read() {
+            Err(Error::SnapshotReadOnlyTransaction(operation))
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Read options honoring the transaction's snapshot, when one was
+    /// requested at creation.
+    ///
+    /// A plain transaction's snapshot handle is null, which RocksDB
+    /// documents as leaving reads on the latest committed state, so
+    /// this is a no-op for every non-snapshot transaction. The handle
+    /// stored into the options is owned by the transaction (which
+    /// outlives every context borrowing it); the temporary wrapper
+    /// only frees its C shell on drop.
+    fn read_options(&self) -> ReadOptions {
+        #[cfg(debug_assertions)]
+        if let Some(age) = self.snapshot_age()
+            && age > SNAPSHOT_AGE_WARN_THRESHOLD
+            && !self
+                .age_warned
+                .swap(true, std::sync::atomic::Ordering::Relaxed)
+        {
+            eprintln!(
+                "WARNING (grovedb-storage): read on a snapshot read transaction whose \
+                 snapshot has been held for {age:?} (threshold {SNAPSHOT_AGE_WARN_THRESHOLD:?}). \
+                 A held snapshot pins every post-snapshot RocksDB version — a leaked or \
+                 session-scoped snapshot transaction becomes compaction debt and write \
+                 amplification under load. Scope snapshot transactions to a single \
+                 multi-operation read. (Warning fires once per transaction.)"
+            );
+        }
+        let mut read_options = ReadOptions::default();
+        read_options.set_snapshot(&self.tx.snapshot());
+        read_options
+    }
+
+    /// Snapshot-honoring point read from the default column family.
+    pub(crate) fn get<K: AsRef<[u8]>>(&self, key: K) -> Result<Option<Vec<u8>>, rocksdb::Error> {
+        self.tx.get_opt(key, &self.read_options())
+    }
+
+    /// Snapshot-honoring point read from a named column family.
+    pub(crate) fn get_cf<K: AsRef<[u8]>>(
+        &self,
+        cf: &ColumnFamily,
+        key: K,
+    ) -> Result<Option<Vec<u8>>, rocksdb::Error> {
+        self.tx.get_cf_opt(cf, key, &self.read_options())
+    }
+
+    /// Snapshot-honoring raw iterator over the default column family.
+    pub(crate) fn raw_iterator(&self) -> DBRawIteratorWithThreadMode<'_, RawTx<'db>> {
+        self.tx.raw_iterator_opt(self.read_options())
+    }
+
+    /// Write into the default column family. Refused on a snapshot
+    /// read transaction.
+    pub(crate) fn put<K: AsRef<[u8]>, V: AsRef<[u8]>>(
+        &self,
+        key: K,
+        value: V,
+    ) -> Result<(), Error> {
+        self.refuse_snapshot_write("put")?;
+        self.tx.put(key, value).map_err(RocksDBError)
+    }
+
+    /// Write into a named column family. Refused on a snapshot read
+    /// transaction.
+    pub(crate) fn put_cf<K: AsRef<[u8]>, V: AsRef<[u8]>>(
+        &self,
+        cf: &ColumnFamily,
+        key: K,
+        value: V,
+    ) -> Result<(), Error> {
+        self.refuse_snapshot_write("put")?;
+        self.tx.put_cf(cf, key, value).map_err(RocksDBError)
+    }
+
+    /// Delete from the default column family. Refused on a snapshot
+    /// read transaction.
+    pub(crate) fn delete<K: AsRef<[u8]>>(&self, key: K) -> Result<(), Error> {
+        self.refuse_snapshot_write("delete")?;
+        self.tx.delete(key).map_err(RocksDBError)
+    }
+
+    /// Delete from a named column family. Refused on a snapshot read
+    /// transaction.
+    pub(crate) fn delete_cf<K: AsRef<[u8]>>(&self, cf: &ColumnFamily, key: K) -> Result<(), Error> {
+        self.refuse_snapshot_write("delete")?;
+        self.tx.delete_cf(cf, key).map_err(RocksDBError)
+    }
+
+    /// Replay a write batch into this transaction. Refused on a
+    /// snapshot read transaction — this is the batch-apply write entry
+    /// point.
+    pub(crate) fn rebuild_from_writebatch(
+        &self,
+        batch: &WriteBatchWithTransaction<true>,
+    ) -> Result<(), Error> {
+        self.refuse_snapshot_write("batch apply")?;
+        self.tx.rebuild_from_writebatch(batch).map_err(RocksDBError)
+    }
+
+    /// Consume and commit the transaction. Refused on a snapshot read
+    /// transaction (which by construction has nothing to commit — its
+    /// writes were already refused).
+    pub fn commit(self) -> Result<(), Error> {
+        self.refuse_snapshot_write("commit")?;
+        self.tx.commit().map_err(RocksDBError)
+    }
+
+    /// Roll back the transaction's pending writes. Allowed on a
+    /// snapshot read transaction: it is a harmless no-op there and an
+    /// error would only complicate callers' cleanup paths.
+    pub fn rollback(&self) -> Result<(), Error> {
+        self.tx.rollback().map_err(RocksDBError)
+    }
+}
 
 /// Storage which uses RocksDB as its backend.
 ///
@@ -532,16 +743,15 @@ impl RocksDbStorage {
         transaction: Option<&<RocksDbStorage as Storage>::Transaction>,
     ) -> CostResult<(), Error> {
         let result = match transaction {
-            None => self.db.write(db_batch),
+            None => self.db.write(db_batch).map_err(RocksDBError),
+            // Refused with a typed error on a snapshot read transaction.
             Some(transaction) => transaction.rebuild_from_writebatch(&db_batch),
         };
 
         if result.is_ok() {
-            result.map_err(RocksDBError).wrap_with_cost(pending_costs)
+            result.wrap_with_cost(pending_costs)
         } else {
-            result
-                .map_err(RocksDBError)
-                .wrap_with_cost(OperationCost::default())
+            result.wrap_with_cost(OperationCost::default())
         }
     }
 
@@ -604,15 +814,26 @@ impl RocksDbStorage {
     ///
     /// Intended for multi-operation READS that must not tear across a
     /// concurrent commit — e.g. a branched axis read probing and walking
-    /// several subtrees. Writing through it is not the intended use:
-    /// `set_snapshot` also arms commit-time conflict detection against
-    /// the snapshot, so commits of such a transaction can fail with
-    /// `Busy` where a plain transaction's would not.
+    /// several subtrees. Read-only **enforced**: `set_snapshot` also arms
+    /// commit-time conflict detection against the snapshot, so writes
+    /// through such a transaction could fail with `Busy` where a plain
+    /// transaction's would have committed — instead of leaving that
+    /// timing-dependent trap open, every write entry point and `commit`
+    /// refuse the transaction with
+    /// [`Error::SnapshotReadOnlyTransaction`].
+    ///
+    /// A snapshot is O(1) to take but pins every post-snapshot RocksDB
+    /// version while held: scope the transaction to a single
+    /// multi-operation read and drop it promptly. [`Tx::snapshot_age`]
+    /// exposes the hold time, and debug builds log loudly when a read
+    /// executes on a snapshot held longer than a second.
     pub fn start_snapshot_read_transaction(&self) -> Tx<'_> {
         let mut transaction_options = OptimisticTransactionOptions::default();
         transaction_options.set_snapshot(true);
-        self.db
-            .transaction_opt(&WriteOptions::default(), &transaction_options)
+        Tx::new_snapshot_read(
+            self.db
+                .transaction_opt(&WriteOptions::default(), &transaction_options),
+        )
     }
 
     /// Clears all data from the database using range deletion on each
@@ -667,22 +888,20 @@ impl<'db> Storage<'db> for RocksDbStorage {
     type Transaction = Tx<'db>;
 
     fn start_transaction(&'db self) -> Self::Transaction {
-        self.db.transaction()
+        Tx::new_plain(self.db.transaction())
     }
 
     fn commit_transaction(&self, transaction: Self::Transaction) -> CostResult<(), Error> {
         // All transaction costs were provided on method calls.
         // Note: for OptimisticTransactionDB, commit() performs conflict
         // validation and may return a Busy or TryAgain error if another
-        // transaction modified the same keys concurrently.
-        transaction
-            .commit()
-            .map_err(RocksDBError)
-            .wrap_with_cost(Default::default())
+        // transaction modified the same keys concurrently. A snapshot
+        // read transaction is refused with a typed error.
+        transaction.commit().wrap_with_cost(Default::default())
     }
 
     fn rollback_transaction(&self, transaction: &Self::Transaction) -> Result<(), Error> {
-        transaction.rollback().map_err(RocksDBError)
+        transaction.rollback()
     }
 
     fn flush(&self) -> Result<(), Error> {

--- a/storage/src/rocksdb_storage/storage.rs
+++ b/storage/src/rocksdb_storage/storage.rs
@@ -156,9 +156,9 @@ const SNAPSHOT_AGE_WARN_THRESHOLD: Duration = Duration::from_secs(1);
 ///   into a deterministic typed error.
 pub struct Tx<'db> {
     tx: RawTx<'db>,
-    /// `Some(creation time)` iff this transaction was created via
-    /// `start_snapshot_read_transaction`. Doubles as the read-only
-    /// marker and the age baseline for [`Tx::snapshot_age`].
+    /// `Some(creation time)` if and only if this transaction was
+    /// created via `start_snapshot_read_transaction`. Doubles as the
+    /// read-only marker and the age baseline for [`Tx::snapshot_age`].
     snapshot_read_since: Option<Instant>,
     /// Debug builds warn once per transaction on a long-held snapshot;
     /// this remembers that the warning already fired.

--- a/storage/src/rocksdb_storage/storage_context/context_immediate.rs
+++ b/storage/src/rocksdb_storage/storage_context/context_immediate.rs
@@ -33,13 +33,15 @@ use grovedb_costs::{
     storage_cost::key_value_cost::KeyValueStorageCost, ChildrenSizesWithIsSumTree, CostResult,
     CostsExt,
 };
-use rocksdb::{ColumnFamily, DBRawIteratorWithThreadMode, ReadOptions, WriteBatchWithTransaction};
+use rocksdb::{ColumnFamily, DBRawIteratorWithThreadMode, WriteBatchWithTransaction};
 
 use super::{make_prefixed_key, PrefixedRocksDbBatch, PrefixedRocksDbRawIterator};
 use crate::{
     error,
     error::Error::RocksDBError,
-    rocksdb_storage::storage::{Db, SubtreePrefix, Tx, AUX_CF_NAME, META_CF_NAME, ROOTS_CF_NAME},
+    rocksdb_storage::storage::{
+        Db, RawTx, SubtreePrefix, Tx, AUX_CF_NAME, META_CF_NAME, ROOTS_CF_NAME,
+    },
     StorageContext,
 };
 
@@ -63,18 +65,6 @@ impl<'db> PrefixedRocksDbImmediateStorageContext<'db> {
 }
 
 impl<'db> PrefixedRocksDbImmediateStorageContext<'db> {
-    /// Read options honoring the transaction's snapshot, when one was
-    /// requested at creation — see the twin helper on
-    /// `PrefixedRocksDbTransactionContext` for the full contract. A
-    /// plain transaction's snapshot handle is null and leaves reads on
-    /// the latest committed state, so this is a no-op for every
-    /// non-snapshot caller.
-    fn read_options(&self) -> ReadOptions {
-        let mut read_options = ReadOptions::default();
-        read_options.set_snapshot(&self.transaction.snapshot());
-        read_options
-    }
-
     /// Get auxiliary data column family
     fn cf_aux(&self) -> &'db ColumnFamily {
         self.storage
@@ -99,7 +89,7 @@ impl<'db> PrefixedRocksDbImmediateStorageContext<'db> {
 
 impl<'db> StorageContext<'db> for PrefixedRocksDbImmediateStorageContext<'db> {
     type Batch = PrefixedRocksDbBatch<'db>;
-    type RawIterator = PrefixedRocksDbRawIterator<DBRawIteratorWithThreadMode<'db, Tx<'db>>>;
+    type RawIterator = PrefixedRocksDbRawIterator<DBRawIteratorWithThreadMode<'db, RawTx<'db>>>;
 
     fn put<K: AsRef<[u8]>>(
         &self,
@@ -108,9 +98,11 @@ impl<'db> StorageContext<'db> for PrefixedRocksDbImmediateStorageContext<'db> {
         _children_sizes: ChildrenSizesWithIsSumTree,
         _cost_info: Option<KeyValueStorageCost>,
     ) -> CostResult<(), Error> {
+        // Writes go through the transaction wrapper, which refuses a
+        // snapshot read transaction with a typed error — same for every
+        // put/delete below.
         self.transaction
             .put(make_prefixed_key(&self.prefix, &key), value)
-            .map_err(RocksDBError)
             .wrap_with_cost(Default::default())
     }
 
@@ -122,7 +114,6 @@ impl<'db> StorageContext<'db> for PrefixedRocksDbImmediateStorageContext<'db> {
     ) -> CostResult<(), Error> {
         self.transaction
             .put_cf(self.cf_aux(), make_prefixed_key(&self.prefix, &key), value)
-            .map_err(RocksDBError)
             .wrap_with_cost(Default::default())
     }
 
@@ -138,7 +129,6 @@ impl<'db> StorageContext<'db> for PrefixedRocksDbImmediateStorageContext<'db> {
                 make_prefixed_key(&self.prefix, &key),
                 value,
             )
-            .map_err(RocksDBError)
             .wrap_with_cost(Default::default())
     }
 
@@ -150,7 +140,6 @@ impl<'db> StorageContext<'db> for PrefixedRocksDbImmediateStorageContext<'db> {
     ) -> CostResult<(), Error> {
         self.transaction
             .put_cf(self.cf_meta(), make_prefixed_key(&self.prefix, &key), value)
-            .map_err(RocksDBError)
             .wrap_with_cost(Default::default())
     }
 
@@ -161,7 +150,6 @@ impl<'db> StorageContext<'db> for PrefixedRocksDbImmediateStorageContext<'db> {
     ) -> CostResult<(), Error> {
         self.transaction
             .delete(make_prefixed_key(&self.prefix, key))
-            .map_err(RocksDBError)
             .wrap_with_cost(Default::default())
     }
 
@@ -172,7 +160,6 @@ impl<'db> StorageContext<'db> for PrefixedRocksDbImmediateStorageContext<'db> {
     ) -> CostResult<(), Error> {
         self.transaction
             .delete_cf(self.cf_aux(), make_prefixed_key(&self.prefix, key))
-            .map_err(RocksDBError)
             .wrap_with_cost(Default::default())
     }
 
@@ -183,7 +170,6 @@ impl<'db> StorageContext<'db> for PrefixedRocksDbImmediateStorageContext<'db> {
     ) -> CostResult<(), Error> {
         self.transaction
             .delete_cf(self.cf_roots(), make_prefixed_key(&self.prefix, key))
-            .map_err(RocksDBError)
             .wrap_with_cost(Default::default())
     }
 
@@ -194,46 +180,36 @@ impl<'db> StorageContext<'db> for PrefixedRocksDbImmediateStorageContext<'db> {
     ) -> CostResult<(), Error> {
         self.transaction
             .delete_cf(self.cf_meta(), make_prefixed_key(&self.prefix, key))
-            .map_err(RocksDBError)
             .wrap_with_cost(Default::default())
     }
 
     fn get<K: AsRef<[u8]>>(&self, key: K) -> CostResult<Option<Vec<u8>>, Error> {
+        // Reads go through the transaction wrapper, which injects the
+        // transaction's snapshot (when one was requested at creation)
+        // into every read's options — same for every read below.
         self.transaction
-            .get_opt(make_prefixed_key(&self.prefix, key), &self.read_options())
+            .get(make_prefixed_key(&self.prefix, key))
             .map_err(RocksDBError)
             .wrap_with_cost(Default::default())
     }
 
     fn get_aux<K: AsRef<[u8]>>(&self, key: K) -> CostResult<Option<Vec<u8>>, Error> {
         self.transaction
-            .get_cf_opt(
-                self.cf_aux(),
-                make_prefixed_key(&self.prefix, key),
-                &self.read_options(),
-            )
+            .get_cf(self.cf_aux(), make_prefixed_key(&self.prefix, key))
             .map_err(RocksDBError)
             .wrap_with_cost(Default::default())
     }
 
     fn get_root<K: AsRef<[u8]>>(&self, key: K) -> CostResult<Option<Vec<u8>>, Error> {
         self.transaction
-            .get_cf_opt(
-                self.cf_roots(),
-                make_prefixed_key(&self.prefix, key),
-                &self.read_options(),
-            )
+            .get_cf(self.cf_roots(), make_prefixed_key(&self.prefix, key))
             .map_err(RocksDBError)
             .wrap_with_cost(Default::default())
     }
 
     fn get_meta<K: AsRef<[u8]>>(&self, key: K) -> CostResult<Option<Vec<u8>>, Error> {
         self.transaction
-            .get_cf_opt(
-                self.cf_meta(),
-                make_prefixed_key(&self.prefix, key),
-                &self.read_options(),
-            )
+            .get_cf(self.cf_meta(), make_prefixed_key(&self.prefix, key))
             .map_err(RocksDBError)
             .wrap_with_cost(Default::default())
     }
@@ -251,14 +227,13 @@ impl<'db> StorageContext<'db> for PrefixedRocksDbImmediateStorageContext<'db> {
     fn commit_batch(&self, batch: Self::Batch) -> CostResult<(), Error> {
         self.transaction
             .rebuild_from_writebatch(&batch.batch)
-            .map_err(RocksDBError)
             .wrap_with_cost(batch.cost_acc)
     }
 
     fn raw_iter(&self) -> Self::RawIterator {
         PrefixedRocksDbRawIterator {
             prefix: self.prefix,
-            raw_iterator: self.transaction.raw_iterator_opt(self.read_options()),
+            raw_iterator: self.transaction.raw_iterator(),
         }
     }
 }

--- a/storage/src/rocksdb_storage/storage_context/context_tx.rs
+++ b/storage/src/rocksdb_storage/storage_context/context_tx.rs
@@ -34,13 +34,15 @@ use grovedb_costs::{
     ChildrenSizesWithIsSumTree, CostResult, CostsExt, OperationCost,
 };
 use integer_encoding::VarInt;
-use rocksdb::{ColumnFamily, DBRawIteratorWithThreadMode, ReadOptions};
+use rocksdb::{ColumnFamily, DBRawIteratorWithThreadMode};
 
 use super::{batch::PrefixedMultiContextBatchPart, make_prefixed_key, PrefixedRocksDbRawIterator};
 use crate::{
     error,
     error::Error::RocksDBError,
-    rocksdb_storage::storage::{Db, SubtreePrefix, Tx, AUX_CF_NAME, META_CF_NAME, ROOTS_CF_NAME},
+    rocksdb_storage::storage::{
+        Db, RawTx, SubtreePrefix, Tx, AUX_CF_NAME, META_CF_NAME, ROOTS_CF_NAME,
+    },
     RawIterator, StorageBatch, StorageContext,
 };
 
@@ -95,23 +97,6 @@ impl<'db> PrefixedRocksDbTransactionContext<'db> {
 }
 
 impl<'db> PrefixedRocksDbTransactionContext<'db> {
-    /// Read options honoring the transaction's snapshot, when one was
-    /// requested at creation
-    /// ([`RocksDbStorage::start_snapshot_read_transaction`](crate::rocksdb_storage::RocksDbStorage::start_snapshot_read_transaction)).
-    ///
-    /// RocksDB transactions do NOT read from their snapshot by default —
-    /// the snapshot must be injected into every read's options. A plain
-    /// transaction's snapshot handle is null, which leaves these options
-    /// reading the latest committed state, so this is a no-op for every
-    /// non-snapshot caller. The handle stored into the options is owned
-    /// by the transaction (which outlives this context); the temporary
-    /// wrapper only frees its C shell on drop.
-    fn read_options(&self) -> ReadOptions {
-        let mut read_options = ReadOptions::default();
-        read_options.set_snapshot(&self.transaction.snapshot());
-        read_options
-    }
-
     /// Get auxiliary data column family
     fn cf_aux(&self) -> &'db ColumnFamily {
         self.storage
@@ -136,7 +121,7 @@ impl<'db> PrefixedRocksDbTransactionContext<'db> {
 
 impl<'db> StorageContext<'db> for PrefixedRocksDbTransactionContext<'db> {
     type Batch = PrefixedMultiContextBatchPart;
-    type RawIterator = PrefixedRocksDbRawIterator<DBRawIteratorWithThreadMode<'db, Tx<'db>>>;
+    type RawIterator = PrefixedRocksDbRawIterator<DBRawIteratorWithThreadMode<'db, RawTx<'db>>>;
 
     fn put<K: AsRef<[u8]>>(
         &self,
@@ -323,8 +308,11 @@ impl<'db> StorageContext<'db> for PrefixedRocksDbTransactionContext<'db> {
     }
 
     fn get<K: AsRef<[u8]>>(&self, key: K) -> CostResult<Option<Vec<u8>>, Error> {
+        // Reads go through the transaction wrapper, which injects the
+        // transaction's snapshot (when one was requested at creation)
+        // into every read's options — same for every read below.
         self.transaction
-            .get_opt(make_prefixed_key(&self.prefix, key), &self.read_options())
+            .get(make_prefixed_key(&self.prefix, key))
             .map_err(RocksDBError)
             .wrap_fn_cost(|value| OperationCost {
                 seek_count: 1,
@@ -340,11 +328,7 @@ impl<'db> StorageContext<'db> for PrefixedRocksDbTransactionContext<'db> {
 
     fn get_aux<K: AsRef<[u8]>>(&self, key: K) -> CostResult<Option<Vec<u8>>, Error> {
         self.transaction
-            .get_cf_opt(
-                self.cf_aux(),
-                make_prefixed_key(&self.prefix, key),
-                &self.read_options(),
-            )
+            .get_cf(self.cf_aux(), make_prefixed_key(&self.prefix, key))
             .map_err(RocksDBError)
             .wrap_fn_cost(|value| OperationCost {
                 seek_count: 1,
@@ -360,11 +344,7 @@ impl<'db> StorageContext<'db> for PrefixedRocksDbTransactionContext<'db> {
 
     fn get_root<K: AsRef<[u8]>>(&self, key: K) -> CostResult<Option<Vec<u8>>, Error> {
         self.transaction
-            .get_cf_opt(
-                self.cf_roots(),
-                make_prefixed_key(&self.prefix, key),
-                &self.read_options(),
-            )
+            .get_cf(self.cf_roots(), make_prefixed_key(&self.prefix, key))
             .map_err(RocksDBError)
             .wrap_fn_cost(|value| OperationCost {
                 seek_count: 1,
@@ -380,11 +360,7 @@ impl<'db> StorageContext<'db> for PrefixedRocksDbTransactionContext<'db> {
 
     fn get_meta<K: AsRef<[u8]>>(&self, key: K) -> CostResult<Option<Vec<u8>>, Error> {
         self.transaction
-            .get_cf_opt(
-                self.cf_meta(),
-                make_prefixed_key(&self.prefix, key),
-                &self.read_options(),
-            )
+            .get_cf(self.cf_meta(), make_prefixed_key(&self.prefix, key))
             .map_err(RocksDBError)
             .wrap_fn_cost(|value| OperationCost {
                 seek_count: 1,
@@ -423,7 +399,7 @@ impl<'db> StorageContext<'db> for PrefixedRocksDbTransactionContext<'db> {
     fn raw_iter(&self) -> Self::RawIterator {
         PrefixedRocksDbRawIterator {
             prefix: self.prefix,
-            raw_iterator: self.transaction.raw_iterator_opt(self.read_options()),
+            raw_iterator: self.transaction.raw_iterator(),
         }
     }
 }

--- a/storage/src/rocksdb_storage/storage_context/raw_iterator.rs
+++ b/storage/src/rocksdb_storage/storage_context/raw_iterator.rs
@@ -33,7 +33,7 @@ use rocksdb::DBRawIteratorWithThreadMode;
 
 use super::make_prefixed_key;
 use crate::{
-    rocksdb_storage::storage::{Db, SubtreePrefix, Tx},
+    rocksdb_storage::storage::{Db, RawTx, SubtreePrefix},
     RawIterator,
 };
 
@@ -187,7 +187,7 @@ impl RawIterator for PrefixedRocksDbRawIterator<DBRawIteratorWithThreadMode<'_, 
     }
 }
 
-impl<'a> RawIterator for PrefixedRocksDbRawIterator<DBRawIteratorWithThreadMode<'a, Tx<'a>>> {
+impl<'a> RawIterator for PrefixedRocksDbRawIterator<DBRawIteratorWithThreadMode<'a, RawTx<'a>>> {
     fn seek_to_first(&mut self) -> CostContext<()> {
         self.raw_iterator.seek(self.prefix);
         ().wrap_with_cost(OperationCost::with_seek_count(1))

--- a/storage/src/rocksdb_storage/tests.rs
+++ b/storage/src/rocksdb_storage/tests.rs
@@ -1840,3 +1840,374 @@ mod transactional_context_without_batch {
         );
     }
 }
+
+/// Item 3 of the snapshot-read hardening (issue #832): correctness of a
+/// snapshot read transaction depends on EVERY read method of both
+/// prefixed transaction contexts threading the snapshot through its
+/// read options. The trait's read surface is small and closed — get /
+/// get_aux / get_root / get_meta and the raw iterator — so one
+/// conformance walk per context covers it, and a read method added
+/// later without snapshot plumbing fails here as an obvious
+/// test-extension gap instead of silently reverting to
+/// latest-committed reads.
+mod snapshot_read_transactions {
+    use super::*;
+    use crate::{error::Error, RawIterator, Storage, StorageBatch, StorageContext};
+
+    const PATH: &[&[u8]] = &[b"tree"];
+
+    /// Seed every column family under one prefix, committed to the DB:
+    /// `updated` and `removed` keys everywhere, plus `iter_a`..`iter_c`
+    /// in the data CF for the iterator walks.
+    fn seed(storage: &TempStorage) {
+        let tx = storage.start_transaction();
+        let batch = StorageBatch::new();
+        let ctx = storage
+            .get_transactional_storage_context(PATH.into(), Some(&batch), &tx)
+            .unwrap();
+        for (key, value) in [
+            (b"updated".as_slice(), b"before".as_slice()),
+            (b"removed", b"doomed"),
+            (b"iter_a", b"va"),
+            (b"iter_b", b"vb"),
+            (b"iter_c", b"vc"),
+        ] {
+            ctx.put(key, value, None, None).unwrap().expect("seed put");
+        }
+        ctx.put_aux(b"updated", b"aux_before", None)
+            .unwrap()
+            .expect("seed put_aux");
+        ctx.put_aux(b"removed", b"aux_doomed", None)
+            .unwrap()
+            .expect("seed put_aux");
+        ctx.put_root(b"updated", b"root_before", None)
+            .unwrap()
+            .expect("seed put_root");
+        ctx.put_root(b"removed", b"root_doomed", None)
+            .unwrap()
+            .expect("seed put_root");
+        ctx.put_meta(b"updated", b"meta_before", None)
+            .unwrap()
+            .expect("seed put_meta");
+        ctx.put_meta(b"removed", b"meta_doomed", None)
+            .unwrap()
+            .expect("seed put_meta");
+        storage
+            .commit_multi_context_batch(batch, Some(&tx))
+            .unwrap()
+            .expect("seed batch commit");
+        storage
+            .commit_transaction(tx)
+            .unwrap()
+            .expect("seed tx commit");
+    }
+
+    /// The "concurrent block commit" that lands AFTER the snapshot
+    /// transaction was created: overwrite `updated`, delete `removed`,
+    /// and insert `fresh` in every column family (data CF also swaps
+    /// `iter_c` for `iter_d`).
+    fn commit_concurrent_change(storage: &TempStorage) {
+        let tx = storage.start_transaction();
+        let batch = StorageBatch::new();
+        let ctx = storage
+            .get_transactional_storage_context(PATH.into(), Some(&batch), &tx)
+            .unwrap();
+        ctx.put(b"updated", b"after", None, None)
+            .unwrap()
+            .expect("overwrite");
+        ctx.put(b"fresh", b"created", None, None)
+            .unwrap()
+            .expect("insert");
+        ctx.put(b"iter_d", b"vd", None, None)
+            .unwrap()
+            .expect("insert");
+        ctx.delete(b"removed", None).unwrap().expect("delete");
+        ctx.delete(b"iter_c", None).unwrap().expect("delete");
+        ctx.put_aux(b"updated", b"aux_after", None)
+            .unwrap()
+            .expect("overwrite aux");
+        ctx.put_aux(b"fresh", b"aux_created", None)
+            .unwrap()
+            .expect("insert aux");
+        ctx.delete_aux(b"removed", None)
+            .unwrap()
+            .expect("delete aux");
+        ctx.put_root(b"updated", b"root_after", None)
+            .unwrap()
+            .expect("overwrite root");
+        ctx.put_root(b"fresh", b"root_created", None)
+            .unwrap()
+            .expect("insert root");
+        ctx.delete_root(b"removed", None)
+            .unwrap()
+            .expect("delete root");
+        ctx.put_meta(b"updated", b"meta_after", None)
+            .unwrap()
+            .expect("overwrite meta");
+        ctx.put_meta(b"fresh", b"meta_created", None)
+            .unwrap()
+            .expect("insert meta");
+        ctx.delete_meta(b"removed", None)
+            .unwrap()
+            .expect("delete meta");
+        storage
+            .commit_multi_context_batch(batch, Some(&tx))
+            .unwrap()
+            .expect("concurrent batch commit");
+        storage
+            .commit_transaction(tx)
+            .unwrap()
+            .expect("concurrent tx commit");
+    }
+
+    fn get<'db>(ctx: &impl StorageContext<'db>, key: &[u8]) -> Option<Vec<u8>> {
+        ctx.get(key).unwrap().expect("get")
+    }
+
+    /// Walk the whole prefix forward from `seek_to_first`, collecting
+    /// (key, value) pairs.
+    fn collect_forward<'db>(ctx: &impl StorageContext<'db>) -> Vec<(Vec<u8>, Vec<u8>)> {
+        let mut iter = ctx.raw_iter();
+        iter.seek_to_first().unwrap();
+        let mut out = Vec::new();
+        while iter.valid().unwrap() {
+            out.push((
+                iter.key().unwrap().expect("key").to_vec(),
+                iter.value().unwrap().expect("value").to_vec(),
+            ));
+            iter.next().unwrap();
+        }
+        out
+    }
+
+    /// Walk the whole prefix backward from `seek_to_last`.
+    fn collect_backward<'db>(ctx: &impl StorageContext<'db>) -> Vec<(Vec<u8>, Vec<u8>)> {
+        let mut iter = ctx.raw_iter();
+        iter.seek_to_last().unwrap();
+        let mut out = Vec::new();
+        while iter.valid().unwrap() {
+            out.push((
+                iter.key().unwrap().expect("key").to_vec(),
+                iter.value().unwrap().expect("value").to_vec(),
+            ));
+            iter.prev().unwrap();
+        }
+        out
+    }
+
+    /// Every read method of the given context must observe the
+    /// creation-time committed state: the pre-commit value of the
+    /// overwritten key, the still-present deleted key, no trace of the
+    /// post-snapshot insertions.
+    fn assert_reads_pinned<'db>(ctx: &impl StorageContext<'db>) {
+        // Point reads, one per column family.
+        assert_eq!(get(ctx, b"updated"), Some(b"before".to_vec()));
+        assert_eq!(get(ctx, b"removed"), Some(b"doomed".to_vec()));
+        assert_eq!(get(ctx, b"fresh"), None);
+        assert_eq!(
+            ctx.get_aux(b"updated").unwrap().expect("get_aux"),
+            Some(b"aux_before".to_vec())
+        );
+        assert_eq!(
+            ctx.get_aux(b"removed").unwrap().expect("get_aux"),
+            Some(b"aux_doomed".to_vec())
+        );
+        assert_eq!(ctx.get_aux(b"fresh").unwrap().expect("get_aux"), None);
+        assert_eq!(
+            ctx.get_root(b"updated").unwrap().expect("get_root"),
+            Some(b"root_before".to_vec())
+        );
+        assert_eq!(
+            ctx.get_root(b"removed").unwrap().expect("get_root"),
+            Some(b"root_doomed".to_vec())
+        );
+        assert_eq!(ctx.get_root(b"fresh").unwrap().expect("get_root"), None);
+        assert_eq!(
+            ctx.get_meta(b"updated").unwrap().expect("get_meta"),
+            Some(b"meta_before".to_vec())
+        );
+        assert_eq!(
+            ctx.get_meta(b"removed").unwrap().expect("get_meta"),
+            Some(b"meta_doomed".to_vec())
+        );
+        assert_eq!(ctx.get_meta(b"fresh").unwrap().expect("get_meta"), None);
+
+        // Raw iterator, every navigation variant. The pre-commit data
+        // CF holds exactly these five keys under the prefix.
+        let pinned: Vec<(Vec<u8>, Vec<u8>)> = [
+            (b"iter_a".as_slice(), b"va".as_slice()),
+            (b"iter_b", b"vb"),
+            (b"iter_c", b"vc"),
+            (b"removed", b"doomed"),
+            (b"updated", b"before"),
+        ]
+        .iter()
+        .map(|(k, v)| (k.to_vec(), v.to_vec()))
+        .collect();
+        assert_eq!(collect_forward(ctx), pinned, "forward walk");
+        assert_eq!(
+            collect_backward(ctx),
+            pinned.iter().cloned().rev().collect::<Vec<_>>(),
+            "backward walk"
+        );
+
+        // seek lands on the deleted-after-snapshot key, seek_for_prev
+        // must not see the post-snapshot `iter_d`.
+        let mut iter = ctx.raw_iter();
+        iter.seek(b"iter_c").unwrap();
+        assert_eq!(
+            iter.key().unwrap().expect("seek key"),
+            b"iter_c",
+            "seek sees the pre-commit key"
+        );
+        let mut iter = ctx.raw_iter();
+        iter.seek_for_prev(b"iter_d").unwrap();
+        assert_eq!(
+            iter.key().unwrap().expect("seek_for_prev key"),
+            b"iter_c",
+            "seek_for_prev lands before the invisible post-snapshot key"
+        );
+    }
+
+    /// The mirror-image control: a context on latest-committed state
+    /// must see the post-commit values.
+    fn assert_reads_latest<'db>(ctx: &impl StorageContext<'db>) {
+        assert_eq!(get(ctx, b"updated"), Some(b"after".to_vec()));
+        assert_eq!(get(ctx, b"removed"), None);
+        assert_eq!(get(ctx, b"fresh"), Some(b"created".to_vec()));
+        assert_eq!(
+            ctx.get_aux(b"fresh").unwrap().expect("get_aux"),
+            Some(b"aux_created".to_vec())
+        );
+        assert_eq!(
+            ctx.get_root(b"fresh").unwrap().expect("get_root"),
+            Some(b"root_created".to_vec())
+        );
+        assert_eq!(
+            ctx.get_meta(b"fresh").unwrap().expect("get_meta"),
+            Some(b"meta_created".to_vec())
+        );
+        let keys: Vec<Vec<u8>> = collect_forward(ctx).into_iter().map(|(k, _)| k).collect();
+        assert!(keys.contains(&b"iter_d".to_vec()), "latest sees iter_d");
+        assert!(!keys.contains(&b"iter_c".to_vec()), "iter_c is gone");
+    }
+
+    #[test]
+    fn every_read_method_of_the_transactional_context_is_pinned() {
+        let storage = TempStorage::new();
+        seed(&storage);
+        let snapshot_tx = storage.start_snapshot_read_transaction();
+        let plain_tx = storage.start_transaction();
+        commit_concurrent_change(&storage);
+
+        let pinned_ctx = storage
+            .get_transactional_storage_context(PATH.into(), None, &snapshot_tx)
+            .unwrap();
+        assert_reads_pinned(&pinned_ctx);
+
+        // A plain transaction reads latest-committed on every
+        // operation — the exact behavior the snapshot suppresses.
+        let latest_ctx = storage
+            .get_transactional_storage_context(PATH.into(), None, &plain_tx)
+            .unwrap();
+        assert_reads_latest(&latest_ctx);
+    }
+
+    #[test]
+    fn every_read_method_of_the_immediate_context_is_pinned() {
+        let storage = TempStorage::new();
+        seed(&storage);
+        let snapshot_tx = storage.start_snapshot_read_transaction();
+        let plain_tx = storage.start_transaction();
+        commit_concurrent_change(&storage);
+
+        let pinned_ctx = storage
+            .get_immediate_storage_context(PATH.into(), &snapshot_tx)
+            .unwrap();
+        assert_reads_pinned(&pinned_ctx);
+
+        let latest_ctx = storage
+            .get_immediate_storage_context(PATH.into(), &plain_tx)
+            .unwrap();
+        assert_reads_latest(&latest_ctx);
+    }
+
+    /// Item 1: a snapshot read transaction is read-only by
+    /// construction, not by documentation — every write entry point and
+    /// commit refuse it with the typed error, and rollback (a harmless
+    /// no-op) still succeeds.
+    #[test]
+    fn snapshot_read_transaction_refuses_writes_and_commit() {
+        let storage = TempStorage::new();
+        seed(&storage);
+        let snapshot_tx = storage.start_snapshot_read_transaction();
+        assert!(snapshot_tx.is_snapshot_read());
+
+        // Immediate context: every write refuses immediately.
+        let ctx = storage
+            .get_immediate_storage_context(PATH.into(), &snapshot_tx)
+            .unwrap();
+        let refused = |result: Result<(), Error>| {
+            assert!(
+                matches!(result, Err(Error::SnapshotReadOnlyTransaction(_))),
+                "expected the typed snapshot-read-only refusal, got {result:?}"
+            );
+        };
+        refused(ctx.put(b"updated", b"smuggled", None, None).unwrap());
+        refused(ctx.put_aux(b"updated", b"smuggled", None).unwrap());
+        refused(ctx.put_root(b"updated", b"smuggled", None).unwrap());
+        refused(ctx.put_meta(b"updated", b"smuggled", None).unwrap());
+        refused(ctx.delete(b"updated", None).unwrap());
+        refused(ctx.delete_aux(b"updated", None).unwrap());
+        refused(ctx.delete_root(b"updated", None).unwrap());
+        refused(ctx.delete_meta(b"updated", None).unwrap());
+        refused(ctx.commit_batch(ctx.new_batch()).unwrap());
+
+        // Batch-apply entry point: puts into a deferred StorageBatch
+        // are accepted (they touch nothing), the apply refuses.
+        let batch = StorageBatch::new();
+        let batched_ctx = storage
+            .get_transactional_storage_context(PATH.into(), Some(&batch), &snapshot_tx)
+            .unwrap();
+        batched_ctx
+            .put(b"updated", b"smuggled", None, None)
+            .unwrap()
+            .expect("a deferred batch put touches nothing yet");
+        refused(
+            storage
+                .commit_multi_context_batch(batch, Some(&snapshot_tx))
+                .unwrap(),
+        );
+
+        // Rollback is allowed; commit refuses and consumes.
+        storage
+            .rollback_transaction(&snapshot_tx)
+            .expect("rollback is a harmless no-op on a snapshot read transaction");
+        refused(storage.commit_transaction(snapshot_tx).unwrap());
+
+        // Nothing leaked through: latest-committed state is untouched.
+        let control_tx = storage.start_transaction();
+        let control = storage
+            .get_transactional_storage_context(PATH.into(), None, &control_tx)
+            .unwrap();
+        assert_eq!(get(&control, b"updated"), Some(b"before".to_vec()));
+    }
+
+    /// Item 2: snapshot lifetime is observable. A plain transaction has
+    /// no snapshot age; a snapshot read transaction reports a
+    /// monotonically growing hold time.
+    #[test]
+    fn snapshot_age_is_exposed_and_grows() {
+        let storage = TempStorage::new();
+
+        let plain_tx = storage.start_transaction();
+        assert!(!plain_tx.is_snapshot_read());
+        assert_eq!(plain_tx.snapshot_age(), None);
+
+        let snapshot_tx = storage.start_snapshot_read_transaction();
+        assert!(snapshot_tx.is_snapshot_read());
+        let first = snapshot_tx.snapshot_age().expect("snapshot age");
+        let second = snapshot_tx.snapshot_age().expect("snapshot age");
+        assert!(second >= first, "age must not run backwards");
+    }
+}

--- a/storage/src/rocksdb_storage/tests.rs
+++ b/storage/src/rocksdb_storage/tests.rs
@@ -2210,4 +2210,29 @@ mod snapshot_read_transactions {
         let second = snapshot_tx.snapshot_age().expect("snapshot age");
         assert!(second >= first, "age must not run backwards");
     }
+
+    /// Holding the snapshot past the debug warning threshold and then
+    /// reading exercises the loud-log path (fires once per
+    /// transaction); reads keep returning pinned data regardless.
+    #[test]
+    fn long_held_snapshot_still_reads_pinned_data() {
+        let storage = TempStorage::new();
+        seed(&storage);
+        let snapshot_tx = storage.start_snapshot_read_transaction();
+        commit_concurrent_change(&storage);
+
+        // Cross the debug-build warning threshold (1s) before reading.
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        assert!(
+            snapshot_tx.snapshot_age().expect("snapshot age") > std::time::Duration::from_secs(1)
+        );
+
+        let ctx = storage
+            .get_transactional_storage_context(PATH.into(), None, &snapshot_tx)
+            .unwrap();
+        // Two reads: the first trips the once-per-transaction warning,
+        // the second takes the already-warned path.
+        assert_eq!(get(&ctx, b"updated"), Some(b"before".to_vec()));
+        assert_eq!(get(&ctx, b"removed"), Some(b"doomed".to_vec()));
+    }
 }

--- a/storage/src/rocksdb_storage/tests.rs
+++ b/storage/src/rocksdb_storage/tests.rs
@@ -2211,6 +2211,48 @@ mod snapshot_read_transactions {
         assert!(second >= first, "age must not run backwards");
     }
 
+    /// The savepoint family is part of the wrapper's public surface —
+    /// platform sets a savepoint per state transition and rewinds one
+    /// failed group without discarding the transaction. Pin the
+    /// pass-through: writes since `set_savepoint` are undone by
+    /// `rollback_to_savepoint`, writes before it survive, and the
+    /// rollback family stays callable on a snapshot read transaction.
+    #[test]
+    fn savepoints_unwind_writes_since_the_savepoint() {
+        let storage = TempStorage::new();
+        let tx = storage.start_transaction();
+        let ctx = storage
+            .get_immediate_storage_context(PATH.into(), &tx)
+            .unwrap();
+
+        ctx.put(b"kept", b"kept_value", None, None)
+            .unwrap()
+            .expect("pre-savepoint put");
+        tx.set_savepoint();
+        ctx.put(b"unwound", b"gone", None, None)
+            .unwrap()
+            .expect("post-savepoint put");
+        assert_eq!(get(&ctx, b"unwound"), Some(b"gone".to_vec()));
+
+        tx.rollback_to_savepoint().expect("rollback to savepoint");
+        assert_eq!(get(&ctx, b"kept"), Some(b"kept_value".to_vec()));
+        assert_eq!(get(&ctx, b"unwound"), None);
+
+        storage
+            .commit_transaction(tx)
+            .unwrap()
+            .expect("commit after savepoint rewind");
+
+        // The rollback family is allowed on a snapshot read
+        // transaction — it can only unwind writes, which such a
+        // transaction cannot accumulate.
+        let snapshot_tx = storage.start_snapshot_read_transaction();
+        snapshot_tx.set_savepoint();
+        snapshot_tx
+            .rollback_to_savepoint()
+            .expect("savepoint family is a harmless no-op on a snapshot read transaction");
+    }
+
     /// Holding the snapshot past the debug warning threshold and then
     /// reading exercises the loud-log path (fires once per
     /// transaction); reads keep returning pinned data regardless.


### PR DESCRIPTION
Closes #832. Follow-up hardening for #831 (`start_snapshot_read_transaction`). None of these were holes in what shipped — both existing callers are read-only and millisecond-scoped — but the primitive's API surface left three traps for future callers. All three are closed by one mechanism.

## The mechanism: the transaction type is now a recognizable wrapper

`Storage::Transaction` for the RocksDB backend (and therefore grovedb's `Transaction` alias) is now a wrapper struct (`storage::rocksdb_storage::Tx`) around the raw RocksDB transaction, carrying the snapshot-read marker set at creation. The raw un-optioned accessors are private to the storage module, so the wrapper is the single funnel for everything done through a transaction. This is the "recognizable wrapper" option from the issue — no registry, no keying problem, no lookup on the hot path.

### 1. Read-only enforced instead of documented

Every write entry point refuses a snapshot read transaction with a new typed error, `Error::SnapshotReadOnlyTransaction(&'static str)` (payload names the refused operation):

- the immediate context's `put`/`put_aux`/`put_root`/`put_meta`/`delete*` family (refused immediately),
- the batch apply (`rebuild_from_writebatch`, covering `commit_multi_context_batch` and the immediate context's `commit_batch`),
- `commit` / `commit_transaction`.

Previously such writes would fail nondeterministically with `Busy`/`TryAgain` at commit time — or worse, commit — because `set_snapshot` arms commit-time conflict detection. Now the failure is deterministic and typed. `rollback` stays allowed: it is a harmless no-op there and refusing it would only complicate callers' cleanup paths. Refusals don't poison the transaction — it still serves pinned reads afterwards (pinned by test).

### 2. Snapshot lifetime observable; loud debug warning on long holds

The read-only marker doubles as a creation timestamp: `is_snapshot_read()` and `snapshot_age()` are public on the transaction. Debug builds additionally log a loud warning — once per transaction — when a read executes on a snapshot held longer than 1s (three orders of magnitude above the intended millisecond-scoped holds), naming the compaction-debt failure mode. The failure mode is a loud log, not a slow node; release builds carry no check on the read path.

### 3. Silent-regression channel on the read funnel closed

Both prefixed transaction contexts now read exclusively through the wrapper's `get`/`get_cf`/`raw_iterator`, each of which injects the transaction's snapshot into that read's `ReadOptions` (the per-context `read_options()` helpers are gone). A read method added later **cannot** reach the raw un-optioned accessors from outside the storage module, so it cannot silently revert to latest-committed reads.

A conformance test walks every read method of the storage-context trait — `get`, `get_aux`, `get_root`, `get_meta`, and every raw-iterator navigation variant (`seek_to_first`/forward, `seek_to_last`/backward, `seek`, `seek_for_prev`) — on **both** context types under a snapshot transaction with a commit landed after creation (overwrite + insert + delete in every column family), asserting pre-commit visibility per method, with a plain-transaction control asserting post-commit visibility. A forgotten new read method surfaces as an obvious test-extension failure.

## Compatibility

- Plain transactions are byte-for-byte unaffected: their snapshot handle is null, which RocksDB documents as reading the latest committed state; `start_transaction` behavior is unchanged.
- The wrapper keeps `commit()`/`rollback()` inherent methods, so existing direct call sites compile unchanged (`commit()` now returns the storage `Error` instead of `rocksdb::Error`).
- The #831 pin tests (branched axis read, recursive proof generation) pass unchanged.

## Non-goal (per the issue)

The platform-side consistency asymmetry (branched `IN` reads snapshot-pinned; other unproved reads latest-committed per operation) is deliberate and remains documented, not extended.

## Testing

- `cargo nextest run --workspace --all-features`: 5090 passed.
- `cargo clippy --workspace --all-features -- -D warnings`: clean.
- `cargo check --workspace --all-features --all-targets` and `cargo build --no-default-features --features verify -p grovedb`: clean.
- New: 4 storage-level tests (two per-context conformance walks, write-refusal walk, lifetime introspection) + 2 grovedb-level tests (typed refusal through `insert`/`delete`/`commit_transaction` with reads surviving refusals; lifetime observability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added snapshot read transactions that provide a consistent, pinned view of data.
  - Snapshot transactions now report their age and remain read-only.
  - Rollback is supported for snapshot transactions.

- **Bug Fixes**
  - Write, delete, batch, and commit attempts on snapshot transactions now return a clear read-only error.
  - Confirmed rejected writes do not modify committed data.

- **Documentation**
  - Expanded guidance on snapshot lifetime, age monitoring, compaction impact, and long-held snapshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->