### PR TITLE
feat: carry the attested skip on PathQueryRun's axis variants

### DIFF
--- a/docs/book/src/unified-path-query.md
+++ b/docs/book/src/unified-path-query.md
@@ -185,6 +185,17 @@ primitives, the budgeted sum reader — so the unified answer is always
 equal to the dedicated entry point's answer (pinned by differential
 tests).
 
+Single-path paginated axis reads (`RankedPage`) carry the
+count-commitment-attested skip alongside the page —
+`AxisEntries { entries, skipped: Some(n) }` — exactly as the direct
+`indexed_*_top_k_paginated*` primitives report it: `n` equals the
+requested offset on a full page and the population when the offset ran
+past the end (the empty page attests the population). `Bounded`
+traversals carry `skipped: None` (no skip concept). This mirrors the
+proved side's `VerifiedPathQuery::AxisEntries` contract; the branched
+variants carry no skip, since a per-branch skip has no meaning for the
+merged union.
+
 Branched reads mirror the proof's absence semantics: a branch key — or
 any suffix segment under it — that does not exist yields `None` for
 that branch rather than failing the whole read.

--- a/docs/book/src/unified-path-query.md
+++ b/docs/book/src/unified-path-query.md
@@ -186,11 +186,12 @@ equal to the dedicated entry point's answer (pinned by differential
 tests).
 
 Single-path paginated axis reads (`RankedPage`) carry the
-count-commitment-attested skip alongside the page —
-`AxisEntries { entries, skipped: Some(n) }` — exactly as the direct
+count-commitment-attested skip alongside the page — on both
+projections, `AxisEntries { entries, skipped: Some(n) }` and
+`AxisKeys { keys, skipped: Some(n) }` — exactly as the direct
 `indexed_*_top_k_paginated*` primitives report it: `n` equals the
-requested offset on a full page and the population when the offset ran
-past the end (the empty page attests the population). `Bounded`
+requested offset on a full page and the population when the offset is
+at or past the end (the empty page attests the population). `Bounded`
 traversals carry `skipped: None` (no skip concept). This mirrors the
 proved side's `VerifiedPathQuery::AxisEntries` contract; the branched
 variants carry no skip, since a per-branch skip has no meaning for the

