### PR TITLE
feat: rebill secondary-mirror re-key churn as replaced bytes

### DIFF
--- a/grovedb/src/batch/indexed_tree/mirror.rs
+++ b/grovedb/src/batch/indexed_tree/mirror.rs
@@ -78,7 +78,60 @@ pub(crate) fn read_post_apply_transitions<'db, S: StorageContext<'db>>(
     Ok(transitions).wrap_with_cost(cost)
 }
 
-/// Assemble one axis's secondary row moves into a sorted Merk batch.
+/// The varint-encoded length of `n` — the same measure
+/// `integer_encoding::VarInt::required_space` gives, hand-rolled so the
+/// core build does not depend on the feature-gated crate.
+fn varint_len(n: u32) -> u32 {
+    match n {
+        0..=0x7F => 1,
+        0x80..=0x3FFF => 2,
+        0x4000..=0x1F_FFFF => 3,
+        0x20_0000..=0xFFF_FFFF => 4,
+        _ => 5,
+    }
+}
+
+/// The charged storage bytes of one secondary row, as the two op paths
+/// account them: the value side is the specialized value cost — exactly
+/// what the delete's `old_specialized_cost` reports as removed and what
+/// the put reports as added — and the key side is the prefixed-key
+/// measure both the merk delete arm and the storage batch's put use
+/// (`HASH_LENGTH + key_len`, varint-framed).
+fn charged_row_bytes(
+    secondary_key: &[u8],
+    row: &Element,
+    secondary_tree_type: grovedb_merk::TreeType,
+    grove_version: &GroveVersion,
+) -> Result<u32, Error> {
+    let serialized = row.serialize(grove_version).map_err(|e| {
+        Error::CorruptedData(format!("indexed mirror churn row serialization: {e}"))
+    })?;
+    let value_cost = Element::specialized_costs_for_key_value(
+        secondary_key,
+        &serialized,
+        secondary_tree_type.inner_node_type(),
+        grove_version,
+    )
+    .map_err(|e| Error::CorruptedData(format!("indexed mirror churn value cost: {e}")))?;
+    let prefixed_key_len = grovedb_merk::HASH_LENGTH_U32 + secondary_key.len() as u32;
+    let key_cost = prefixed_key_len + varint_len(prefixed_key_len);
+    Ok(value_cost + key_cost)
+}
+
+/// Assemble one axis's secondary row moves into a sorted Merk batch, plus
+/// the batch's re-key CHURN: for every row that MOVES (old and new rows
+/// both exist, on different sort keys), the smaller of the two rows'
+/// charged bytes. The raw accounting of a move is a full removal plus a
+/// full addition; the churn is the portion of that which is logically an
+/// update — [`apply_indexed_secondary_mirror_post_apply`] surfaces it so
+/// batch-commit cost assembly can rebill it as `replaced_bytes`.
+/// (Unconditional: the indexed-tree family has never shipped in a
+/// released version, so there is no historical accounting to preserve —
+/// the same in-place rule the rest of this machinery follows.)
+/// Taking the min of element-level measures
+/// keeps the churn a conservative lower bound on both lanes' real
+/// contributions (which additionally carry AVL link overhead), so the
+/// later reclassification can never underflow either lane.
 ///
 /// Each transition is compared as this axis's `(key, row, target hash)`
 /// rather than the raw aggregates: on the avg axis two different
@@ -91,14 +144,16 @@ pub(crate) fn read_post_apply_transitions<'db, S: StorageContext<'db>>(
 /// representation buys: a value-only primary update — and equally a deep
 /// mutation that only changes a child subtree's root, or a
 /// `RefreshReference` on a reference-shaped primary — now rewrites every
-/// configured axis's row.
+/// configured axis's row. (A fixed-key rewrite is a plain put, already in
+/// the replaced lane — it contributes no churn here.)
 fn build_axis_mirror_batch(
     transitions: &[AggregateTransition],
     axis: IndexAxis,
     grove_version: &GroveVersion,
-) -> CostResult<Vec<BatchEntry<Vec<u8>>>, Error> {
+) -> CostResult<(Vec<BatchEntry<Vec<u8>>>, u32), Error> {
     let mut cost = OperationCost::default();
     let secondary_tree_type = crate::operations::indexed_tree::axis_secondary_tree_type(axis);
+    let mut rekey_churn_bytes: u32 = 0;
     let mut secondary_batch: Vec<BatchEntry<Vec<u8>>> = Vec::with_capacity(transitions.len() * 2);
     for (key, old_state, new_state) in transitions {
         let entry_for = |state: &MaybeEntryState| -> Result<_, Error> {
@@ -125,9 +180,30 @@ fn build_axis_mirror_batch(
         // failing the whole GroveDB batch. Where the key is unchanged the put
         // alone overwrites the payload, which is what the row needs.
         let new_secondary_key_ref = new_entry.as_ref().map(|(key, ..)| key);
-        if let Some((old_secondary_key, ..)) = &old_entry
+        if let Some((old_secondary_key, old_row, _)) = &old_entry
             && Some(old_secondary_key) != new_secondary_key_ref
         {
+            if let Some((new_secondary_key, new_row, _)) = &new_entry {
+                let old_bytes = cost_return_on_error_no_add!(
+                    cost,
+                    charged_row_bytes(
+                        old_secondary_key,
+                        old_row,
+                        secondary_tree_type,
+                        grove_version
+                    )
+                );
+                let new_bytes = cost_return_on_error_no_add!(
+                    cost,
+                    charged_row_bytes(
+                        new_secondary_key,
+                        new_row,
+                        secondary_tree_type,
+                        grove_version
+                    )
+                );
+                rekey_churn_bytes = rekey_churn_bytes.saturating_add(old_bytes.min(new_bytes));
+            }
             cost_return_on_error!(
                 &mut cost,
                 Element::delete_into_batch_operations(
@@ -169,14 +245,16 @@ fn build_axis_mirror_batch(
         }
     }
     secondary_batch.sort_by(|a, b| a.0.cmp(&b.0));
-    Ok(secondary_batch).wrap_with_cost(cost)
+    Ok((secondary_batch, rekey_churn_bytes)).wrap_with_cost(cost)
 }
 
 /// Apply one axis's secondary-mirror update for every captured transition,
 /// after the primary merk's batch ops have been applied. Returns that axis
 /// secondary's post-mirror `(root_hash, root_key)` so the caller can fold it
 /// into the parent's H1-A composition — directly for the single-axis
-/// variants, or through `axes_digest` for PCPSIT.
+/// variants, or through `axes_digest` for PCPSIT — plus the batch's re-key
+/// churn bytes (see [`build_axis_mirror_batch`]), which the caller
+/// accumulates for the commit-time cost reclassification.
 ///
 /// Call once per configured axis, with the SAME transitions slice from one
 /// [`read_post_apply_transitions`] call. Each axis derives its own sort key
@@ -195,14 +273,14 @@ pub(crate) fn apply_indexed_secondary_mirror_post_apply<'db, S: StorageContext<'
     axis: IndexAxis,
     secondary_merk: &mut Merk<S>,
     grove_version: &GroveVersion,
-) -> CostResult<(CryptoHash, Option<Vec<u8>>), Error> {
+) -> CostResult<(CryptoHash, Option<Vec<u8>>, u32), Error> {
     let mut cost = OperationCost::default();
 
     cost_return_on_error_no_add!(
         cost,
         enforce_axis_item_key_bound(transitions.iter().map(|(key, ..)| key), axis)
     );
-    let secondary_batch = cost_return_on_error!(
+    let (secondary_batch, rekey_churn_bytes) = cost_return_on_error!(
         &mut cost,
         build_axis_mirror_batch(transitions, axis, grove_version)
     );
@@ -239,5 +317,5 @@ pub(crate) fn apply_indexed_secondary_mirror_post_apply<'db, S: StorageContext<'
                 "indexed secondary root hash capture after mirror: {e}"
             )))
     );
-    Ok((sec_hash, sec_root_key)).wrap_with_cost(cost)
+    Ok((sec_hash, sec_root_key, rekey_churn_bytes)).wrap_with_cost(cost)
 }

--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -1552,6 +1552,12 @@ struct TreeCacheMerkByPath<S, F, F2> {
     /// `apply_batch`'s post-apply phase to select cleanup namespaces from
     /// what was really stored rather than what the op declared.
     deleted_tree_actual_types: Vec<(Vec<Vec<u8>>, TreeType)>,
+    /// Total secondary-mirror re-key churn bytes accumulated across every
+    /// indexed primary this apply mirrored. Consumed by `apply_batch`'s
+    /// commit-time cost assembly, which rebills this many bytes out of the
+    /// added and unattributed-removal lanes into `replaced_bytes` — a row
+    /// move is physically a delete plus an insert but logically an update.
+    indexed_mirror_rekey_churn_bytes: u32,
 }
 
 impl<S, F, F2> fmt::Debug for TreeCacheMerkByPath<S, F, F2> {
@@ -1573,6 +1579,79 @@ struct BatchApplyCaptures {
     /// target that was really deleted; cleanup namespaces are selected from
     /// the actual type, not the declared one.
     deleted_tree_actual_types: Vec<(Vec<Vec<u8>>, TreeType)>,
+    /// Total secondary-mirror re-key churn bytes; rebilled as
+    /// `replaced_bytes` at commit-time cost assembly.
+    indexed_mirror_rekey_churn_bytes: u32,
+}
+
+/// Rebill secondary-mirror re-key churn as the update it logically is.
+///
+/// A mirrored row MOVE is physically a delete at the old sort key plus an
+/// insert at the new one, so the raw commit accounting reports the old
+/// row's bytes as removed and the new row's as added — perpetual-storage
+/// price for churn that does not grow the store, with the removal
+/// unattributable (mirror rows carry no flags, so it lands in the
+/// unattributed lane: `BasicStorageRemoval`, or the
+/// `(Identifier::default(), UNKNOWN_EPOCH)` bucket once merged into a
+/// sectioned removal). This moves `churn_bytes` out of both lanes into
+/// `replaced_bytes`.
+///
+/// `churn_bytes` is a per-pair min of element-level charged sizes (see
+/// `build_axis_mirror_batch`), a conservative lower bound on both lanes'
+/// real contributions — and the caps below make the subtraction safe even
+/// if that ever ceased to hold: nothing is rebilled that the lanes cannot
+/// cover, and flagged (refundable) removal buckets are never touched.
+pub(crate) fn reclassify_indexed_mirror_rekey_churn(
+    storage_cost: &mut StorageCost,
+    churn_bytes: u32,
+) {
+    use grovedb_costs::storage_cost::removal::{Identifier, StorageRemovedBytes::*, UNKNOWN_EPOCH};
+    if churn_bytes == 0 {
+        return;
+    }
+    let unattributed_removal = match &storage_cost.removed_bytes {
+        NoStorageRemoval => 0,
+        BasicStorageRemoval(bytes) => *bytes,
+        SectionedStorageRemoval(by_identifier) => by_identifier
+            .get(&Identifier::default())
+            .and_then(|by_epoch| by_epoch.get(UNKNOWN_EPOCH))
+            .copied()
+            .unwrap_or(0),
+    };
+    let net = churn_bytes
+        .min(storage_cost.added_bytes)
+        .min(unattributed_removal);
+    if net == 0 {
+        return;
+    }
+    storage_cost.added_bytes -= net;
+    storage_cost.replaced_bytes += net;
+    match &mut storage_cost.removed_bytes {
+        NoStorageRemoval => unreachable!("net is capped by the unattributed removal"),
+        BasicStorageRemoval(bytes) => {
+            *bytes -= net;
+            if *bytes == 0 {
+                storage_cost.removed_bytes = NoStorageRemoval;
+            }
+        }
+        SectionedStorageRemoval(by_identifier) => {
+            let identifier = Identifier::default();
+            if let Some(by_epoch) = by_identifier.get_mut(&identifier) {
+                let remaining = by_epoch.get(UNKNOWN_EPOCH).copied().unwrap_or(0) - net;
+                if remaining == 0 {
+                    by_epoch.remove(UNKNOWN_EPOCH);
+                } else {
+                    by_epoch.insert(UNKNOWN_EPOCH, remaining);
+                }
+                if by_epoch.is_empty() {
+                    by_identifier.remove(&identifier);
+                }
+            }
+            if by_identifier.is_empty() {
+                storage_cost.removed_bytes = NoStorageRemoval;
+            }
+        }
+    }
 }
 
 /// Result of the pre-apply `DeleteTree` scan shared by
@@ -1706,6 +1785,13 @@ trait TreeCache<G, SR> {
     /// type. Default impl returns an empty Vec.
     fn take_deleted_tree_actual_types(&mut self) -> Vec<(Vec<Vec<u8>>, TreeType)> {
         Vec::new()
+    }
+
+    /// After all level processing completes, `apply_batch` calls this to
+    /// retrieve the total secondary-mirror re-key churn bytes for the
+    /// commit-time cost reclassification. Default impl returns 0.
+    fn take_indexed_mirror_rekey_churn_bytes(&mut self) -> u32 {
+        0
     }
 }
 
@@ -2429,6 +2515,10 @@ where
 
     fn take_deleted_tree_actual_types(&mut self) -> Vec<(Vec<Vec<u8>>, TreeType)> {
         std::mem::take(&mut self.deleted_tree_actual_types)
+    }
+
+    fn take_indexed_mirror_rekey_churn_bytes(&mut self) -> u32 {
+        std::mem::take(&mut self.indexed_mirror_rekey_churn_bytes)
     }
 
     fn update_base_merk_root_key(
@@ -4073,7 +4163,7 @@ where
             );
             let mut per_axis = Vec::with_capacity(secondaries.len());
             for (axis, mut secondary_merk) in secondaries {
-                let (sec_hash, sec_root_key) = cost_return_on_error!(
+                let (sec_hash, sec_root_key, rekey_churn_bytes) = cost_return_on_error!(
                     &mut cost,
                     indexed_tree::apply_indexed_secondary_mirror_post_apply(
                         &transitions,
@@ -4082,6 +4172,9 @@ where
                         grove_version,
                     )
                 );
+                self.indexed_mirror_rekey_churn_bytes = self
+                    .indexed_mirror_rekey_churn_bytes
+                    .saturating_add(rekey_churn_bytes);
                 per_axis.push((axis.tag(), sec_hash, sec_root_key));
             }
             self.indexed_secondary_after_apply
@@ -4695,6 +4788,8 @@ impl GroveDb {
                     cidx_overwrite_cleanup_paths: merk_tree_cache
                         .take_cidx_overwrite_cleanup_paths(),
                     deleted_tree_actual_types: merk_tree_cache.take_deleted_tree_actual_types(),
+                    indexed_mirror_rekey_churn_bytes: merk_tree_cache
+                        .take_indexed_mirror_rekey_churn_bytes(),
                 };
                 return Ok((Some(ops_by_level_paths), captures)).wrap_with_cost(cost);
             }
@@ -4703,6 +4798,8 @@ impl GroveDb {
         let captures = BatchApplyCaptures {
             cidx_overwrite_cleanup_paths: merk_tree_cache.take_cidx_overwrite_cleanup_paths(),
             deleted_tree_actual_types: merk_tree_cache.take_deleted_tree_actual_types(),
+            indexed_mirror_rekey_churn_bytes: merk_tree_cache
+                .take_indexed_mirror_rekey_churn_bytes(),
         };
         Ok((None, captures)).wrap_with_cost(cost)
     }
@@ -4755,6 +4852,7 @@ impl GroveDb {
                     indexed_secondary_after_apply: Default::default(),
                     cidx_overwrite_cleanup_paths: Default::default(),
                     deleted_tree_actual_types: Default::default(),
+                    indexed_mirror_rekey_churn_bytes: 0,
                 },
                 grove_version
             )
@@ -4816,6 +4914,7 @@ impl GroveDb {
                     indexed_secondary_after_apply: Default::default(),
                     cidx_overwrite_cleanup_paths: Default::default(),
                     deleted_tree_actual_types: Default::default(),
+                    indexed_mirror_rekey_churn_bytes: 0,
                 },
                 grove_version
             )
@@ -5854,6 +5953,7 @@ impl GroveDb {
         let BatchApplyCaptures {
             cidx_overwrite_cleanup_paths,
             deleted_tree_actual_types,
+            indexed_mirror_rekey_churn_bytes,
         } = batch_apply_captures;
 
         // V4+: fold the `(path, ACTUAL stored type)` pairs captured during
@@ -6049,6 +6149,13 @@ impl GroveDb {
             self.db
                 .commit_multi_context_batch(storage_batch, Some(tx.as_ref()))
                 .map_err(|e| e.into())
+        );
+
+        // Rebill mirrored re-key churn as replaced bytes now that the
+        // commit has folded every op's storage cost into `cost`.
+        reclassify_indexed_mirror_rekey_churn(
+            &mut cost.storage_cost,
+            indexed_mirror_rekey_churn_bytes,
         );
 
         // Keep this commented for easy debugging in the future.
@@ -6352,10 +6459,12 @@ impl GroveDb {
         let BatchApplyCaptures {
             cidx_overwrite_cleanup_paths: partial_cidx_overwrite_cleanup_paths,
             deleted_tree_actual_types: partial_deleted_tree_actual_types,
+            indexed_mirror_rekey_churn_bytes: partial_rekey_churn_bytes,
         } = partial_captures;
         let BatchApplyCaptures {
             cidx_overwrite_cleanup_paths: continue_cidx_overwrite_cleanup_paths,
             deleted_tree_actual_types: continue_deleted_tree_actual_types,
+            indexed_mirror_rekey_churn_bytes: continue_rekey_churn_bytes,
         } = continue_captures;
 
         // V4+: fold captures from BOTH applies into the cleanup lists
@@ -6556,6 +6665,13 @@ impl GroveDb {
             self.db
                 .commit_db_write_batch(write_batch, pending_costs, Some(tx.as_ref()))
                 .map_err(|e| e.into())
+        );
+
+        // Rebill mirrored re-key churn from BOTH applies as replaced bytes
+        // (see apply_batch_with_element_flags_update).
+        reclassify_indexed_mirror_rekey_churn(
+            &mut cost.storage_cost,
+            partial_rekey_churn_bytes.saturating_add(continue_rekey_churn_bytes),
         );
 
         tx.commit_local().wrap_with_cost(cost)

--- a/grovedb/src/estimated_costs/average_case_costs.rs
+++ b/grovedb/src/estimated_costs/average_case_costs.rs
@@ -572,7 +572,11 @@ impl GroveDb {
                 max_size: secondary_key_size,
             };
             // The mirror is delete-old-row then insert-new-row, each of which
-            // rebalances and re-roots the secondary.
+            // rebalances and re-roots the secondary. (The ACTUAL commit
+            // accounting rebills a moved pair's churn out of added/removed
+            // into replaced; this estimate deliberately keeps the raw
+            // delete+insert shape, over-reserving `added_bytes` by up to
+            // the churn rather than ever coming in under.)
             //
             // The inserted row must be sized with the AXIS's real row shape:
             // `average_case_merk_insert_element` charges non-tree elements by

--- a/grovedb/src/tests/indexed_secondary_rekey_cost_tests.rs
+++ b/grovedb/src/tests/indexed_secondary_rekey_cost_tests.rs
@@ -183,6 +183,71 @@ mod tests {
         );
     }
 
+    #[test]
+    fn partial_batch_combines_both_segments_churn() {
+        // The partial flow accumulates churn from TWO applies — the initial
+        // segment and the continuation the add-on closure supplies — and
+        // reclassifies their sum at its single commit. Re-key one group in
+        // each segment: if either segment's churn were dropped, its old
+        // row's removal would survive into the final cost.
+        //
+        // Scoped to the COST LANES only: apply_partial_batch has a
+        // pre-existing state bug when both segments touch the same
+        // secondary (the initial segment's row deletion is resurrected by
+        // the continuation's rotation writes — see
+        // https://github.com/dashpay/grovedb/issues/842), so state-level
+        // assertions belong to that fix, not this accounting change.
+        let grove_version = GroveVersion::latest();
+
+        let db = setup_pcit_with_group(grove_version, 2);
+        db.insert_into_count_indexed_tree(
+            [TEST_LEAF, b"cidx"].as_ref(),
+            b"q",
+            Element::empty_count_tree(),
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert group q");
+        for i in 0..2u64 {
+            db.insert(
+                [TEST_LEAF, b"cidx", b"q"].as_ref(),
+                &i.to_be_bytes(),
+                Element::new_item(vec![]),
+                None,
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("populate group q");
+        }
+
+        let bump_op = |group: &[u8]| {
+            QualifiedGroveDbOp::insert_or_replace_op(
+                vec![TEST_LEAF.to_vec(), b"cidx".to_vec(), group.to_vec()],
+                2u64.to_be_bytes().to_vec(),
+                Element::new_item(vec![]),
+            )
+        };
+
+        let cost_result = db.apply_partial_batch(
+            vec![bump_op(b"p")],
+            Some(crate::batch::BatchApplyOptions::default()),
+            |_cost, _left_over_ops| Ok(vec![bump_op(b"q")]),
+            None,
+            grove_version,
+        );
+        let cost = cost_result.cost;
+        cost_result.value.expect("partial batch applies");
+
+        assert_eq!(
+            total_removed(&cost),
+            0,
+            "both segments' re-key churn must be rebilled at the one commit"
+        );
+        assert!(cost.storage_cost.replaced_bytes > 0);
+    }
+
     // -----------------------------------------------------------------
     // Unit: the reclassifier's lane handling
     // -----------------------------------------------------------------

--- a/grovedb/src/tests/indexed_secondary_rekey_cost_tests.rs
+++ b/grovedb/src/tests/indexed_secondary_rekey_cost_tests.rs
@@ -1,0 +1,263 @@
+//! Cost accounting for secondary-mirror re-keys.
+//!
+//! A mirrored row MOVE (a group's count changing re-keys its row from
+//! `(old_count ‖ key)` to `(new_count ‖ key)`) is physically a delete plus
+//! an insert, but bills as the update it logically is: the pair's churn is
+//! rebilled out of `added_bytes` and the unattributed removal lane into
+//! `replaced_bytes` at batch-commit cost assembly (the removal lane was
+//! unattributable anyway — mirror rows carry no flags, so nobody was ever
+//! refunded those bytes). Unconditional: the indexed-tree family has never
+//! shipped in a released version, so there is no historical accounting to
+//! preserve.
+//!
+//! The integration tests pin the intended absolute semantics — a pure
+//! re-key reports NO removal and steady-state re-keys accrete no added
+//! bytes — plus the negative space: a genuine drain (the group deleted)
+//! still reports its removal in full. The unit tests pin the
+//! reclassifier's lane handling, including that flagged (refundable)
+//! sectioned buckets are never touched.
+
+#[cfg(test)]
+mod tests {
+    use grovedb_costs::{
+        storage_cost::{
+            removal::{StorageRemovedBytes, UNKNOWN_EPOCH},
+            StorageCost,
+        },
+        OperationCost,
+    };
+    use grovedb_version::version::GroveVersion;
+    use intmap::IntMap;
+
+    use crate::{
+        batch::{
+            reclassify_indexed_mirror_rekey_churn, QualifiedGroveDbOp, SubelementsDeletionBehavior,
+        },
+        tests::{make_test_grovedb, TEST_LEAF},
+        Element,
+    };
+
+    fn total_removed(cost: &OperationCost) -> u64 {
+        cost.storage_cost.removed_bytes.total_removed_bytes() as u64
+    }
+
+    /// A PCIT at `[TEST_LEAF, "cidx"]` with one count-tree group `"p"`
+    /// holding `count` items — the steady pre-state a re-key needs.
+    fn setup_pcit_with_group(
+        grove_version: &GroveVersion,
+        count: u64,
+    ) -> crate::tests::TempGroveDb {
+        let db = make_test_grovedb(grove_version);
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"cidx",
+            Element::empty_provable_count_indexed_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert PCIT");
+        db.insert_into_count_indexed_tree(
+            [TEST_LEAF, b"cidx"].as_ref(),
+            b"p",
+            Element::empty_count_tree(),
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert group");
+        for i in 0..count {
+            db.insert(
+                [TEST_LEAF, b"cidx", b"p"].as_ref(),
+                &i.to_be_bytes(),
+                Element::new_item(vec![]),
+                None,
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("populate group");
+        }
+        db
+    }
+
+    /// Bump the group's count via one batch (the deep write bubbles up and
+    /// re-keys the mirror row), returning the batch's cost.
+    fn bump_group_count(
+        db: &crate::tests::TempGroveDb,
+        item: u64,
+        grove_version: &GroveVersion,
+    ) -> OperationCost {
+        let cost_result = db.apply_batch(
+            vec![QualifiedGroveDbOp::insert_or_replace_op(
+                vec![TEST_LEAF.to_vec(), b"cidx".to_vec(), b"p".to_vec()],
+                item.to_be_bytes().to_vec(),
+                Element::new_item(vec![]),
+            )],
+            None,
+            None,
+            grove_version,
+        );
+        let cost = cost_result.cost;
+        cost_result.value.expect("bump batch applies");
+        cost
+    }
+
+    // -----------------------------------------------------------------
+    // Integration: the intended absolute semantics through apply_batch
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn pure_rekey_reports_no_removal_and_carries_replaced() {
+        // Bumping an existing group's count moves its mirror row. The old
+        // and new rows have equal charged sizes (fixed-width sort key,
+        // same item key, same payload shape), the batch deletes nothing
+        // else, and the row carries no flags — so the ENTIRE removal is
+        // churn and must be rebilled: no removal survives, and the
+        // replaced lane carries at least the row.
+        let grove_version = GroveVersion::latest();
+        let db = setup_pcit_with_group(grove_version, 2);
+        let cost = bump_group_count(&db, 2, grove_version);
+
+        assert_eq!(
+            total_removed(&cost),
+            0,
+            "a pure re-key must report no storage removal"
+        );
+        assert!(
+            cost.storage_cost.replaced_bytes > 0,
+            "the moved row must land in the replaced lane"
+        );
+        let root_hash = db
+            .root_hash(None, grove_version)
+            .unwrap()
+            .expect("root hash");
+        assert_ne!(root_hash, [0u8; 32]);
+    }
+
+    #[test]
+    fn repeated_rekeys_stay_growth_free() {
+        // Steady state: after the first bump, every further bump moves the
+        // row again — none of that churn may accrete in the added lane, so
+        // consecutive bumps report identical added bytes and zero removal.
+        let grove_version = GroveVersion::latest();
+        let db = setup_pcit_with_group(grove_version, 2);
+        let first = bump_group_count(&db, 2, grove_version);
+        let second = bump_group_count(&db, 3, grove_version);
+
+        assert_eq!(total_removed(&first), 0);
+        assert_eq!(total_removed(&second), 0);
+        assert_eq!(
+            first.storage_cost.added_bytes, second.storage_cost.added_bytes,
+            "steady-state bumps must not accrete added bytes from the mirror"
+        );
+        assert!(second.storage_cost.replaced_bytes > 0);
+    }
+
+    #[test]
+    fn genuine_drain_still_reports_its_removal() {
+        // Deleting the group is a real drain — the mirror row goes away
+        // with nothing replacing it (old row, no new row: not a moved
+        // pair), so the reclassifier must leave the removal fully intact.
+        let grove_version = GroveVersion::latest();
+        let db = setup_pcit_with_group(grove_version, 2);
+
+        let cost_result = db.apply_batch(
+            vec![QualifiedGroveDbOp::delete_tree_op(
+                vec![TEST_LEAF.to_vec(), b"cidx".to_vec()],
+                b"p".to_vec(),
+                grovedb_merk::tree_type::TreeType::CountTree,
+                SubelementsDeletionBehavior::DeleteChildren,
+            )],
+            None,
+            None,
+            grove_version,
+        );
+        let cost = cost_result.cost;
+        cost_result.value.expect("drain batch applies");
+
+        assert!(
+            total_removed(&cost) > 0,
+            "a drain's removal must survive the reclassifier untouched"
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // Unit: the reclassifier's lane handling
+    // -----------------------------------------------------------------
+
+    fn cost_with(added: u32, replaced: u32, removed: StorageRemovedBytes) -> StorageCost {
+        StorageCost {
+            added_bytes: added,
+            replaced_bytes: replaced,
+            removed_bytes: removed,
+        }
+    }
+
+    #[test]
+    fn reclassifier_moves_churn_between_lanes_basic() {
+        let mut cost = cost_with(500, 40, StorageRemovedBytes::BasicStorageRemoval(120));
+        reclassify_indexed_mirror_rekey_churn(&mut cost, 100);
+        assert_eq!(cost.added_bytes, 400);
+        assert_eq!(cost.replaced_bytes, 140);
+        assert_eq!(
+            cost.removed_bytes,
+            StorageRemovedBytes::BasicStorageRemoval(20)
+        );
+    }
+
+    #[test]
+    fn reclassifier_caps_by_both_lanes_and_normalizes_empty_removal() {
+        // Churn larger than the lanes can cover: capped at min(added,
+        // removal) = 30; the emptied removal collapses to NoStorageRemoval.
+        let mut cost = cost_with(200, 0, StorageRemovedBytes::BasicStorageRemoval(30));
+        reclassify_indexed_mirror_rekey_churn(&mut cost, u32::MAX);
+        assert_eq!(cost.added_bytes, 170);
+        assert_eq!(cost.replaced_bytes, 30);
+        assert_eq!(cost.removed_bytes, StorageRemovedBytes::NoStorageRemoval);
+
+        // Zero churn and zero removal are both no-ops.
+        let mut untouched = cost_with(200, 10, StorageRemovedBytes::NoStorageRemoval);
+        reclassify_indexed_mirror_rekey_churn(&mut untouched, 50);
+        assert_eq!(
+            untouched,
+            cost_with(200, 10, StorageRemovedBytes::NoStorageRemoval)
+        );
+    }
+
+    #[test]
+    fn reclassifier_only_touches_the_unattributed_sectioned_bucket() {
+        // A sectioned removal mixing a flagged identity's refundable bytes
+        // with the unattributed bucket (where a mirror's BasicStorageRemoval
+        // lands when merged): only the unattributed bucket may be drawn
+        // down, and it is pruned when emptied.
+        let flagged_identity = [7u8; 32];
+        let mut by_identifier = std::collections::BTreeMap::new();
+        let mut flagged = IntMap::new();
+        flagged.insert(3u16, 400u32);
+        by_identifier.insert(flagged_identity, flagged);
+        let mut unattributed = IntMap::new();
+        unattributed.insert(UNKNOWN_EPOCH, 80u32);
+        by_identifier.insert([0u8; 32], unattributed);
+
+        let mut cost = cost_with(
+            1000,
+            0,
+            StorageRemovedBytes::SectionedStorageRemoval(by_identifier),
+        );
+        reclassify_indexed_mirror_rekey_churn(&mut cost, 300);
+
+        // Capped by the unattributed bucket (80), never the flagged 400.
+        assert_eq!(cost.added_bytes, 920);
+        assert_eq!(cost.replaced_bytes, 80);
+        let StorageRemovedBytes::SectionedStorageRemoval(rest) = &cost.removed_bytes else {
+            panic!("flagged removal must survive as sectioned");
+        };
+        assert!(!rest.contains_key(&[0u8; 32]), "emptied bucket is pruned");
+        assert_eq!(
+            rest.get(&flagged_identity).and_then(|m| m.get(3u16)),
+            Some(&400)
+        );
+    }
+}

--- a/grovedb/src/tests/mod.rs
+++ b/grovedb/src/tests/mod.rs
@@ -67,6 +67,7 @@ mod indexed_axis_offset_proof_tests;
 mod indexed_axis_paginated_cost_tests;
 mod indexed_axis_proof_tests;
 mod indexed_reference_row_tests;
+mod indexed_secondary_rekey_cost_tests;
 mod indexed_target_chain_tamper_tests;
 mod indexed_tree_secondary_drift_tests;
 mod indexed_tree_security_regression_tests;


### PR DESCRIPTION
## Issue being fixed or feature implemented

A mirrored row MOVE — a group's aggregate changing re-keys its secondary row from `(old_sort ‖ key)` to `(new_sort ‖ key)` — is physically a delete plus an insert, so commit accounting reports the old row's bytes as `removed_bytes` and the new row's as `added_bytes`. For fee models that bill added bytes at a perpetual-storage rate (Dash Platform: 27,000 credits/byte, vs 400 for replaced), every aggregate change pays full storage price for churn that does not grow the store. Worse, the removal side compensates nobody: mirror rows carry no element flags, and both mirror paths use `apply_with_specialized_costs`' default callbacks, so the removal is always an unattributed `BasicStorageRemoval` — burned, not refunded.

Measured downstream: on a Platform ranked (`ProvableCountIndexedTree`-backed) index this churn is a solid slice of the ~15M-credit-per-write marginal cost of each ranked axis.

## What was done?

- `build_axis_mirror_batch` computes each batch's **re-key churn**: for every row that moves (old and new rows both exist, on different sort keys), min(old, new) of the pair's element-level charged key + value bytes — the value side via `Element::specialized_costs_for_key_value` (exactly what the delete's `old_specialized_cost` reports removed and the put reports added), the key side via the shared prefixed-key measure. The min of element-level measures is a conservative lower bound on both lanes' real contributions (which also carry AVL link overhead), so the later subtraction can never underflow either lane. Fixed-key rewrites (already plain puts in the replaced lane), fresh rows, and genuine drains are not moved pairs and contribute nothing.
- The churn is threaded through `TreeCacheMerkByPath` and `BatchApplyCaptures` exactly like the existing capture fields, and rebilled at commit-time cost assembly in BOTH the full and partial batch flows: it leaves `added_bytes` and the **unattributed** removal lane (`BasicStorageRemoval`, or the `(Identifier::default(), UNKNOWN_EPOCH)` bucket of a sectioned removal — flagged, refundable buckets are never touched) and lands in `replaced_bytes`.
- **Unconditional — no version slot.** The indexed-tree family has never shipped in a released version (it landed on develop after GROVE_V4 was cut, and every one of its slots is 0 across V1..V4), so there is no historical accounting to preserve: the same in-place rule the rest of this machinery follows. Root hashes and stored state are identical either way; only the reported cost split changes.
- Average-case estimator unchanged by design — it keeps the raw delete+insert shape as a deliberate upper bound on `added_bytes` (a storage-fee reservation must never come in under); comments updated to say so. The worst-case estimator doesn't charge the mirror at all (documented gap, unchanged).
- Non-batch propagation (`mirror_indexed_axis_to_secondary`) keeps raw accounting: batch apply is the consensus write path, and the non-batch mirror's costs assemble per public op rather than at one commit point. Noted as a follow-up if any embedder bills non-batch indexed writes.

## How Has This Been Tested?

New `indexed_secondary_rekey_cost_tests` (6 tests):
- integration, absolute semantics through `apply_batch`: a count bump on an existing group reports **zero** storage removal with the replaced lane carrying the row; steady-state repeated bumps report identical added bytes and zero removal (the mirror no longer accretes storage-priced churn); and — the negative space — a genuine drain (`DeleteTree` of the group) still reports its removal in full, since a delete-only mirror has no moved pair;
- unit, the reclassifier's lane handling: basic-removal draw-down, capping by both lanes with empty-removal normalization, and that a sectioned removal's **flagged** buckets are never drawn down (only the unattributed `(Identifier::default(), UNKNOWN_EPOCH)` bucket, pruned when emptied).

Full `cargo test -p grovedb --all-features`: 2,931 passing. `cargo fmt` clean; clippy clean on the touched files.

## Breaking Changes

None — the affected element family is unreleased, state and root hashes are byte-identical, and only the cost split (added/replaced/removed) reported to the embedder changes.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)