--- a/grovedb/src/operations/get/run_path_query.rs
+++ b/grovedb/src/operations/get/run_path_query.rs
@@ -85,8 +85,22 @@ pub enum PathQueryRun {
     /// outer key, each from one walk over that key's leaf.
     AggregateCountAndSumPerKey(Vec<(Vec<u8>, u64, i64)>),
     /// Single-path axis read (`TopK` / `Bounded` traversals): the
-    /// entries in walk order.
-    AxisEntries(AxisEntries),
+    /// entries in walk order, plus the attested skip for paginated
+    /// traversals.
+    AxisEntries {
+        /// The entries, in walk order.
+        entries: AxisEntries,
+        /// How many entries the offset actually skipped — derived from
+        /// the counted subtree commitments exactly as
+        /// [`IndexedTopKPage::skipped`](crate::IndexedTopKPage::skipped)
+        /// reports it: equal to the requested offset on a full page,
+        /// smaller when the walk exhausted the secondary (an offset at
+        /// or past the end returns an empty page whose `skipped` is the
+        /// population). `Some` for `RankedPage` traversals, `None` for
+        /// `Bounded` ones (no skip concept) — mirroring
+        /// [`VerifiedPathQuery::AxisEntries`](crate::operations::proof::VerifiedPathQuery::AxisEntries).
+        skipped: Option<u64>,
+    },
     /// Branched axis read: per branch key, in query order, the entries
     /// — or `None` when the branch key is absent at the branching
     /// level (mirroring the branched proof's authenticated-absence
@@ -95,7 +109,13 @@ pub enum PathQueryRun {
     /// Single-path axis read with `AxisProjection::Keys`: the ranking
     /// pairs in walk order, read straight from the pinned secondary
     /// view; no primary value resolved.
-    AxisKeys(AxisKeys),
+    AxisKeys {
+        /// The ranking pairs, in walk order.
+        keys: AxisKeys,
+        /// The attested skip, exactly as [`Self::AxisEntries`] carries
+        /// it: `Some` for `RankedPage` traversals, `None` for `Bounded`.
+        skipped: Option<u64>,
+    },
     /// Branched axis read with `AxisProjection::Keys`: per branch key,
     /// in query order, the ranking pairs — or `None` for an absent
     /// branch, exactly as [`Self::BranchedAxisEntries`].
@@ -316,11 +336,14 @@ impl GroveDb {
                         &mut cost,
                         self.run_axis_read(full_path.as_slice(), axis, transaction, grove_version)
                     );
+                    // The branched variants deliberately carry no skip:
+                    // a per-branch skip has no meaning for the merged
+                    // union, so the page's skip is discarded here.
                     match run {
-                        PathQueryRun::AxisEntries(entries) if !keys_projection => {
+                        PathQueryRun::AxisEntries { entries, .. } if !keys_projection => {
                             branches.push((branch_key.clone(), Some(entries)));
                         }
-                        PathQueryRun::AxisKeys(keys) if keys_projection => {
+                        PathQueryRun::AxisKeys { keys, .. } if keys_projection => {
                             key_branches.push((branch_key.clone(), Some(keys)));
                         }
                         _ => {
@@ -390,7 +413,7 @@ impl GroveDb {
         match &axis_query.traversal {
             AxisTraversal::RankedPage { k, offset } => {
                 if keys_only {
-                    let keys = cost_return_on_error!(
+                    let (keys, skipped) = cost_return_on_error!(
                         &mut cost,
                         self.axis_top_k_paginated_keys(
                             path,
@@ -402,9 +425,13 @@ impl GroveDb {
                             grove_version
                         )
                     );
-                    return Ok(PathQueryRun::AxisKeys(keys)).wrap_with_cost(cost);
+                    return Ok(PathQueryRun::AxisKeys {
+                        keys,
+                        skipped: Some(skipped),
+                    })
+                    .wrap_with_cost(cost);
                 }
-                let entries = cost_return_on_error!(
+                let (entries, skipped) = cost_return_on_error!(
                     &mut cost,
                     self.axis_top_k_paginated_entries(
                         path,
@@ -416,7 +443,11 @@ impl GroveDb {
                         grove_version
                     )
                 );
-                Ok(PathQueryRun::AxisEntries(entries)).wrap_with_cost(cost)
+                Ok(PathQueryRun::AxisEntries {
+                    entries,
+                    skipped: Some(skipped),
+                })
+                .wrap_with_cost(cost)
             }
             AxisTraversal::Bounded { lo, hi, limit } => {
                 if keys_only {
@@ -433,7 +464,11 @@ impl GroveDb {
                             grove_version
                         )
                     );
-                    return Ok(PathQueryRun::AxisKeys(keys)).wrap_with_cost(cost);
+                    return Ok(PathQueryRun::AxisKeys {
+                        keys,
+                        skipped: None,
+                    })
+                    .wrap_with_cost(cost);
                 }
                 let entries = cost_return_on_error!(
                     &mut cost,
@@ -448,7 +483,11 @@ impl GroveDb {
                         grove_version
                     )
                 );
-                Ok(PathQueryRun::AxisEntries(entries)).wrap_with_cost(cost)
+                Ok(PathQueryRun::AxisEntries {
+                    entries,
+                    skipped: None,
+                })
+                .wrap_with_cost(cost)
             }
             AxisTraversal::RankOfKey { key } => {
                 let rank = cost_return_on_error!(
@@ -543,7 +582,7 @@ impl GroveDb {
     }
 
     /// TopK dispatch across the three axes, normalizing into
-    /// [`AxisEntries`].
+    /// [`AxisEntries`] plus the page's attested skipped count.
     #[allow(clippy::too_many_arguments)]
     fn axis_top_k_paginated_entries(
         &self,
@@ -554,10 +593,10 @@ impl GroveDb {
         descending: bool,
         transaction: TransactionArg,
         grove_version: &GroveVersion,
-    ) -> CostResult<AxisEntries, Error> {
+    ) -> CostResult<(AxisEntries, u64), Error> {
         let mut cost = Default::default();
-        let entries = match axis {
-            IndexAxis::Count => AxisEntries::Count(cost_return_on_error!(
+        let page = match axis {
+            IndexAxis::Count => cost_return_on_error!(
                 &mut cost,
                 self.indexed_count_top_k_paginated(
                     path,
@@ -567,9 +606,9 @@ impl GroveDb {
                     transaction,
                     grove_version
                 )
-                .map_ok(|page| page.entries)
-            )),
-            IndexAxis::Sum => AxisEntries::Sum(cost_return_on_error!(
+                .map_ok(|page| (AxisEntries::Count(page.entries), page.skipped))
+            ),
+            IndexAxis::Sum => cost_return_on_error!(
                 &mut cost,
                 self.indexed_sum_top_k_paginated(
                     path,
@@ -579,9 +618,9 @@ impl GroveDb {
                     transaction,
                     grove_version
                 )
-                .map_ok(|page| page.entries)
-            )),
-            IndexAxis::Avg => AxisEntries::Avg(cost_return_on_error!(
+                .map_ok(|page| (AxisEntries::Sum(page.entries), page.skipped))
+            ),
+            IndexAxis::Avg => cost_return_on_error!(
                 &mut cost,
                 self.indexed_avg_top_k_paginated(
                     path,
@@ -591,10 +630,10 @@ impl GroveDb {
                     transaction,
                     grove_version
                 )
-                .map_ok(|page| page.entries)
-            )),
+                .map_ok(|page| (AxisEntries::Avg(page.entries), page.skipped))
+            ),
         };
-        Ok(entries).wrap_with_cost(cost)
+        Ok(page).wrap_with_cost(cost)
     }
 
     /// Bounded dispatch across the three axes, clamping the `i128`
@@ -655,7 +694,8 @@ impl GroveDb {
 
 impl GroveDb {
     /// TopK dispatch across the three axes for the keys projection —
-    /// the `_keys` reads, which never open the primary.
+    /// the `_keys` reads, which never open the primary — plus the
+    /// page's attested skipped count.
     #[allow(clippy::too_many_arguments)]
     fn axis_top_k_paginated_keys(
         &self,
@@ -666,10 +706,10 @@ impl GroveDb {
         descending: bool,
         transaction: TransactionArg,
         grove_version: &GroveVersion,
-    ) -> CostResult<AxisKeys, Error> {
+    ) -> CostResult<(AxisKeys, u64), Error> {
         let mut cost = Default::default();
-        let keys = match axis {
-            IndexAxis::Count => AxisKeys::Count(cost_return_on_error!(
+        let page = match axis {
+            IndexAxis::Count => cost_return_on_error!(
                 &mut cost,
                 self.indexed_count_top_k_paginated_keys(
                     path,
@@ -679,9 +719,9 @@ impl GroveDb {
                     transaction,
                     grove_version
                 )
-                .map_ok(|page| page.entries)
-            )),
-            IndexAxis::Sum => AxisKeys::Sum(cost_return_on_error!(
+                .map_ok(|page| (AxisKeys::Count(page.entries), page.skipped))
+            ),
+            IndexAxis::Sum => cost_return_on_error!(
                 &mut cost,
                 self.indexed_sum_top_k_paginated_keys(
                     path,
@@ -691,9 +731,9 @@ impl GroveDb {
                     transaction,
                     grove_version
                 )
-                .map_ok(|page| page.entries)
-            )),
-            IndexAxis::Avg => AxisKeys::Avg(cost_return_on_error!(
+                .map_ok(|page| (AxisKeys::Sum(page.entries), page.skipped))
+            ),
+            IndexAxis::Avg => cost_return_on_error!(
                 &mut cost,
                 self.indexed_avg_top_k_paginated_keys(
                     path,
@@ -703,10 +743,10 @@ impl GroveDb {
                     transaction,
                     grove_version
                 )
-                .map_ok(|page| page.entries)
-            )),
+                .map_ok(|page| (AxisKeys::Avg(page.entries), page.skipped))
+            ),
         };
-        Ok(keys).wrap_with_cost(cost)
+        Ok(page).wrap_with_cost(cost)
     }
 
     /// Bounded dispatch across the three axes for the keys projection.

--- a/grovedb/src/tests/axis_read_projection_tests.rs
+++ b/grovedb/src/tests/axis_read_projection_tests.rs
@@ -109,14 +109,14 @@ mod tests {
 
     fn entries_of(run: PathQueryRun) -> AxisEntries {
         match run {
-            PathQueryRun::AxisEntries(e) => e,
+            PathQueryRun::AxisEntries { entries, .. } => entries,
             other => panic!("expected AxisEntries, got {other:?}"),
         }
     }
 
     fn keys_of(run: PathQueryRun) -> AxisKeys {
         match run {
-            PathQueryRun::AxisKeys(k) => k,
+            PathQueryRun::AxisKeys { keys, .. } => keys,
             other => panic!("expected AxisKeys, got {other:?}"),
         }
     }
@@ -139,23 +139,49 @@ mod tests {
                 for offset in [0u64, 2] {
                     let entries_q = AxisQuery::top_k(axis, 2, offset, descending);
                     let keys_q = entries_q.clone().keys_only();
-                    let entries = entries_of(run(&db, &PathQuery::new_axis(path(), entries_q), gv));
-                    let keys = keys_of(run(&db, &PathQuery::new_axis(path(), keys_q), gv));
+                    let PathQueryRun::AxisEntries {
+                        entries,
+                        skipped: entries_skipped,
+                    } = run(&db, &PathQuery::new_axis(path(), entries_q), gv)
+                    else {
+                        panic!("expected AxisEntries");
+                    };
+                    let PathQueryRun::AxisKeys {
+                        keys,
+                        skipped: keys_skipped,
+                    } = run(&db, &PathQuery::new_axis(path(), keys_q), gv)
+                    else {
+                        panic!("expected AxisKeys");
+                    };
                     assert_eq!(
                         keys,
                         entries.to_keys(),
                         "{axis:?} descending={descending} offset={offset}"
                     );
                     assert_eq!(keys.len(), entries.len());
+                    // The keys projection carries the same attested
+                    // skip as the entries read of the same page.
+                    assert_eq!(entries_skipped, Some(offset));
+                    assert_eq!(keys_skipped, Some(offset));
                 }
                 let entries_q = AxisQuery::bounded(axis, i128::MIN, i128::MAX, 3, descending);
                 let keys_q = entries_q.clone().keys_only();
                 let entries = entries_of(run(&db, &PathQuery::new_axis(path(), entries_q), gv));
-                let keys = keys_of(run(&db, &PathQuery::new_axis(path(), keys_q), gv));
+                let PathQueryRun::AxisKeys {
+                    keys,
+                    skipped: bounded_skipped,
+                } = run(&db, &PathQuery::new_axis(path(), keys_q), gv)
+                else {
+                    panic!("expected AxisKeys");
+                };
                 assert_eq!(
                     keys,
                     entries.to_keys(),
                     "{axis:?} bounded descending={descending}"
+                );
+                assert_eq!(
+                    bounded_skipped, None,
+                    "bounded traversals have no skip concept"
                 );
             }
         }

--- a/grovedb/src/tests/run_path_query_tests.rs
+++ b/grovedb/src/tests/run_path_query_tests.rs
@@ -206,8 +206,8 @@ mod tests {
                 .unwrap()
                 .expect("unified top-k");
             assert_eq!(
-                run_entries(run),
-                AxisEntries::Sum(direct.entries),
+                run_entries_and_skip(run),
+                (AxisEntries::Sum(direct.entries), Some(direct.skipped)),
                 "top-k k={k} offset={offset} descending={descending}"
             );
         }
@@ -246,7 +246,140 @@ mod tests {
             )
             .unwrap()
             .expect("unified bounded");
-        assert_eq!(run_entries(run), AxisEntries::Sum(direct));
+        assert_eq!(
+            run_entries_and_skip(run),
+            (AxisEntries::Sum(direct), None),
+            "bounded traversals have no skip concept"
+        );
+    }
+
+    /// The attested skip across the offset spectrum: at offset 0 the
+    /// skip is 0, at a mid-population offset it equals the offset, and
+    /// at or past the end the page is empty and `skipped` attests the
+    /// population. In every case the unified read returns exactly the
+    /// `(entries, skipped)` pair the direct primitive returns — for
+    /// both the entries and the keys projections — and the unproved
+    /// skip equals the proof-attested one.
+    #[test]
+    fn axis_top_k_skip_matches_direct_primitive_across_the_offset_spectrum() {
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+        build_psit(&db, grove_version, PSIT_ENTRIES);
+        let population = PSIT_ENTRIES.len() as u64;
+
+        for descending in [true, false] {
+            // offset 0 (full page), mid-population, exactly the end,
+            // and past the end (both end cases: empty page, skipped =
+            // population).
+            for offset in [0u64, 3, population, population + 3] {
+                let k = 3u16;
+
+                // Entries projection against the direct primitive.
+                let direct = db
+                    .indexed_sum_top_k_paginated(
+                        [TEST_LEAF, b"psit"].as_ref(),
+                        k,
+                        offset,
+                        descending,
+                        None,
+                        grove_version,
+                    )
+                    .unwrap()
+                    .expect("direct top-k");
+                if offset >= population {
+                    assert!(direct.entries.is_empty(), "offset {offset} is past the end");
+                    assert_eq!(
+                        direct.skipped, population,
+                        "the empty page's skip attests the population"
+                    );
+                } else {
+                    assert_eq!(direct.skipped, offset);
+                }
+                let entries_pq =
+                    PathQuery::new_axis_top_k(psit_path(), IndexAxis::Sum, k, offset, descending);
+                let run = db
+                    .run_path_query(
+                        &entries_pq,
+                        true,
+                        true,
+                        true,
+                        QueryResultType::QueryKeyElementPairResultType,
+                        None,
+                        grove_version,
+                    )
+                    .unwrap()
+                    .expect("unified top-k");
+                assert_eq!(
+                    run_entries_and_skip(run),
+                    (
+                        AxisEntries::Sum(direct.entries.clone()),
+                        Some(direct.skipped)
+                    ),
+                    "entries: offset={offset} descending={descending}"
+                );
+
+                // Keys projection against its direct primitive.
+                let direct_keys = db
+                    .indexed_sum_top_k_paginated_keys(
+                        [TEST_LEAF, b"psit"].as_ref(),
+                        k,
+                        offset,
+                        descending,
+                        None,
+                        grove_version,
+                    )
+                    .unwrap()
+                    .expect("direct top-k keys");
+                assert_eq!(direct_keys.skipped, direct.skipped);
+                let keys_pq = PathQuery::new_axis(
+                    psit_path(),
+                    AxisQuery::top_k(IndexAxis::Sum, k, offset, descending).keys_only(),
+                );
+                let run = db
+                    .run_path_query(
+                        &keys_pq,
+                        true,
+                        true,
+                        true,
+                        QueryResultType::QueryKeyElementPairResultType,
+                        None,
+                        grove_version,
+                    )
+                    .unwrap()
+                    .expect("unified top-k keys");
+                match run {
+                    PathQueryRun::AxisKeys { keys, skipped } => {
+                        assert_eq!(
+                            (keys, skipped),
+                            (
+                                crate::query_result_type::AxisKeys::Sum(direct_keys.entries),
+                                Some(direct_keys.skipped)
+                            ),
+                            "keys: offset={offset} descending={descending}"
+                        );
+                    }
+                    other => panic!("expected AxisKeys, got {other:?}"),
+                }
+
+                // The unproved skip mirrors the proof-attested one.
+                let proof = db
+                    .prove_query(&entries_pq, None, grove_version)
+                    .unwrap()
+                    .expect("prove top-k");
+                let crate::operations::proof::VerifiedPathQuery::AxisEntries {
+                    skipped: verified_skipped,
+                    ..
+                } = GroveDb::verify_path_query(&proof, &entries_pq, grove_version).expect("verify")
+                else {
+                    panic!("expected verified AxisEntries");
+                };
+                assert_eq!(
+                    verified_skipped,
+                    Some(direct.skipped),
+                    "verified skip: offset={offset} descending={descending}"
+                );
+            }
+        }
     }
 
     #[test]
@@ -839,7 +972,10 @@ mod tests {
             )
             .unwrap()
             .expect("unified count top-k");
-        assert_eq!(run_entries(run), AxisEntries::Count(direct.entries));
+        assert_eq!(
+            run_entries_and_skip(run),
+            (AxisEntries::Count(direct.entries), Some(direct.skipped))
+        );
 
         // Bounded on the count axis, with bounds deliberately below and
         // above the u64 domain so the count clamp is exercised (the sum
@@ -867,7 +1003,10 @@ mod tests {
             )
             .unwrap()
             .expect("unified count bounded");
-        assert_eq!(run_entries(run), AxisEntries::Count(direct));
+        assert_eq!(
+            run_entries_and_skip(run),
+            (AxisEntries::Count(direct), None)
+        );
 
         // Aggregate over the value range on the count axis.
         let direct = db
@@ -946,7 +1085,10 @@ mod tests {
             )
             .unwrap()
             .expect("unified avg top-k");
-        assert_eq!(run_entries(run), AxisEntries::Avg(direct.entries));
+        assert_eq!(
+            run_entries_and_skip(run),
+            (AxisEntries::Avg(direct.entries), Some(direct.skipped))
+        );
 
         // Bounded on the avg axis takes the i128 bounds unclamped — the
         // avg domain is the whole i128 range.
@@ -981,7 +1123,7 @@ mod tests {
             )
             .unwrap()
             .expect("unified avg bounded");
-        assert_eq!(run_entries(run), AxisEntries::Avg(direct));
+        assert_eq!(run_entries_and_skip(run), (AxisEntries::Avg(direct), None));
     }
 
     // -----------------------------------------------------------------
@@ -1582,8 +1724,12 @@ mod tests {
     // -----------------------------------------------------------------
 
     fn run_entries(run: PathQueryRun) -> AxisEntries {
+        run_entries_and_skip(run).0
+    }
+
+    fn run_entries_and_skip(run: PathQueryRun) -> (AxisEntries, Option<u64>) {
         match run {
-            PathQueryRun::AxisEntries(entries) => entries,
+            PathQueryRun::AxisEntries { entries, skipped } => (entries, skipped),
             other => panic!("expected AxisEntries, got {other:?}"),
         }
     }


### PR DESCRIPTION
Closes #834.

Platform wants to route all ranked / having-range document queries — single-prefix included — through the unified `PathQuery` surface, retiring the direct `indexed_*` call sites in its executors. The one capability gap: the unproved unified read dropped the count-commitment-attested skip that the direct paginated primitives and the proved side (`VerifiedPathQuery::AxisEntries`) both carry.

## The change

The two single-path axis variants of `PathQueryRun` now carry the skip alongside the page:

- `PathQueryRun::AxisEntries { entries, skipped: Option<u64> }`
- `PathQueryRun::AxisKeys { keys, skipped: Option<u64> }`

`Some(n)` for `AxisTraversal::RankedPage` traversals — threaded straight from the `IndexedTopKPage` / `IndexedTopKKeysPage` the direct primitives return, so it is derived from the counted subtree commitments exactly as `indexed_*_top_k_paginated*` derives it: equal to the requested offset on a full page, smaller when the walk exhausted the secondary (an offset at or past the end returns an empty page whose `skipped` attests the population). `None` for `Bounded` traversals (no skip concept), mirroring the proved side's contract.

The **branched** variants stay unchanged: a non-zero offset is rejected together with branching upstream, so a branched read's skip is structurally zero and a per-branch skip carries no meaning for the merged union; the branched arm explicitly discards the page's skip with a comment saying so.

Breaking change to `PathQueryRun` — V4-era API with no released consumers; in-tree callers and dashpay/platform adapt at the pin bump.

## Tests

- New `axis_top_k_skip_matches_direct_primitive_across_the_offset_spectrum`: for both directions and both projections (entries + keys), across offset 0, mid-population, exactly-the-end, and past-the-end, the unified read returns the identical `(entries, skipped)` pair as the direct primitive, and the unproved skip equals the proof-attested `VerifiedPathQuery::AxisEntries` skip.
- Existing differential tests extended to assert the skip on every top-k arm (`Some(direct.skipped)`) and `None` on every bounded arm, on all three axes.
- The keys-vs-entries projection conformance test now also pins the keys projection to the same attested skip as the entries read.
- Book chapter (`unified-path-query.md`) documents the contract.

Full suite: 2922 passed, 0 failed (`cargo nextest run -p grovedb --all-features`); clippy (CI invocation) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Paginated single-path axis reads now report the number of skipped entries alongside ranked results.
  * Skip counts accurately reflect requested offsets, including offsets beyond available entries.
  * Entry and key projections provide consistent pagination metadata.
* **Behavior Updates**
  * Bounded reads do not include skip counts.
  * Branched reads omit skip counts where no single aggregate value is meaningful.
* **Documentation**
  * Added guidance describing skip-count attestation for paginated axis reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->