### PR TITLE
fix: follow-ups from the per-instance limits reviews (#844/#845)

### DIFF
--- a/grovedb-query/Cargo.toml
+++ b/grovedb-query/Cargo.toml
@@ -28,6 +28,8 @@ grovedb-storage = { version = "5.0.1", path = "../storage", optional = true }
 assert_matches = { workspace = true }
 bincode = { workspace = true, features = ["serde"] }
 indexmap = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = "1.0"
 serde_test = "1.0"
 
 [features]

--- a/grovedb-query/src/query.rs
+++ b/grovedb-query/src/query.rs
@@ -936,21 +936,28 @@ mod tests {
 /// broke as fields were appended (`serde(default)` cannot turn EOF
 /// into an omitted field), and a self-describing reader from *before*
 /// a field silently ignored its unknown key — turning a bounded query
-/// into an unlimited one. This module mirrors the bincode codec's
-/// versioning instead:
+/// into an unlimited one, or a read-mode query into plain key
+/// selection. This module mirrors the bincode codec's versioning
+/// instead:
 ///
 /// - **Non-self-describing formats** (`!is_human_readable`, e.g.
-///   serde-bincode): a fixed layout with a leading `version` integer
-///   and every field always present, so the format round-trips and a
-///   reader from another generation fails at the layout instead of
-///   misreading.
+///   serde-bincode): a framed layout — a leading `MAGIC` sentinel,
+///   then a version integer, then every field always present. A
+///   plain `version: u8` alone would NOT fail closed: the released
+///   unframed layout begins with the `items` vector length, so a
+///   legacy reader would consume a small version byte as a length and
+///   reinterpret the remaining fields as query items. The magic
+///   decodes there as an absurd items length instead, which errors —
+///   and this reader requires the magic exactly, so released payloads
+///   error cleanly here too (positional layouts carry no
+///   self-description to migrate on).
 /// - **Self-describing formats** (`is_human_readable`, e.g. JSON):
-///   versions 1 and 2 keep the flat, pre-limit map layout (plus a
-///   `version` key old readers ignore), preserving interop for every
-///   query an old reader can serve. Version 3 — the limit-bearing
-///   form old readers *cannot* serve — nests its fields under a
-///   `body` key, so an old reader hard-fails on the missing flat
-///   fields instead of silently dropping the limit.
+///   version 1 — the only content the **released** derived layout can
+///   serve — keeps the flat map layout (plus a `version` key old
+///   readers ignore). Versions 2 and 3 (read-mode- and limit-bearing
+///   forms) nest their fields under a `body` key, so an old reader
+///   hard-fails on the missing flat fields instead of silently
+///   dropping the read mode or the limit.
 ///
 /// Decoding validates canonicality exactly like bincode: the version
 /// must be the lowest that can represent the contents.
@@ -988,9 +995,17 @@ mod query_serde {
         Ok(())
     }
 
-    /// Fixed positional layout — every field always present.
+    /// The positional frame sentinel. Chosen so a legacy unframed
+    /// reader, which decodes the leading bytes as its `items` vector
+    /// length, sees an absurd length and errors instead of
+    /// reinterpreting the payload.
+    const POSITIONAL_MAGIC: u64 = u64::from_be_bytes(*b"grvquery");
+
+    /// Framed positional layout — magic, version, then every field
+    /// always present.
     #[derive(Serialize)]
     struct PositionalRef<'a> {
+        magic: u64,
         version: u8,
         items: &'a Vec<QueryItem>,
         default_subquery_branch: &'a SubqueryBranch,
@@ -1004,6 +1019,7 @@ mod query_serde {
     #[derive(Deserialize)]
     #[serde(rename = "Query")]
     struct PositionalOwned {
+        magic: u64,
         version: u8,
         items: Vec<QueryItem>,
         default_subquery_branch: SubqueryBranch,
@@ -1014,7 +1030,8 @@ mod query_serde {
         limit: Option<u16>,
     }
 
-    /// The nested body of the human-readable version-3 form.
+    /// The nested body of the human-readable version-2 and version-3
+    /// forms.
     #[derive(Serialize, Deserialize)]
     struct BodyOwned {
         items: Vec<QueryItem>,
@@ -1023,7 +1040,7 @@ mod query_serde {
         left_to_right: bool,
         add_parent_tree_on_subquery: bool,
         read_mode: Option<Box<ReadMode>>,
-        limit: u16,
+        limit: Option<u16>,
     }
 
     #[derive(Serialize)]
@@ -1034,7 +1051,7 @@ mod query_serde {
         left_to_right: bool,
         add_parent_tree_on_subquery: bool,
         read_mode: &'a Option<Box<ReadMode>>,
-        limit: u16,
+        limit: &'a Option<u16>,
     }
 
     impl Serialize for Query {
@@ -1042,6 +1059,7 @@ mod query_serde {
             let version = wire_version(self.read_mode.is_some(), self.limit.is_some());
             if !serializer.is_human_readable() {
                 return PositionalRef {
+                    magic: POSITIONAL_MAGIC,
                     version,
                     items: &self.items,
                     default_subquery_branch: &self.default_subquery_branch,
@@ -1055,7 +1073,11 @@ mod query_serde {
             }
             use serde::ser::SerializeStruct;
             match version {
-                3 => {
+                2 | 3 => {
+                    // Both non-released forms nest: the released
+                    // derived reader ignores unknown flat keys, so
+                    // either feature would silently vanish in a flat
+                    // map.
                     let mut state = serializer.serialize_struct("Query", 2)?;
                     state.serialize_field("version", &version)?;
                     state.serialize_field(
@@ -1067,29 +1089,9 @@ mod query_serde {
                             left_to_right: self.left_to_right,
                             add_parent_tree_on_subquery: self.add_parent_tree_on_subquery,
                             read_mode: &self.read_mode,
-                            limit: self.limit.expect("version 3 iff limit is present"),
+                            limit: &self.limit,
                         },
                     )?;
-                    state.end()
-                }
-                2 => {
-                    let mut state = serializer.serialize_struct("Query", 7)?;
-                    state.serialize_field("version", &version)?;
-                    state.serialize_field("items", &self.items)?;
-                    state.serialize_field(
-                        "default_subquery_branch",
-                        &self.default_subquery_branch,
-                    )?;
-                    state.serialize_field(
-                        "conditional_subquery_branches",
-                        &self.conditional_subquery_branches,
-                    )?;
-                    state.serialize_field("left_to_right", &self.left_to_right)?;
-                    state.serialize_field(
-                        "add_parent_tree_on_subquery",
-                        &self.add_parent_tree_on_subquery,
-                    )?;
-                    state.serialize_field("read_mode", &self.read_mode)?;
                     state.end()
                 }
                 _ => {
@@ -1181,11 +1183,20 @@ mod query_serde {
                     || read_mode.is_some()
                 {
                     return Err(de::Error::custom(
-                        "a version-3 Query nests every field under `body`; flat fields may \
-                         not accompany it",
+                        "a version-2 or version-3 Query nests every field under `body`; flat \
+                         fields may not accompany it",
                     ));
                 }
-                validate_canonical::<A::Error>(version, body.read_mode.is_some(), true)?;
+                validate_canonical::<A::Error>(
+                    version,
+                    body.read_mode.is_some(),
+                    body.limit.is_some(),
+                )?;
+                if version < 2 {
+                    return Err(de::Error::custom(
+                        "a nested Query body requires version 2 or 3",
+                    ));
+                }
                 return Ok(Query {
                     items: body.items,
                     default_subquery_branch: body.default_subquery_branch,
@@ -1193,15 +1204,29 @@ mod query_serde {
                     left_to_right: body.left_to_right,
                     add_parent_tree_on_subquery: body.add_parent_tree_on_subquery,
                     read_mode: body.read_mode,
-                    limit: Some(body.limit),
+                    limit: body.limit,
                 });
             }
 
+            // The flat layout carries neither a read mode nor a limit
+            // (both bump the query to the nested form); a `read_mode`
+            // key in a flat map is refused rather than accepted, since
+            // the released reader would drop it silently and the two
+            // generations must not diverge on the same payload. A
+            // missing `version` key is the released pre-versioning
+            // layout — accepted for compatibility.
+            if read_mode
+                .as_ref()
+                .is_some_and(|read_mode| read_mode.is_some())
+            {
+                return Err(de::Error::custom(
+                    "a flat Query map may not carry a read mode; read-mode queries nest under \
+                     `body` (version 2)",
+                ));
+            }
             let read_mode = read_mode.unwrap_or(None);
-            // A missing `version` key is the pre-versioning flat layout
-            // — accepted for compatibility; it can never carry a limit.
             if let Some(version) = version {
-                validate_canonical::<A::Error>(version, read_mode.is_some(), false)?;
+                validate_canonical::<A::Error>(version, false, false)?;
             }
             Ok(Query {
                 items: items.ok_or_else(|| de::Error::missing_field("items"))?,
@@ -1222,6 +1247,12 @@ mod query_serde {
         fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Query, D::Error> {
             if !deserializer.is_human_readable() {
                 let wire = PositionalOwned::deserialize(deserializer)?;
+                if wire.magic != POSITIONAL_MAGIC {
+                    return Err(de::Error::custom(
+                        "positional Query payload does not carry the framed layout's magic \
+                         sentinel",
+                    ));
+                }
                 validate_canonical::<D::Error>(
                     wire.version,
                     wire.read_mode.is_some(),

--- a/grovedb-query/src/query.rs
+++ b/grovedb-query/src/query.rs
@@ -12,7 +12,6 @@ use crate::{query_item::QueryItem, Key, Path, ReadMode, SubqueryBranch};
 /// `Query` represents one or more keys or ranges of keys, which can be used to
 /// resolve a proof which will include all the requested values.
 #[derive(Debug, Default, Clone, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Query {
     /// Items
     pub items: Vec<QueryItem>,
@@ -68,14 +67,9 @@ pub struct Query {
     /// engine does constantly. It is invisible on the wire and in
     /// serde: `Box<T>` encodes exactly as `T`.
     ///
-    /// Serde note: the field is always serialized (as an `Option`), so
-    /// positional, non-self-describing serde formats round-trip; only
-    /// *deserialization* tolerates its absence (`default`), which is
-    /// what keeps pre-field self-describing payloads (JSON without the
-    /// key) decodable. `skip_serializing_if` must NOT be added here —
-    /// a skipped field has no presence tag in positional formats, so
-    /// every field after it shifts and the payload decodes wrongly.
-    #[cfg_attr(feature = "serde", serde(default))]
+    /// Serde: see the `query_serde` module — the representation is
+    /// versioned and hand-written, mirroring the bincode codec's
+    /// fail-closed rules across format generations.
     pub read_mode: Option<Box<ReadMode>>,
     /// Per-instance result limit for this query node.
     ///
@@ -104,10 +98,7 @@ pub struct Query {
     /// limit anywhere encodes that node as version 3, which decoders
     /// that predate the field reject.
     ///
-    /// Serde note: always serialized, absence tolerated only on
-    /// deserialization — see [`read_mode`](Self::read_mode) for why
-    /// `skip_serializing_if` must not be added.
-    #[cfg_attr(feature = "serde", serde(default))]
+    /// Serde: see the `query_serde` module.
     pub limit: Option<u16>,
 }
 
@@ -935,5 +926,318 @@ mod tests {
             current.default_subquery_branch.subquery.is_none(),
             "innermost query should have no further subquery"
         );
+    }
+}
+
+/// Versioned serde representation for [`Query`].
+///
+/// The derived representation was unsafe across code generations in
+/// both directions: a positional (non-self-describing) serializer
+/// broke as fields were appended (`serde(default)` cannot turn EOF
+/// into an omitted field), and a self-describing reader from *before*
+/// a field silently ignored its unknown key — turning a bounded query
+/// into an unlimited one. This module mirrors the bincode codec's
+/// versioning instead:
+///
+/// - **Non-self-describing formats** (`!is_human_readable`, e.g.
+///   serde-bincode): a fixed layout with a leading `version` integer
+///   and every field always present, so the format round-trips and a
+///   reader from another generation fails at the layout instead of
+///   misreading.
+/// - **Self-describing formats** (`is_human_readable`, e.g. JSON):
+///   versions 1 and 2 keep the flat, pre-limit map layout (plus a
+///   `version` key old readers ignore), preserving interop for every
+///   query an old reader can serve. Version 3 — the limit-bearing
+///   form old readers *cannot* serve — nests its fields under a
+///   `body` key, so an old reader hard-fails on the missing flat
+///   fields instead of silently dropping the limit.
+///
+/// Decoding validates canonicality exactly like bincode: the version
+/// must be the lowest that can represent the contents.
+#[cfg(feature = "serde")]
+mod query_serde {
+    use std::fmt;
+
+    use serde::{
+        de::{self, MapAccess, Visitor},
+        Deserialize, Deserializer, Serialize, Serializer,
+    };
+
+    use super::*;
+
+    fn wire_version(read_mode: bool, limit: bool) -> u8 {
+        match (read_mode, limit) {
+            (_, true) => 3,
+            (true, false) => 2,
+            (false, false) => 1,
+        }
+    }
+
+    fn validate_canonical<E: de::Error>(
+        version: u8,
+        read_mode: bool,
+        limit: bool,
+    ) -> Result<(), E> {
+        let expected = wire_version(read_mode, limit);
+        if version != expected {
+            return Err(E::custom(format!(
+                "non-canonical Query serde version {version} for its contents (expected \
+                 {expected})"
+            )));
+        }
+        Ok(())
+    }
+
+    /// Fixed positional layout — every field always present.
+    #[derive(Serialize)]
+    struct PositionalRef<'a> {
+        version: u8,
+        items: &'a Vec<QueryItem>,
+        default_subquery_branch: &'a SubqueryBranch,
+        conditional_subquery_branches: &'a Option<IndexMap<QueryItem, SubqueryBranch>>,
+        left_to_right: bool,
+        add_parent_tree_on_subquery: bool,
+        read_mode: &'a Option<Box<ReadMode>>,
+        limit: &'a Option<u16>,
+    }
+
+    #[derive(Deserialize)]
+    #[serde(rename = "Query")]
+    struct PositionalOwned {
+        version: u8,
+        items: Vec<QueryItem>,
+        default_subquery_branch: SubqueryBranch,
+        conditional_subquery_branches: Option<IndexMap<QueryItem, SubqueryBranch>>,
+        left_to_right: bool,
+        add_parent_tree_on_subquery: bool,
+        read_mode: Option<Box<ReadMode>>,
+        limit: Option<u16>,
+    }
+
+    /// The nested body of the human-readable version-3 form.
+    #[derive(Serialize, Deserialize)]
+    struct BodyOwned {
+        items: Vec<QueryItem>,
+        default_subquery_branch: SubqueryBranch,
+        conditional_subquery_branches: Option<IndexMap<QueryItem, SubqueryBranch>>,
+        left_to_right: bool,
+        add_parent_tree_on_subquery: bool,
+        read_mode: Option<Box<ReadMode>>,
+        limit: u16,
+    }
+
+    #[derive(Serialize)]
+    struct BodyRef<'a> {
+        items: &'a Vec<QueryItem>,
+        default_subquery_branch: &'a SubqueryBranch,
+        conditional_subquery_branches: &'a Option<IndexMap<QueryItem, SubqueryBranch>>,
+        left_to_right: bool,
+        add_parent_tree_on_subquery: bool,
+        read_mode: &'a Option<Box<ReadMode>>,
+        limit: u16,
+    }
+
+    impl Serialize for Query {
+        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            let version = wire_version(self.read_mode.is_some(), self.limit.is_some());
+            if !serializer.is_human_readable() {
+                return PositionalRef {
+                    version,
+                    items: &self.items,
+                    default_subquery_branch: &self.default_subquery_branch,
+                    conditional_subquery_branches: &self.conditional_subquery_branches,
+                    left_to_right: self.left_to_right,
+                    add_parent_tree_on_subquery: self.add_parent_tree_on_subquery,
+                    read_mode: &self.read_mode,
+                    limit: &self.limit,
+                }
+                .serialize(serializer);
+            }
+            use serde::ser::SerializeStruct;
+            match version {
+                3 => {
+                    let mut state = serializer.serialize_struct("Query", 2)?;
+                    state.serialize_field("version", &version)?;
+                    state.serialize_field(
+                        "body",
+                        &BodyRef {
+                            items: &self.items,
+                            default_subquery_branch: &self.default_subquery_branch,
+                            conditional_subquery_branches: &self.conditional_subquery_branches,
+                            left_to_right: self.left_to_right,
+                            add_parent_tree_on_subquery: self.add_parent_tree_on_subquery,
+                            read_mode: &self.read_mode,
+                            limit: self.limit.expect("version 3 iff limit is present"),
+                        },
+                    )?;
+                    state.end()
+                }
+                2 => {
+                    let mut state = serializer.serialize_struct("Query", 7)?;
+                    state.serialize_field("version", &version)?;
+                    state.serialize_field("items", &self.items)?;
+                    state.serialize_field(
+                        "default_subquery_branch",
+                        &self.default_subquery_branch,
+                    )?;
+                    state.serialize_field(
+                        "conditional_subquery_branches",
+                        &self.conditional_subquery_branches,
+                    )?;
+                    state.serialize_field("left_to_right", &self.left_to_right)?;
+                    state.serialize_field(
+                        "add_parent_tree_on_subquery",
+                        &self.add_parent_tree_on_subquery,
+                    )?;
+                    state.serialize_field("read_mode", &self.read_mode)?;
+                    state.end()
+                }
+                _ => {
+                    let mut state = serializer.serialize_struct("Query", 6)?;
+                    state.serialize_field("version", &version)?;
+                    state.serialize_field("items", &self.items)?;
+                    state.serialize_field(
+                        "default_subquery_branch",
+                        &self.default_subquery_branch,
+                    )?;
+                    state.serialize_field(
+                        "conditional_subquery_branches",
+                        &self.conditional_subquery_branches,
+                    )?;
+                    state.serialize_field("left_to_right", &self.left_to_right)?;
+                    state.serialize_field(
+                        "add_parent_tree_on_subquery",
+                        &self.add_parent_tree_on_subquery,
+                    )?;
+                    state.end()
+                }
+            }
+        }
+    }
+
+    struct QueryVisitor;
+
+    impl<'de> Visitor<'de> for QueryVisitor {
+        type Value = Query;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a versioned Query map")
+        }
+
+        fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Query, A::Error> {
+            let mut version: Option<u8> = None;
+            let mut body: Option<BodyOwned> = None;
+            let mut items: Option<Vec<QueryItem>> = None;
+            let mut default_subquery_branch: Option<SubqueryBranch> = None;
+            let mut conditional_subquery_branches: Option<
+                Option<IndexMap<QueryItem, SubqueryBranch>>,
+            > = None;
+            let mut left_to_right: Option<bool> = None;
+            let mut add_parent_tree_on_subquery: Option<bool> = None;
+            let mut read_mode: Option<Option<Box<ReadMode>>> = None;
+
+            while let Some(key) = map.next_key::<String>()? {
+                match key.as_str() {
+                    "version" => version = Some(map.next_value()?),
+                    "body" => body = Some(map.next_value()?),
+                    "items" => items = Some(map.next_value()?),
+                    "default_subquery_branch" => default_subquery_branch = Some(map.next_value()?),
+                    "conditional_subquery_branches" => {
+                        conditional_subquery_branches = Some(map.next_value()?)
+                    }
+                    "left_to_right" => left_to_right = Some(map.next_value()?),
+                    "add_parent_tree_on_subquery" => {
+                        add_parent_tree_on_subquery = Some(map.next_value()?)
+                    }
+                    "read_mode" => read_mode = Some(map.next_value()?),
+                    other => {
+                        // Unknown keys fail closed: silently ignoring a
+                        // key is exactly how a limit was dropped by
+                        // pre-versioning readers.
+                        return Err(de::Error::unknown_field(
+                            other,
+                            &[
+                                "version",
+                                "body",
+                                "items",
+                                "default_subquery_branch",
+                                "conditional_subquery_branches",
+                                "left_to_right",
+                                "add_parent_tree_on_subquery",
+                                "read_mode",
+                            ],
+                        ));
+                    }
+                }
+            }
+
+            if let Some(body) = body {
+                let version = version.ok_or_else(|| de::Error::missing_field("version"))?;
+                if items.is_some()
+                    || default_subquery_branch.is_some()
+                    || conditional_subquery_branches.is_some()
+                    || left_to_right.is_some()
+                    || add_parent_tree_on_subquery.is_some()
+                    || read_mode.is_some()
+                {
+                    return Err(de::Error::custom(
+                        "a version-3 Query nests every field under `body`; flat fields may \
+                         not accompany it",
+                    ));
+                }
+                validate_canonical::<A::Error>(version, body.read_mode.is_some(), true)?;
+                return Ok(Query {
+                    items: body.items,
+                    default_subquery_branch: body.default_subquery_branch,
+                    conditional_subquery_branches: body.conditional_subquery_branches,
+                    left_to_right: body.left_to_right,
+                    add_parent_tree_on_subquery: body.add_parent_tree_on_subquery,
+                    read_mode: body.read_mode,
+                    limit: Some(body.limit),
+                });
+            }
+
+            let read_mode = read_mode.unwrap_or(None);
+            // A missing `version` key is the pre-versioning flat layout
+            // — accepted for compatibility; it can never carry a limit.
+            if let Some(version) = version {
+                validate_canonical::<A::Error>(version, read_mode.is_some(), false)?;
+            }
+            Ok(Query {
+                items: items.ok_or_else(|| de::Error::missing_field("items"))?,
+                default_subquery_branch: default_subquery_branch
+                    .ok_or_else(|| de::Error::missing_field("default_subquery_branch"))?,
+                conditional_subquery_branches: conditional_subquery_branches.unwrap_or(None),
+                left_to_right: left_to_right
+                    .ok_or_else(|| de::Error::missing_field("left_to_right"))?,
+                add_parent_tree_on_subquery: add_parent_tree_on_subquery
+                    .ok_or_else(|| de::Error::missing_field("add_parent_tree_on_subquery"))?,
+                read_mode,
+                limit: None,
+            })
+        }
+    }
+
+    impl<'de> Deserialize<'de> for Query {
+        fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Query, D::Error> {
+            if !deserializer.is_human_readable() {
+                let wire = PositionalOwned::deserialize(deserializer)?;
+                validate_canonical::<D::Error>(
+                    wire.version,
+                    wire.read_mode.is_some(),
+                    wire.limit.is_some(),
+                )?;
+                return Ok(Query {
+                    items: wire.items,
+                    default_subquery_branch: wire.default_subquery_branch,
+                    conditional_subquery_branches: wire.conditional_subquery_branches,
+                    left_to_right: wire.left_to_right,
+                    add_parent_tree_on_subquery: wire.add_parent_tree_on_subquery,
+                    read_mode: wire.read_mode,
+                    limit: wire.limit,
+                });
+            }
+            deserializer.deserialize_map(QueryVisitor)
+        }
     }
 }

--- a/grovedb-query/tests/query_serde_versioning.rs
+++ b/grovedb-query/tests/query_serde_versioning.rs
@@ -1,0 +1,183 @@
+//! Cross-generation safety of `Query`'s versioned serde representation.
+//!
+//! `BaseQuery` below reproduces the pre-limit derived layout (the one
+//! shipped before per-instance limits): flat fields through
+//! `read_mode`, which carries `default` + `skip_serializing_if`. The
+//! contract under test, in both directions:
+//!
+//! - base-writer payloads a base reader could serve still decode at
+//!   head (self-describing formats), or fail *cleanly* (positional
+//!   formats, which the base layout never round-tripped reliably);
+//! - head-writer payloads carrying a limit — which a base reader
+//!   cannot serve — hard-fail at base instead of silently decoding as
+//!   an unlimited query;
+//! - head/head round-trips work in both format families, and
+//!   non-canonical version claims are rejected.
+
+#![cfg(feature = "serde")]
+
+use bincode::config;
+use grovedb_query::{Query, QueryItem, ReadMode, SubqueryBranch, SumBudgetRead};
+use indexmap::IndexMap;
+use serde::{Deserialize, Serialize};
+
+/// The pre-limit derived serde layout, byte-for-byte as it shipped.
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct BaseQuery {
+    items: Vec<QueryItem>,
+    default_subquery_branch: SubqueryBranch,
+    conditional_subquery_branches: Option<IndexMap<QueryItem, SubqueryBranch>>,
+    left_to_right: bool,
+    add_parent_tree_on_subquery: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    read_mode: Option<Box<ReadMode>>,
+}
+
+fn read_mode() -> Box<ReadMode> {
+    Box::new(ReadMode::SumBudget(SumBudgetRead {
+        sum_limit: 500,
+        match_limit: Some(100),
+    }))
+}
+
+fn head_query(with_read_mode: bool, limit: Option<u16>) -> Query {
+    let mut inner = Query::new_single_key(b"leaf".to_vec());
+    inner.limit = limit.map(|_| 2); // nested cap rides along when capped
+    let mut query = Query::new_single_query_item(QueryItem::RangeFull(..));
+    query.set_subquery(inner);
+    if with_read_mode {
+        query.read_mode = Some(read_mode());
+    }
+    query.limit = limit;
+    query
+}
+
+#[test]
+fn head_round_trips_every_combination_in_both_format_families() {
+    for (with_read_mode, limit) in [
+        (false, None),
+        (true, None),
+        (false, Some(3)),
+        (true, Some(3)),
+    ] {
+        let query = head_query(with_read_mode, limit);
+
+        let json = serde_json::to_string(&query).expect("json encode");
+        let decoded: Query = serde_json::from_str(&json).expect("json decode");
+        assert_eq!(decoded, query, "json round trip");
+
+        let bytes =
+            bincode::serde::encode_to_vec(&query, config::standard()).expect("positional encode");
+        let (decoded, consumed): (Query, usize) =
+            bincode::serde::decode_from_slice(&bytes, config::standard())
+                .expect("positional decode");
+        assert_eq!(consumed, bytes.len());
+        assert_eq!(decoded, query, "positional round trip");
+    }
+}
+
+#[test]
+fn base_writer_payloads_stay_readable_at_head_in_json() {
+    for with_read_mode in [false, true] {
+        let base = BaseQuery {
+            items: vec![QueryItem::Key(b"k".to_vec())],
+            default_subquery_branch: SubqueryBranch::default(),
+            conditional_subquery_branches: None,
+            left_to_right: true,
+            add_parent_tree_on_subquery: false,
+            read_mode: with_read_mode.then(read_mode),
+        };
+        let json = serde_json::to_string(&base).expect("base json encode");
+        let decoded: Query = serde_json::from_str(&json).expect("head must read base payloads");
+        assert_eq!(decoded.items, base.items);
+        assert_eq!(decoded.read_mode.is_some(), with_read_mode);
+        assert_eq!(decoded.limit, None);
+    }
+}
+
+#[test]
+fn head_flat_json_without_a_limit_stays_readable_at_base() {
+    // Versions 1 and 2 keep the flat layout (plus a `version` key the
+    // base derive ignores), so every query a base reader can serve
+    // keeps flowing to it.
+    for with_read_mode in [false, true] {
+        let query = head_query(with_read_mode, None);
+        let json = serde_json::to_string(&query).expect("head json encode");
+        let decoded: BaseQuery =
+            serde_json::from_str(&json).expect("base must read flat head payloads");
+        assert_eq!(decoded.items, query.items);
+        assert_eq!(decoded.read_mode.is_some(), with_read_mode);
+    }
+}
+
+#[test]
+fn limited_head_json_fails_closed_at_base() {
+    // The limit-bearing form nests under `body`, so a base reader —
+    // which would silently drop an unknown `limit` key in a flat map —
+    // hard-fails on the missing flat fields instead of decoding an
+    // unlimited query.
+    let query = head_query(false, Some(3));
+    let json = serde_json::to_string(&query).expect("head json encode");
+    assert!(
+        serde_json::from_str::<BaseQuery>(&json).is_err(),
+        "a base reader must not silently decode a limited query"
+    );
+}
+
+#[test]
+fn positional_payloads_fail_cleanly_across_generations() {
+    // Positional base payloads (the read-mode-bearing shape was the
+    // only one the base layout round-tripped) fail with a decode error
+    // at head — never a silent misread.
+    let base = BaseQuery {
+        items: vec![QueryItem::Key(b"k".to_vec())],
+        default_subquery_branch: SubqueryBranch::default(),
+        conditional_subquery_branches: None,
+        left_to_right: true,
+        add_parent_tree_on_subquery: false,
+        read_mode: Some(read_mode()),
+    };
+    let base_bytes =
+        bincode::serde::encode_to_vec(&base, config::standard()).expect("base positional encode");
+    assert!(
+        bincode::serde::decode_from_slice::<Query, _>(&base_bytes, config::standard()).is_err(),
+        "head must fail closed on base positional payloads"
+    );
+
+    // And head positional payloads fail at base likewise.
+    let head_bytes = bincode::serde::encode_to_vec(head_query(false, Some(3)), config::standard())
+        .expect("head positional encode");
+    assert!(
+        bincode::serde::decode_from_slice::<BaseQuery, _>(&head_bytes, config::standard()).is_err(),
+        "base must fail closed on head positional payloads"
+    );
+}
+
+#[test]
+fn non_canonical_version_claims_are_rejected() {
+    // Flat JSON claiming version 3 (limits only travel nested).
+    let flat_v3 = r#"{"version":3,"items":[],"default_subquery_branch":{"subquery_path":null,"subquery":null},"conditional_subquery_branches":null,"left_to_right":true,"add_parent_tree_on_subquery":false}"#;
+    assert!(serde_json::from_str::<Query>(flat_v3).is_err());
+
+    // Flat JSON claiming version 1 while carrying a read mode.
+    let query = head_query(true, None);
+    let json = serde_json::to_string(&query).expect("encode");
+    let json = json.replace("\"version\":2", "\"version\":1");
+    assert!(serde_json::from_str::<Query>(&json).is_err());
+
+    // An unknown flat key — the silent-drop vector — is refused.
+    let unknown_key = r#"{"items":[],"default_subquery_branch":{"subquery_path":null,"subquery":null},"conditional_subquery_branches":null,"left_to_right":true,"add_parent_tree_on_subquery":false,"limit":3}"#;
+    assert!(serde_json::from_str::<Query>(unknown_key).is_err());
+
+    // A version-3 positional payload whose limit slot is None.
+    let query = head_query(false, Some(3));
+    let mut bytes =
+        bincode::serde::encode_to_vec(&query, config::standard()).expect("positional encode");
+    // version byte leads the positional layout; downgrade the claim.
+    assert_eq!(bytes[0], 3);
+    bytes[0] = 1;
+    assert!(
+        bincode::serde::decode_from_slice::<Query, _>(&bytes, config::standard()).is_err(),
+        "positional canonicality must hold too"
+    );
+}

--- a/grovedb-query/tests/query_serde_versioning.rs
+++ b/grovedb-query/tests/query_serde_versioning.rs
@@ -1,16 +1,21 @@
 //! Cross-generation safety of `Query`'s versioned serde representation.
 //!
-//! `BaseQuery` below reproduces the pre-limit derived layout (the one
-//! shipped before per-instance limits): flat fields through
-//! `read_mode`, which carries `default` + `skip_serializing_if`. The
+//! `ReleasedQuery` reproduces the **released** v5.0.1 derived layout —
+//! the actual compatibility surface: five flat fields, no `read_mode`,
+//! no `limit`, unknown keys silently ignored by its derive. The
 //! contract under test, in both directions:
 //!
-//! - base-writer payloads a base reader could serve still decode at
-//!   head (self-describing formats), or fail *cleanly* (positional
-//!   formats, which the base layout never round-tripped reliably);
-//! - head-writer payloads carrying a limit — which a base reader
-//!   cannot serve — hard-fail at base instead of silently decoding as
-//!   an unlimited query;
+//! - flat head payloads (version 1 — the only content a released
+//!   reader can serve) keep flowing to released readers, and released
+//!   payloads keep decoding at head (self-describing formats);
+//! - head payloads carrying features a released reader cannot serve —
+//!   a read mode or a limit — hard-fail there instead of silently
+//!   decoding with the feature dropped;
+//! - positional payloads never cross generations silently: the framed
+//!   layout's magic decodes as an absurd `items` length under the
+//!   released unframed layout (a bare leading version byte would have
+//!   been consumed as a small length and reinterpreted), and the
+//!   framed reader requires the magic exactly;
 //! - head/head round-trips work in both format families, and
 //!   non-canonical version claims are rejected.
 
@@ -21,16 +26,14 @@ use grovedb_query::{Query, QueryItem, ReadMode, SubqueryBranch, SumBudgetRead};
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
-/// The pre-limit derived serde layout, byte-for-byte as it shipped.
+/// The released v5.0.1 derived serde layout, byte-for-byte as shipped.
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
-struct BaseQuery {
+struct ReleasedQuery {
     items: Vec<QueryItem>,
     default_subquery_branch: SubqueryBranch,
     conditional_subquery_branches: Option<IndexMap<QueryItem, SubqueryBranch>>,
     left_to_right: bool,
     add_parent_tree_on_subquery: bool,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    read_mode: Option<Box<ReadMode>>,
 }
 
 fn read_mode() -> Box<ReadMode> {
@@ -50,6 +53,16 @@ fn head_query(with_read_mode: bool, limit: Option<u16>) -> Query {
     }
     query.limit = limit;
     query
+}
+
+fn released_query() -> ReleasedQuery {
+    ReleasedQuery {
+        items: vec![QueryItem::Key(b"k".to_vec())],
+        default_subquery_branch: SubqueryBranch::default(),
+        conditional_subquery_branches: None,
+        left_to_right: true,
+        add_parent_tree_on_subquery: false,
+    }
 }
 
 #[test]
@@ -77,105 +90,117 @@ fn head_round_trips_every_combination_in_both_format_families() {
 }
 
 #[test]
-fn base_writer_payloads_stay_readable_at_head_in_json() {
-    for with_read_mode in [false, true] {
-        let base = BaseQuery {
-            items: vec![QueryItem::Key(b"k".to_vec())],
-            default_subquery_branch: SubqueryBranch::default(),
-            conditional_subquery_branches: None,
-            left_to_right: true,
-            add_parent_tree_on_subquery: false,
-            read_mode: with_read_mode.then(read_mode),
-        };
-        let json = serde_json::to_string(&base).expect("base json encode");
-        let decoded: Query = serde_json::from_str(&json).expect("head must read base payloads");
-        assert_eq!(decoded.items, base.items);
-        assert_eq!(decoded.read_mode.is_some(), with_read_mode);
-        assert_eq!(decoded.limit, None);
-    }
+fn released_json_payloads_stay_readable_at_head() {
+    let released = released_query();
+    let json = serde_json::to_string(&released).expect("released json encode");
+    let decoded: Query = serde_json::from_str(&json).expect("head must read released payloads");
+    assert_eq!(decoded.items, released.items);
+    assert_eq!(decoded.read_mode, None);
+    assert_eq!(decoded.limit, None);
 }
 
 #[test]
-fn head_flat_json_without_a_limit_stays_readable_at_base() {
-    // Versions 1 and 2 keep the flat layout (plus a `version` key the
-    // base derive ignores), so every query a base reader can serve
-    // keeps flowing to it.
-    for with_read_mode in [false, true] {
-        let query = head_query(with_read_mode, None);
-        let json = serde_json::to_string(&query).expect("head json encode");
-        let decoded: BaseQuery =
-            serde_json::from_str(&json).expect("base must read flat head payloads");
-        assert_eq!(decoded.items, query.items);
-        assert_eq!(decoded.read_mode.is_some(), with_read_mode);
-    }
-}
-
-#[test]
-fn limited_head_json_fails_closed_at_base() {
-    // The limit-bearing form nests under `body`, so a base reader —
-    // which would silently drop an unknown `limit` key in a flat map —
-    // hard-fails on the missing flat fields instead of decoding an
-    // unlimited query.
-    let query = head_query(false, Some(3));
+fn plain_head_json_stays_readable_at_released() {
+    // Version 1 keeps the flat layout (plus a `version` key the
+    // released derive ignores), so every query a released reader can
+    // serve keeps flowing to it.
+    let query = head_query(false, None);
     let json = serde_json::to_string(&query).expect("head json encode");
-    assert!(
-        serde_json::from_str::<BaseQuery>(&json).is_err(),
-        "a base reader must not silently decode a limited query"
-    );
+    let decoded: ReleasedQuery =
+        serde_json::from_str(&json).expect("released must read flat head payloads");
+    assert_eq!(decoded.items, query.items);
+}
+
+#[test]
+fn feature_bearing_head_json_fails_closed_at_released() {
+    // Read-mode and limit-bearing forms nest under `body`: the
+    // released derive — which silently ignores unknown keys in a flat
+    // map — hard-fails on the missing flat fields instead of decoding
+    // the query with the feature dropped.
+    for (with_read_mode, limit) in [(true, None), (false, Some(3)), (true, Some(3))] {
+        let query = head_query(with_read_mode, limit);
+        let json = serde_json::to_string(&query).expect("head json encode");
+        assert!(
+            serde_json::from_str::<ReleasedQuery>(&json).is_err(),
+            "a released reader must not silently decode a feature-bearing query"
+        );
+    }
+}
+
+#[test]
+fn flat_json_carrying_features_is_refused_at_head() {
+    // A flat map smuggling `read_mode` or `limit` would mean different
+    // things to the two released surfaces (the released derive drops
+    // both keys silently), so the head reader refuses it outright.
+    let with_flat_read_mode = r#"{"items":[],"default_subquery_branch":{"subquery_path":null,"subquery":null},"conditional_subquery_branches":null,"left_to_right":true,"add_parent_tree_on_subquery":false,"read_mode":{"SumBudget":{"sum_limit":5,"match_limit":null}}}"#;
+    assert!(serde_json::from_str::<Query>(with_flat_read_mode).is_err());
+
+    let with_flat_limit = r#"{"items":[],"default_subquery_branch":{"subquery_path":null,"subquery":null},"conditional_subquery_branches":null,"left_to_right":true,"add_parent_tree_on_subquery":false,"limit":3}"#;
+    assert!(serde_json::from_str::<Query>(with_flat_limit).is_err());
 }
 
 #[test]
 fn positional_payloads_fail_cleanly_across_generations() {
-    // Positional base payloads (the read-mode-bearing shape was the
-    // only one the base layout round-tripped) fail with a decode error
-    // at head — never a silent misread.
-    let base = BaseQuery {
-        items: vec![QueryItem::Key(b"k".to_vec())],
-        default_subquery_branch: SubqueryBranch::default(),
-        conditional_subquery_branches: None,
-        left_to_right: true,
-        add_parent_tree_on_subquery: false,
-        read_mode: Some(read_mode()),
-    };
-    let base_bytes =
-        bincode::serde::encode_to_vec(&base, config::standard()).expect("base positional encode");
+    // Released positional payloads are unframed; the framed reader
+    // requires the magic and errors cleanly.
+    let released_bytes = bincode::serde::encode_to_vec(released_query(), config::standard())
+        .expect("released positional encode");
     assert!(
-        bincode::serde::decode_from_slice::<Query, _>(&base_bytes, config::standard()).is_err(),
-        "head must fail closed on base positional payloads"
+        bincode::serde::decode_from_slice::<Query, _>(&released_bytes, config::standard()).is_err(),
+        "head must fail closed on released positional payloads"
     );
 
-    // And head positional payloads fail at base likewise.
-    let head_bytes = bincode::serde::encode_to_vec(head_query(false, Some(3)), config::standard())
-        .expect("head positional encode");
-    assert!(
-        bincode::serde::decode_from_slice::<BaseQuery, _>(&head_bytes, config::standard()).is_err(),
-        "base must fail closed on head positional payloads"
-    );
+    // Head positional payloads must not decode under the released
+    // layout — not even by fully consuming the bytes as reinterpreted
+    // fields. The leading magic reads there as an absurd `items`
+    // length, which errors.
+    for (with_read_mode, limit) in [
+        (false, None),
+        (true, None),
+        (false, Some(3)),
+        (true, Some(3)),
+    ] {
+        let head_bytes =
+            bincode::serde::encode_to_vec(head_query(with_read_mode, limit), config::standard())
+                .expect("head positional encode");
+        assert!(
+            bincode::serde::decode_from_slice::<ReleasedQuery, _>(&head_bytes, config::standard())
+                .is_err(),
+            "released must fail closed on head positional payloads"
+        );
+    }
 }
 
 #[test]
 fn non_canonical_version_claims_are_rejected() {
-    // Flat JSON claiming version 3 (limits only travel nested).
-    let flat_v3 = r#"{"version":3,"items":[],"default_subquery_branch":{"subquery_path":null,"subquery":null},"conditional_subquery_branches":null,"left_to_right":true,"add_parent_tree_on_subquery":false}"#;
-    assert!(serde_json::from_str::<Query>(flat_v3).is_err());
+    // Flat JSON claiming version 2 or 3 (features only travel nested).
+    for version in [2u8, 3] {
+        let flat = format!(
+            r#"{{"version":{version},"items":[],"default_subquery_branch":{{"subquery_path":null,"subquery":null}},"conditional_subquery_branches":null,"left_to_right":true,"add_parent_tree_on_subquery":false}}"#
+        );
+        assert!(serde_json::from_str::<Query>(&flat).is_err());
+    }
 
-    // Flat JSON claiming version 1 while carrying a read mode.
+    // A nested body whose version claim does not match its contents.
     let query = head_query(true, None);
     let json = serde_json::to_string(&query).expect("encode");
-    let json = json.replace("\"version\":2", "\"version\":1");
-    assert!(serde_json::from_str::<Query>(&json).is_err());
+    assert!(json.contains("\"version\":2"));
+    let downgraded = json.replace("\"version\":2", "\"version\":1");
+    assert!(serde_json::from_str::<Query>(&downgraded).is_err());
+    let upgraded = json.replace("\"version\":2", "\"version\":3");
+    assert!(serde_json::from_str::<Query>(&upgraded).is_err());
 
-    // An unknown flat key — the silent-drop vector — is refused.
-    let unknown_key = r#"{"items":[],"default_subquery_branch":{"subquery_path":null,"subquery":null},"conditional_subquery_branches":null,"left_to_right":true,"add_parent_tree_on_subquery":false,"limit":3}"#;
-    assert!(serde_json::from_str::<Query>(unknown_key).is_err());
-
-    // A version-3 positional payload whose limit slot is None.
+    // A framed positional payload with a downgraded version claim.
     let query = head_query(false, Some(3));
     let mut bytes =
         bincode::serde::encode_to_vec(&query, config::standard()).expect("positional encode");
-    // version byte leads the positional layout; downgrade the claim.
-    assert_eq!(bytes[0], 3);
-    bytes[0] = 1;
+    // The magic's varint encoding leads; the version byte follows it.
+    let magic_len =
+        bincode::serde::encode_to_vec(u64::from_be_bytes(*b"grvquery"), config::standard())
+            .expect("encode magic")
+            .len();
+    assert_eq!(bytes[magic_len], 3);
+    bytes[magic_len] = 1;
     assert!(
         bincode::serde::decode_from_slice::<Query, _>(&bytes, config::standard()).is_err(),
         "positional canonicality must hold too"

--- a/grovedb/src/element/query.rs
+++ b/grovedb/src/element/query.rs
@@ -376,15 +376,27 @@ impl ElementQueryExtensions for Element {
             grove_version.grovedb_versions.element.query_item
         );
 
-        // This legacy signature threads only the global limit/offset
-        // pair, and a per-instance budget cannot ride it: the budget is
-        // per node *instance*, while this entry point is called once
-        // per item — re-seeding a fresh cap per item would silently
-        // change what the cap means. The engine's own walk seeds the
-        // instance budget in `get_query_apply_function_internal`; a
-        // direct caller whose queried node carries its own cap fails
-        // closed here instead of having the cap ignored. (Caps on
-        // subqueries BELOW this node are served through the descent.)
+        // Whole-query preflight, exactly like the other public Element
+        // wrappers: a per-instance limit hiding in an unmatched
+        // conditional branch would otherwise make acceptance depend on
+        // database contents (rejected only once stored data makes the
+        // branch match during descent).
+        if let Err(e) = crate::query::reject_unserved_instance_limits_in_query(
+            &sized_query.query,
+            grove_version,
+        ) {
+            return Err(e).wrap_with_cost(OperationCost::default());
+        }
+        // Additionally, this legacy signature threads only the global
+        // limit/offset pair, and a per-instance budget cannot ride it:
+        // the budget is per node *instance*, while this entry point is
+        // called once per item — re-seeding a fresh cap per item would
+        // silently change what the cap means. The engine's own walk
+        // seeds the instance budget in
+        // `get_query_apply_function_internal`; a direct caller whose
+        // queried node carries its own cap fails closed here instead of
+        // having the cap ignored. (Caps on subqueries BELOW this node
+        // are served through the descent.)
         if sized_query.query.limit.is_some() {
             return Err(Error::NotSupported(
                 "ElementQueryExtensions::query_item does not serve a per-instance limit \
@@ -485,6 +497,12 @@ pub(crate) fn query_item_internal(
     use grovedb_storage::Storage;
 
     use crate::util::{compat, TxRef};
+
+    // Subordinate slot check — see `get_query_apply_function_internal`.
+    check_grovedb_v0_with_cost!(
+        "query_item",
+        grove_version.grovedb_versions.element.query_item
+    );
 
     let mut cost = OperationCost::default();
     let tx = TxRef::new(storage, transaction);
@@ -674,6 +692,19 @@ pub(crate) fn get_query_apply_function_internal(
     add_element_function: fn(PathQueryPushArgs, &GroveVersion) -> CostResult<(), Error>,
     grove_version: &GroveVersion,
 ) -> CostResult<(QueryResultElements, u16, u16), Error> {
+    // The subordinate method-version slot holds for the internal body
+    // exactly as it did when the public wrapper was the only entry —
+    // the engines recurse through here directly, and a future/replay
+    // version table bumping the slot must not silently run today's
+    // semantics.
+    check_grovedb_v0_with_cost!(
+        "get_query_apply_function",
+        grove_version
+            .grovedb_versions
+            .element
+            .get_query_apply_function
+    );
+
     let mut cost = OperationCost::default();
 
     // Per-instance limits are serving-gated: grove versions whose
@@ -698,12 +729,27 @@ pub(crate) fn get_query_apply_function_internal(
                 .wrap_with_cost(cost);
             }
             1 => {
-                if grove_version.grovedb_versions.element.path_query_push == 0 {
-                    return Err(Error::CorruptedCodeExecution(
-                        "grove version table serves per-instance limits but selects the v0 \
-                         path_query_push engine, which cannot account for them",
-                    ))
-                    .wrap_with_cost(cost);
+                // Exact-match the engine selector — see
+                // `reject_unserved_instance_limits_in_query`.
+                match grove_version.grovedb_versions.element.path_query_push {
+                    0 => {
+                        return Err(Error::CorruptedCodeExecution(
+                            "grove version table serves per-instance limits but selects the v0 \
+                             path_query_push engine, which cannot account for them",
+                        ))
+                        .wrap_with_cost(cost);
+                    }
+                    1 => {}
+                    version => {
+                        return Err(Error::VersionError(
+                            grovedb_version::error::GroveVersionError::UnknownVersionMismatch {
+                                method: "path_query_push".to_string(),
+                                known_versions: vec![0, 1],
+                                received: version,
+                            },
+                        ))
+                        .wrap_with_cost(cost);
+                    }
                 }
                 if instance_limit == 0 {
                     return Err(Error::InvalidQuery(
@@ -805,6 +851,12 @@ pub(crate) fn get_path_query_internal(
     transaction: TransactionArg,
     grove_version: &GroveVersion,
 ) -> CostResult<(QueryResultElements, u16, u16), Error> {
+    // Subordinate slot check — see `get_query_apply_function_internal`.
+    check_grovedb_v0_with_cost!(
+        "get_path_query",
+        grove_version.grovedb_versions.element.get_path_query
+    );
+
     let path_slices = path_query
         .path
         .iter()

--- a/grovedb/src/operations/proof/generate.rs
+++ b/grovedb/src/operations/proof/generate.rs
@@ -1855,8 +1855,21 @@ impl GroveDb {
 
         let limit = if path.len() < path_query.path.len() {
             None
-        } else {
+        } else if matches!(query.has_subquery, crate::query::HasSubquery::NoSubquery) {
+            // Pure terminal layer: its merk rows ARE the result rows,
+            // so the tighter of the global and instance budgets bounds
+            // what the merk walk needs to emit.
             limit_state.effective_layer_limit(frame_instance)
+        } else {
+            // The layer has subquery branches: the instance chain
+            // budgets descendant ROWS, not children, so it must not
+            // truncate which children the merk walk emits — an empty
+            // child consumes no instance budget, and a later populated
+            // child may still owe rows. Only the global budget (whose
+            // empty-layer charge keeps it aligned with truncation)
+            // bounds this walk; instance caps bound each descent's own
+            // layers and stop further descents via `done_with_results`.
+            limit_state.global
         };
 
         // Aggregate-count short-circuit (v1 path). Same validation contract
@@ -2401,8 +2414,21 @@ impl GroveDb {
                                 let mut lower_path = path.clone();
                                 lower_path.push(key.as_slice());
 
+                                // The non-Merk adapters bypass the recursive
+                                // frame creation, so the lower query's own
+                                // per-instance cap must be min-composed here —
+                                // the verifier derives the identical value.
+                                let lower_instance = super::V1LimitState::min_caps(
+                                    frame_instance,
+                                    cost_return_on_error_no_add!(
+                                        cost,
+                                        path_query
+                                            .query_items_at_path(&lower_path, grove_version)
+                                    )
+                                    .and_then(|lower_query| lower_query.instance_limit),
+                                );
                                 let mut non_merk_effective =
-                                    limit_state.effective_layer_limit(frame_instance);
+                                    limit_state.effective_layer_limit(lower_instance);
                                 let non_merk_before = non_merk_effective;
                                 let layer_proof = cost_return_on_error!(
                                     &mut cost,
@@ -2436,8 +2462,21 @@ impl GroveDb {
                                 let mut lower_path = path.clone();
                                 lower_path.push(key.as_slice());
 
+                                // The non-Merk adapters bypass the recursive
+                                // frame creation, so the lower query's own
+                                // per-instance cap must be min-composed here —
+                                // the verifier derives the identical value.
+                                let lower_instance = super::V1LimitState::min_caps(
+                                    frame_instance,
+                                    cost_return_on_error_no_add!(
+                                        cost,
+                                        path_query
+                                            .query_items_at_path(&lower_path, grove_version)
+                                    )
+                                    .and_then(|lower_query| lower_query.instance_limit),
+                                );
                                 let mut non_merk_effective =
-                                    limit_state.effective_layer_limit(frame_instance);
+                                    limit_state.effective_layer_limit(lower_instance);
                                 let non_merk_before = non_merk_effective;
                                 let layer_proof = cost_return_on_error!(
                                     &mut cost,
@@ -2476,8 +2515,21 @@ impl GroveDb {
                                 let mut lower_path = path.clone();
                                 lower_path.push(key.as_slice());
 
+                                // The non-Merk adapters bypass the recursive
+                                // frame creation, so the lower query's own
+                                // per-instance cap must be min-composed here —
+                                // the verifier derives the identical value.
+                                let lower_instance = super::V1LimitState::min_caps(
+                                    frame_instance,
+                                    cost_return_on_error_no_add!(
+                                        cost,
+                                        path_query
+                                            .query_items_at_path(&lower_path, grove_version)
+                                    )
+                                    .and_then(|lower_query| lower_query.instance_limit),
+                                );
                                 let mut non_merk_effective =
-                                    limit_state.effective_layer_limit(frame_instance);
+                                    limit_state.effective_layer_limit(lower_instance);
                                 let non_merk_before = non_merk_effective;
                                 let layer_proof = cost_return_on_error!(
                                     &mut cost,
@@ -2512,8 +2564,21 @@ impl GroveDb {
                                 let mut lower_path = path.clone();
                                 lower_path.push(key.as_slice());
 
+                                // The non-Merk adapters bypass the recursive
+                                // frame creation, so the lower query's own
+                                // per-instance cap must be min-composed here —
+                                // the verifier derives the identical value.
+                                let lower_instance = super::V1LimitState::min_caps(
+                                    frame_instance,
+                                    cost_return_on_error_no_add!(
+                                        cost,
+                                        path_query
+                                            .query_items_at_path(&lower_path, grove_version)
+                                    )
+                                    .and_then(|lower_query| lower_query.instance_limit),
+                                );
                                 let mut non_merk_effective =
-                                    limit_state.effective_layer_limit(frame_instance);
+                                    limit_state.effective_layer_limit(lower_instance);
                                 let non_merk_before = non_merk_effective;
                                 let layer_proof = cost_return_on_error!(
                                     &mut cost,
@@ -3361,7 +3426,24 @@ impl GroveDb {
                             | Ok(Element::CommitmentTree(..))
                                 if !done_with_results =>
                             {
-                                limit_state.charge_row_with_instance(&mut frame_instance);
+                                if query.has_subquery_or_matching_in_path_on_key(key) {
+                                    // A subquery matches but the tree is
+                                    // empty: an empty CHILD, not a result
+                                    // row. The charge bounds walks across
+                                    // many empty children (the trusted
+                                    // read's empty-subquery charge is its
+                                    // twin) and so hits the global budget
+                                    // only — per-instance budgets count
+                                    // result rows. The verifier mirrors
+                                    // this exactly; the aggregate-carrier
+                                    // empty hosts never reach this arm
+                                    // (their descent arms match first).
+                                    limit_state.charge_empty_layer();
+                                } else {
+                                    // The empty tree itself is the queried
+                                    // result row.
+                                    limit_state.charge_row_with_instance(&mut frame_instance);
+                                }
                                 has_a_result_at_level |= true;
                             }
 
@@ -3594,9 +3676,17 @@ impl GroveDb {
                 .map_err(|e| Error::CorruptedData(format!("{}", e)))
         );
 
-        // Update limit: count individual values in the queried range
+        // Update limit: count individual values in the queried range.
+        // The range can be empty relative to the stored entries — e.g.
+        // a query whose positions all sit at or past `total_count`
+        // clamps `end` below `start` — in which case nothing was
+        // consumed; a plain subtraction here underflowed (panicking in
+        // debug, charging ~u16::MAX rows in release).
         if let Some(limit) = overall_limit.as_mut() {
-            let count = (end.min(total_count) - start).min(u16::MAX as u64) as u16;
+            let count = end
+                .min(total_count)
+                .saturating_sub(start)
+                .min(u16::MAX as u64) as u16;
             *limit = limit.saturating_sub(count);
         }
 

--- a/grovedb/src/operations/proof/generate.rs
+++ b/grovedb/src/operations/proof/generate.rs
@@ -2418,17 +2418,16 @@ impl GroveDb {
                                 // frame creation, so the lower query's own
                                 // per-instance cap must be min-composed here —
                                 // the verifier derives the identical value.
-                                let lower_instance = super::V1LimitState::min_caps(
-                                    frame_instance,
-                                    cost_return_on_error_no_add!(
-                                        cost,
-                                        path_query
-                                            .query_items_at_path(&lower_path, grove_version)
-                                    )
-                                    .and_then(|lower_query| lower_query.instance_limit),
-                                );
-                                let mut non_merk_effective =
-                                    limit_state.effective_layer_limit(lower_instance);
+                                let mut non_merk_effective = limit_state
+                                    .effective_lower_layer_limit(
+                                        frame_instance,
+                                        cost_return_on_error_no_add!(
+                                            cost,
+                                            path_query
+                                                .query_items_at_path(&lower_path, grove_version)
+                                        )
+                                        .and_then(|lower_query| lower_query.instance_limit),
+                                    );
                                 let non_merk_before = non_merk_effective;
                                 let layer_proof = cost_return_on_error!(
                                     &mut cost,
@@ -2466,17 +2465,16 @@ impl GroveDb {
                                 // frame creation, so the lower query's own
                                 // per-instance cap must be min-composed here —
                                 // the verifier derives the identical value.
-                                let lower_instance = super::V1LimitState::min_caps(
-                                    frame_instance,
-                                    cost_return_on_error_no_add!(
-                                        cost,
-                                        path_query
-                                            .query_items_at_path(&lower_path, grove_version)
-                                    )
-                                    .and_then(|lower_query| lower_query.instance_limit),
-                                );
-                                let mut non_merk_effective =
-                                    limit_state.effective_layer_limit(lower_instance);
+                                let mut non_merk_effective = limit_state
+                                    .effective_lower_layer_limit(
+                                        frame_instance,
+                                        cost_return_on_error_no_add!(
+                                            cost,
+                                            path_query
+                                                .query_items_at_path(&lower_path, grove_version)
+                                        )
+                                        .and_then(|lower_query| lower_query.instance_limit),
+                                    );
                                 let non_merk_before = non_merk_effective;
                                 let layer_proof = cost_return_on_error!(
                                     &mut cost,
@@ -2519,17 +2517,16 @@ impl GroveDb {
                                 // frame creation, so the lower query's own
                                 // per-instance cap must be min-composed here —
                                 // the verifier derives the identical value.
-                                let lower_instance = super::V1LimitState::min_caps(
-                                    frame_instance,
-                                    cost_return_on_error_no_add!(
-                                        cost,
-                                        path_query
-                                            .query_items_at_path(&lower_path, grove_version)
-                                    )
-                                    .and_then(|lower_query| lower_query.instance_limit),
-                                );
-                                let mut non_merk_effective =
-                                    limit_state.effective_layer_limit(lower_instance);
+                                let mut non_merk_effective = limit_state
+                                    .effective_lower_layer_limit(
+                                        frame_instance,
+                                        cost_return_on_error_no_add!(
+                                            cost,
+                                            path_query
+                                                .query_items_at_path(&lower_path, grove_version)
+                                        )
+                                        .and_then(|lower_query| lower_query.instance_limit),
+                                    );
                                 let non_merk_before = non_merk_effective;
                                 let layer_proof = cost_return_on_error!(
                                     &mut cost,
@@ -2568,17 +2565,16 @@ impl GroveDb {
                                 // frame creation, so the lower query's own
                                 // per-instance cap must be min-composed here —
                                 // the verifier derives the identical value.
-                                let lower_instance = super::V1LimitState::min_caps(
-                                    frame_instance,
-                                    cost_return_on_error_no_add!(
-                                        cost,
-                                        path_query
-                                            .query_items_at_path(&lower_path, grove_version)
-                                    )
-                                    .and_then(|lower_query| lower_query.instance_limit),
-                                );
-                                let mut non_merk_effective =
-                                    limit_state.effective_layer_limit(lower_instance);
+                                let mut non_merk_effective = limit_state
+                                    .effective_lower_layer_limit(
+                                        frame_instance,
+                                        cost_return_on_error_no_add!(
+                                            cost,
+                                            path_query
+                                                .query_items_at_path(&lower_path, grove_version)
+                                        )
+                                        .and_then(|lower_query| lower_query.instance_limit),
+                                    );
                                 let non_merk_before = non_merk_effective;
                                 let layer_proof = cost_return_on_error!(
                                     &mut cost,
@@ -3635,8 +3631,11 @@ impl GroveDb {
                 })
         );
 
-        // Convert query items to a position range
-        let (start, end) = cost_return_on_error_no_add!(
+        // Validate that the items convert to a position range. The
+        // bounding span itself is no longer used here: the proof
+        // generator derives its own range from the query, and the row
+        // charge below counts semantic matches rather than the span.
+        let (_start, _end) = cost_return_on_error_no_add!(
             cost,
             Self::query_items_to_range(&sub_query.items, total_count)
         );
@@ -3676,17 +3675,20 @@ impl GroveDb {
                 .map_err(|e| Error::CorruptedData(format!("{}", e)))
         );
 
-        // Update limit: count individual values in the queried range.
-        // The range can be empty relative to the stored entries — e.g.
-        // a query whose positions all sit at or past `total_count`
-        // clamps `end` below `start` — in which case nothing was
-        // consumed; a plain subtraction here underflowed (panicking in
-        // debug, charging ~u16::MAX rows in release).
+        // Update limit: charge the rows the query semantically matches,
+        // exactly as the verifier does — NOT the width of the bounding
+        // proof range. A sparse query (say positions 0 and 100) proves
+        // a wide range but returns two rows; charging the span
+        // desynchronizes the shared budget and makes the verifier
+        // reject honest proofs for later layers. This also charges
+        // zero for a range that is empty relative to the stored
+        // entries (a plain span subtraction underflowed there).
         if let Some(limit) = overall_limit.as_mut() {
-            let count = end
-                .min(total_count)
-                .saturating_sub(start)
-                .min(u16::MAX as u64) as u16;
+            let matched = cost_return_on_error_no_add!(
+                cost,
+                Self::expand_query_to_u64_positions(&sub_query.items, total_count)
+            );
+            let count = matched.len().min(u16::MAX as usize) as u16;
             *limit = limit.saturating_sub(count);
         }
 

--- a/grovedb/src/operations/proof/mod.rs
+++ b/grovedb/src/operations/proof/mod.rs
@@ -229,6 +229,21 @@ impl V1LimitState {
         self.consumed_total += 1;
     }
 
+    /// The effective budget for a specialized (non-Merk) lower layer:
+    /// the tighter of the global budget, the enclosing frame's
+    /// instance budget, and the lower query's own per-instance cap.
+    /// The adapters bypass recursive frame creation, so prover and
+    /// verifier both derive the lower budget through this single
+    /// helper — a divergence here would silently split their
+    /// accounting.
+    pub(crate) fn effective_lower_layer_limit(
+        &self,
+        frame_instance: Option<u16>,
+        lower_instance_limit: Option<u16>,
+    ) -> Option<u16> {
+        self.effective_layer_limit(Self::min_caps(frame_instance, lower_instance_limit))
+    }
+
     /// The budget a single layer's merk walk may still produce under —
     /// the tighter of the global budget and the frame's instance
     /// budget.

--- a/grovedb/src/operations/proof/verify.rs
+++ b/grovedb/src/operations/proof/verify.rs
@@ -2044,16 +2044,15 @@ impl GroveDb {
                                             // the lower query's own per-instance
                                             // cap — these adapters bypass the
                                             // recursive frame creation.
-                                            let lower_instance = super::V1LimitState::min_caps(
-                                                frame_instance,
-                                                query
-                                                    .query_items_at_path(&path, grove_version)?
-                                                    .and_then(|lower_query| {
-                                                        lower_query.instance_limit
-                                                    }),
-                                            );
-                                            let mut non_merk_effective =
-                                                limit_state.effective_layer_limit(lower_instance);
+                                            let mut non_merk_effective = limit_state
+                                                .effective_lower_layer_limit(
+                                                    frame_instance,
+                                                    query
+                                                        .query_items_at_path(&path, grove_version)?
+                                                        .and_then(|lower_query| {
+                                                            lower_query.instance_limit
+                                                        }),
+                                                );
                                             let non_merk_before = non_merk_effective;
                                             let lower_hash = Self::verify_mmr_lower_layer(
                                                 mmr_bytes,
@@ -2077,16 +2076,15 @@ impl GroveDb {
                                             // the lower query's own per-instance
                                             // cap — these adapters bypass the
                                             // recursive frame creation.
-                                            let lower_instance = super::V1LimitState::min_caps(
-                                                frame_instance,
-                                                query
-                                                    .query_items_at_path(&path, grove_version)?
-                                                    .and_then(|lower_query| {
-                                                        lower_query.instance_limit
-                                                    }),
-                                            );
-                                            let mut non_merk_effective =
-                                                limit_state.effective_layer_limit(lower_instance);
+                                            let mut non_merk_effective = limit_state
+                                                .effective_lower_layer_limit(
+                                                    frame_instance,
+                                                    query
+                                                        .query_items_at_path(&path, grove_version)?
+                                                        .and_then(|lower_query| {
+                                                            lower_query.instance_limit
+                                                        }),
+                                                );
                                             let non_merk_before = non_merk_effective;
                                             let lower_hash = Self::verify_bulk_append_lower_layer(
                                                 bulk_bytes,
@@ -2110,16 +2108,15 @@ impl GroveDb {
                                             // the lower query's own per-instance
                                             // cap — these adapters bypass the
                                             // recursive frame creation.
-                                            let lower_instance = super::V1LimitState::min_caps(
-                                                frame_instance,
-                                                query
-                                                    .query_items_at_path(&path, grove_version)?
-                                                    .and_then(|lower_query| {
-                                                        lower_query.instance_limit
-                                                    }),
-                                            );
-                                            let mut non_merk_effective =
-                                                limit_state.effective_layer_limit(lower_instance);
+                                            let mut non_merk_effective = limit_state
+                                                .effective_lower_layer_limit(
+                                                    frame_instance,
+                                                    query
+                                                        .query_items_at_path(&path, grove_version)?
+                                                        .and_then(|lower_query| {
+                                                            lower_query.instance_limit
+                                                        }),
+                                                );
                                             let non_merk_before = non_merk_effective;
                                             let lower_hash = Self::verify_dense_tree_lower_layer(
                                                 dense_bytes,
@@ -2143,16 +2140,15 @@ impl GroveDb {
                                             // the lower query's own per-instance
                                             // cap — these adapters bypass the
                                             // recursive frame creation.
-                                            let lower_instance = super::V1LimitState::min_caps(
-                                                frame_instance,
-                                                query
-                                                    .query_items_at_path(&path, grove_version)?
-                                                    .and_then(|lower_query| {
-                                                        lower_query.instance_limit
-                                                    }),
-                                            );
-                                            let mut non_merk_effective =
-                                                limit_state.effective_layer_limit(lower_instance);
+                                            let mut non_merk_effective = limit_state
+                                                .effective_lower_layer_limit(
+                                                    frame_instance,
+                                                    query
+                                                        .query_items_at_path(&path, grove_version)?
+                                                        .and_then(|lower_query| {
+                                                            lower_query.instance_limit
+                                                        }),
+                                                );
                                             let non_merk_before = non_merk_effective;
                                             let lower_hash =
                                                 Self::verify_commitment_tree_lower_layer(
@@ -2424,10 +2420,25 @@ impl GroveDb {
                         && internal_query.has_subquery_or_matching_in_path_on_key(key)
                     {
                         // An EMPTY tree a subquery matches: an empty
-                        // child, not a result row. Mirror the prover's
-                        // charge exactly — global budget only (it
-                        // bounds walks across many empty children),
-                        // per-instance budgets count result rows.
+                        // child, not a result row. When the governing
+                        // query asks for parent-tree inclusion, the
+                        // matched parent is still reported — empty and
+                        // non-empty parents must behave alike — and,
+                        // like every parent-tree row, it does not
+                        // consume a budget slot (the documented
+                        // known limitation on the flag).
+                        if query.should_add_parent_tree_at_path(current_path, grove_version)? {
+                            let path_key_optional_value =
+                                ProvedPathKeyOptionalValue::from_proved_key_value(
+                                    path.iter().map(|p| p.to_vec()).collect(),
+                                    proved_key_value.clone(),
+                                );
+                            result.push(path_key_optional_value.try_into_versioned(grove_version)?);
+                        }
+                        // Mirror the prover's charge exactly — global
+                        // budget only (it bounds walks across many
+                        // empty children), per-instance budgets count
+                        // result rows.
                         limit_state.charge_empty_layer();
                         if limit_state.is_exhausted(frame_instance) {
                             break;
@@ -2577,7 +2588,13 @@ impl GroveDb {
             ));
         }
 
-        // Add each verified leaf to the result set
+        // Add each verified leaf to the result set, following the query
+        // direction so a cap keeps the intended end of the range.
+        let mut verified_leaves = verified_leaves;
+        verified_leaves.sort_by_key(|(leaf_index, _)| *leaf_index);
+        if !sub_query.left_to_right {
+            verified_leaves.reverse();
+        }
         for (leaf_index, value) in verified_leaves {
             let key = leaf_index.to_be_bytes().to_vec();
             let element = Element::new_item(value);
@@ -2682,9 +2699,16 @@ impl GroveDb {
         let (start, end) = Self::extract_range_from_query_items(&sub_query.items)?;
         let end = end.min(proof_result.total_count);
 
-        let values = proof_result
+        let mut values = proof_result
             .values_in_range(start, end)
             .map_err(|e| Error::CorruptedData(format!("{}", e)))?;
+        // Result rows follow the query direction; the cap below then
+        // keeps the LAST positions for a descending query instead of
+        // truncating to the first ascending ones.
+        values.sort_by_key(|(position, _)| *position);
+        if !sub_query.left_to_right {
+            values.reverse();
+        }
 
         // Completeness: every position the query expects must be present in
         // the proof values. Build the expected set and check coverage.
@@ -2862,6 +2886,13 @@ impl GroveDb {
             .map_err(|e| Error::InvalidProof(query.clone(), format!("{}", e)))?;
 
         // Add each verified entry to the result set
+        // Follow the query direction so a cap keeps the intended end of
+        // the range.
+        let mut verified_entries = verified_entries;
+        verified_entries.sort_by_key(|(position, _)| *position);
+        if !sub_query.left_to_right {
+            verified_entries.reverse();
+        }
         for (position, value) in verified_entries {
             let key = position.to_be_bytes().to_vec();
             let elem = Element::new_item(value);
@@ -3035,7 +3066,7 @@ impl GroveDb {
     /// Expand query items (with BE u64 keys) into a set of individual positions
     /// bounded by `count`. Used for completeness checking in non-Merk
     /// verifiers.
-    fn expand_query_to_u64_positions(
+    pub(crate) fn expand_query_to_u64_positions(
         items: &[grovedb_merk::proofs::query::QueryItem],
         count: u64,
     ) -> Result<BTreeSet<u64>, Error> {

--- a/grovedb/src/operations/proof/verify.rs
+++ b/grovedb/src/operations/proof/verify.rs
@@ -1536,10 +1536,29 @@ impl GroveDb {
             ..Default::default()
         };
 
+        // Mirror of the prover's per-layer limit rule: a pure terminal
+        // layer (no subquery branches) runs under the tighter of the
+        // global and instance budgets — its merk rows ARE result rows.
+        // A layer with subquery branches runs under the global budget
+        // only: the instance chain budgets descendant ROWS, not
+        // children, and must not truncate which children appear (an
+        // empty child consumes no instance budget, so a later populated
+        // child may still owe rows). Prover and verifier must derive
+        // the identical value here or honest proofs fail the
+        // more-data-than-limit check.
+        let layer_limit = if matches!(
+            internal_query.has_subquery,
+            crate::query::HasSubquery::NoSubquery
+        ) {
+            limit_state.effective_layer_limit(frame_instance)
+        } else {
+            limit_state.global
+        };
+
         let (root_hash, merk_result) = level_query
             .execute_proof(
                 merk_proof_bytes,
-                limit_state.effective_layer_limit(frame_instance),
+                layer_limit,
                 left_to_right,
                 PROOF_VERSION_LATEST, // V1 proof: strict mode rejects items in value hash nodes
             )
@@ -2021,8 +2040,20 @@ impl GroveDb {
                                             )?
                                         }
                                         ProofBytes::MMR(mmr_bytes) => {
+                                            // Mirror of the prover: min-compose
+                                            // the lower query's own per-instance
+                                            // cap — these adapters bypass the
+                                            // recursive frame creation.
+                                            let lower_instance = super::V1LimitState::min_caps(
+                                                frame_instance,
+                                                query
+                                                    .query_items_at_path(&path, grove_version)?
+                                                    .and_then(|lower_query| {
+                                                        lower_query.instance_limit
+                                                    }),
+                                            );
                                             let mut non_merk_effective =
-                                                limit_state.effective_layer_limit(frame_instance);
+                                                limit_state.effective_layer_limit(lower_instance);
                                             let non_merk_before = non_merk_effective;
                                             let lower_hash = Self::verify_mmr_lower_layer(
                                                 mmr_bytes,
@@ -2042,8 +2073,20 @@ impl GroveDb {
                                             lower_hash
                                         }
                                         ProofBytes::BulkAppendTree(bulk_bytes) => {
+                                            // Mirror of the prover: min-compose
+                                            // the lower query's own per-instance
+                                            // cap — these adapters bypass the
+                                            // recursive frame creation.
+                                            let lower_instance = super::V1LimitState::min_caps(
+                                                frame_instance,
+                                                query
+                                                    .query_items_at_path(&path, grove_version)?
+                                                    .and_then(|lower_query| {
+                                                        lower_query.instance_limit
+                                                    }),
+                                            );
                                             let mut non_merk_effective =
-                                                limit_state.effective_layer_limit(frame_instance);
+                                                limit_state.effective_layer_limit(lower_instance);
                                             let non_merk_before = non_merk_effective;
                                             let lower_hash = Self::verify_bulk_append_lower_layer(
                                                 bulk_bytes,
@@ -2063,8 +2106,20 @@ impl GroveDb {
                                             lower_hash
                                         }
                                         ProofBytes::DenseTree(dense_bytes) => {
+                                            // Mirror of the prover: min-compose
+                                            // the lower query's own per-instance
+                                            // cap — these adapters bypass the
+                                            // recursive frame creation.
+                                            let lower_instance = super::V1LimitState::min_caps(
+                                                frame_instance,
+                                                query
+                                                    .query_items_at_path(&path, grove_version)?
+                                                    .and_then(|lower_query| {
+                                                        lower_query.instance_limit
+                                                    }),
+                                            );
                                             let mut non_merk_effective =
-                                                limit_state.effective_layer_limit(frame_instance);
+                                                limit_state.effective_layer_limit(lower_instance);
                                             let non_merk_before = non_merk_effective;
                                             let lower_hash = Self::verify_dense_tree_lower_layer(
                                                 dense_bytes,
@@ -2084,8 +2139,20 @@ impl GroveDb {
                                             lower_hash
                                         }
                                         ProofBytes::CommitmentTree(ct_bytes) => {
+                                            // Mirror of the prover: min-compose
+                                            // the lower query's own per-instance
+                                            // cap — these adapters bypass the
+                                            // recursive frame creation.
+                                            let lower_instance = super::V1LimitState::min_caps(
+                                                frame_instance,
+                                                query
+                                                    .query_items_at_path(&path, grove_version)?
+                                                    .and_then(|lower_query| {
+                                                        lower_query.instance_limit
+                                                    }),
+                                            );
                                             let mut non_merk_effective =
-                                                limit_state.effective_layer_limit(frame_instance);
+                                                limit_state.effective_layer_limit(lower_instance);
                                             let non_merk_before = non_merk_effective;
                                             let lower_hash =
                                                 Self::verify_commitment_tree_lower_layer(
@@ -2349,6 +2416,19 @@ impl GroveDb {
                             );
                         result.push(path_key_optional_value.try_into_versioned(grove_version)?);
                         limit_state.charge_row_with_instance(&mut frame_instance);
+                        if limit_state.is_exhausted(frame_instance) {
+                            break;
+                        }
+                    } else if element.is_any_tree()
+                        && !element.is_non_empty_tree()
+                        && internal_query.has_subquery_or_matching_in_path_on_key(key)
+                    {
+                        // An EMPTY tree a subquery matches: an empty
+                        // child, not a result row. Mirror the prover's
+                        // charge exactly — global budget only (it
+                        // bounds walks across many empty children),
+                        // per-instance budgets count result rows.
+                        limit_state.charge_empty_layer();
                         if limit_state.is_exhausted(frame_instance) {
                             break;
                         }

--- a/grovedb/src/query/merge/v1.rs
+++ b/grovedb/src/query/merge/v1.rs
@@ -111,8 +111,27 @@ pub(super) fn merge_v1(path_queries: Vec<&PathQuery>) -> Result<PathQuery, Error
     let mut merged_query = Query::merge_multiple_directional(queries_for_common_path_this_level)
         .map_err(|e| Error::NotSupported(e.to_string()))?;
 
-    // add conditional subqueries
-    for sub_path_query in queries_for_common_path_sub_level {
+    // Add conditional subqueries in a canonical order: every
+    // limit-free branch first (through the full merge machinery, which
+    // is still limit-free at that point), then the limit-carrying
+    // branches as exclusive grafts. Without the partition, acceptance
+    // would depend on input order — a disjoint limited branch
+    // processed early would force a later limit-free overlap onto the
+    // graft path and refuse it. The partition is deterministic (stable
+    // over input order), and the verifier re-runs the same merge, so
+    // both sides derive the identical query.
+    let carries_limits = |branch: &SubqueryBranch| {
+        branch
+            .subquery
+            .as_deref()
+            .is_some_and(|subquery| subquery.has_instance_limit_anywhere())
+    };
+    let (limited_branches, unlimited_branches): (Vec<SubqueryBranch>, Vec<SubqueryBranch>) =
+        queries_for_common_path_sub_level
+            .into_iter()
+            .partition(&carries_limits);
+
+    for sub_path_query in unlimited_branches {
         let SubqueryBranch {
             subquery_path,
             subquery,
@@ -120,18 +139,6 @@ pub(super) fn merge_v1(path_queries: Vec<&PathQuery>) -> Result<PathQuery, Error
         let mut subquery_path =
             subquery_path.ok_or(Error::CorruptedCodeExecution("subquery path must exist"))?;
         let key = subquery_path.remove(0); // must exist
-
-        // Whether the merged root's own selection already covers this
-        // branch's key — assessed BEFORE the branch's item is inserted
-        // (the graft's own `Key` would otherwise always match). A
-        // grafted conditional overrides the root query's default/
-        // terminal semantics for that key, so when limits are in play
-        // this is a collision, not a graft: proceeding would silently
-        // drop the root input's contribution for the key.
-        let overlaps_root_selection = merged_query
-            .items
-            .iter()
-            .any(|item| item.contains(key.as_slice()));
         merged_query.insert_item(QueryItem::Key(key.clone()));
         let rest_of_path = if subquery_path.is_empty() {
             None
@@ -142,43 +149,59 @@ pub(super) fn merge_v1(path_queries: Vec<&PathQuery>) -> Result<PathQuery, Error
             subquery_path: rest_of_path,
             subquery,
         };
-        let limits_in_play = merged_query.has_instance_limit_anywhere()
-            || subquery_branch
-                .subquery
-                .as_deref()
-                .is_some_and(|subquery| subquery.has_instance_limit_anywhere());
-        if limits_in_play {
-            // Budgets never blend: a limit-carrying branch (lifted or
-            // authored) merges only as an exclusive graft. Any overlap
-            // — with an existing conditional, or with the merged root's
-            // own selection for this key — would need the two sides'
-            // bodies (and budgets) merged, which is refused by design.
-            let collides = overlaps_root_selection
-                || merged_query
-                    .conditional_subquery_branches
-                    .as_ref()
-                    .is_some_and(|branches| {
-                        branches.keys().any(|item| item.contains(key.as_slice()))
-                    });
-            if collides {
-                return Err(Error::NotSupported(format!(
-                    "can not merge limited path queries whose branches collide at key {}; \
-                     remove the limits or merge the colliding queries separately",
-                    hex_to_ascii(&key),
-                )));
-            }
-            merged_query.add_conditional_subquery(
-                QueryItem::Key(key),
-                subquery_branch.subquery_path,
-                subquery_branch.subquery.map(|subquery| *subquery),
-            );
-        } else {
-            // See v0: read modes are rejected in the prelude; propagate
-            // rather than discard if one ever reaches here.
-            merged_query
-                .merge_conditional_boxed_subquery(QueryItem::Key(key), subquery_branch)
-                .map_err(|e| Error::NotSupported(e.to_string()))?;
+        // See v0: read modes are rejected in the prelude; propagate
+        // rather than discard if one ever reaches here. The merged
+        // query is still limit-free in this phase, so the machinery's
+        // blanket instance-limit gate cannot misfire.
+        merged_query
+            .merge_conditional_boxed_subquery(QueryItem::Key(key), subquery_branch)
+            .map_err(|e| Error::NotSupported(e.to_string()))?;
+    }
+
+    for sub_path_query in limited_branches {
+        let SubqueryBranch {
+            subquery_path,
+            subquery,
+        } = sub_path_query;
+        let mut subquery_path =
+            subquery_path.ok_or(Error::CorruptedCodeExecution("subquery path must exist"))?;
+        let key = subquery_path.remove(0); // must exist
+
+        // Budgets never blend: a limit-carrying branch merges only as
+        // an exclusive graft. Overlap with the merged root's own
+        // selection (assessed BEFORE this branch's item is inserted —
+        // the graft's own `Key` would otherwise always match) or with
+        // any already-merged conditional would need the two sides'
+        // bodies — and budgets — merged, which is refused by design.
+        // Only the actually colliding structures are consulted, so a
+        // disjoint limited branch cannot change another branch's
+        // acceptance.
+        let collides = merged_query
+            .items
+            .iter()
+            .any(|item| item.contains(key.as_slice()))
+            || merged_query
+                .conditional_subquery_branches
+                .as_ref()
+                .is_some_and(|branches| branches.keys().any(|item| item.contains(key.as_slice())));
+        if collides {
+            return Err(Error::NotSupported(format!(
+                "can not merge limited path queries whose branches collide at key {}; \
+                 remove the limits or merge the colliding queries separately",
+                hex_to_ascii(&key),
+            )));
         }
+        merged_query.insert_item(QueryItem::Key(key.clone()));
+        let rest_of_path = if subquery_path.is_empty() {
+            None
+        } else {
+            Some(subquery_path)
+        };
+        merged_query.add_conditional_subquery(
+            QueryItem::Key(key),
+            rest_of_path,
+            subquery.map(|subquery| *subquery),
+        );
     }
 
     // The agreed direction travels to the merged root (it would

--- a/grovedb/src/query/merge/v1.rs
+++ b/grovedb/src/query/merge/v1.rs
@@ -120,6 +120,17 @@ pub(super) fn merge_v1(path_queries: Vec<&PathQuery>) -> Result<PathQuery, Error
         let mut subquery_path =
             subquery_path.ok_or(Error::CorruptedCodeExecution("subquery path must exist"))?;
         let key = subquery_path.remove(0); // must exist
+                                           // Whether the merged root's own selection already covers this
+                                           // branch's key — assessed BEFORE the branch's item is inserted
+                                           // (the graft's own `Key` would otherwise always match). A
+                                           // grafted conditional overrides the root query's default/
+                                           // terminal semantics for that key, so when limits are in play
+                                           // this is a collision, not a graft: proceeding would silently
+                                           // drop the root input's contribution for the key.
+        let overlaps_root_selection = merged_query
+            .items
+            .iter()
+            .any(|item| item.contains(key.as_slice()));
         merged_query.insert_item(QueryItem::Key(key.clone()));
         let rest_of_path = if subquery_path.is_empty() {
             None
@@ -138,13 +149,16 @@ pub(super) fn merge_v1(path_queries: Vec<&PathQuery>) -> Result<PathQuery, Error
         if limits_in_play {
             // Budgets never blend: a limit-carrying branch (lifted or
             // authored) merges only as an exclusive graft. Any overlap
-            // with an existing conditional would need the two branches'
-            // bodies — and budgets — merged, which is refused by
-            // design.
-            let collides = merged_query
-                .conditional_subquery_branches
-                .as_ref()
-                .is_some_and(|branches| branches.keys().any(|item| item.contains(key.as_slice())));
+            // — with an existing conditional, or with the merged root's
+            // own selection for this key — would need the two sides'
+            // bodies (and budgets) merged, which is refused by design.
+            let collides = overlaps_root_selection
+                || merged_query
+                    .conditional_subquery_branches
+                    .as_ref()
+                    .is_some_and(|branches| {
+                        branches.keys().any(|item| item.contains(key.as_slice()))
+                    });
             if collides {
                 return Err(Error::NotSupported(format!(
                     "can not merge limited path queries whose branches collide at key {}; \

--- a/grovedb/src/query/merge/v1.rs
+++ b/grovedb/src/query/merge/v1.rs
@@ -69,7 +69,7 @@ pub(super) fn merge_v1(path_queries: Vec<&PathQuery>) -> Result<PathQuery, Error
                     // The input lands at the merged root, where its
                     // query body merges with the other root-level
                     // inputs — budgets cannot blend, so limits are
-                    // refused here even under v2.
+                    // refused here.
                     if carries_limits {
                         return Err(Error::NotSupported(
                             "can not merge a limited path query that lands at the merged root: \
@@ -120,13 +120,14 @@ pub(super) fn merge_v1(path_queries: Vec<&PathQuery>) -> Result<PathQuery, Error
         let mut subquery_path =
             subquery_path.ok_or(Error::CorruptedCodeExecution("subquery path must exist"))?;
         let key = subquery_path.remove(0); // must exist
-                                           // Whether the merged root's own selection already covers this
-                                           // branch's key — assessed BEFORE the branch's item is inserted
-                                           // (the graft's own `Key` would otherwise always match). A
-                                           // grafted conditional overrides the root query's default/
-                                           // terminal semantics for that key, so when limits are in play
-                                           // this is a collision, not a graft: proceeding would silently
-                                           // drop the root input's contribution for the key.
+
+        // Whether the merged root's own selection already covers this
+        // branch's key — assessed BEFORE the branch's item is inserted
+        // (the graft's own `Key` would otherwise always match). A
+        // grafted conditional overrides the root query's default/
+        // terminal semantics for that key, so when limits are in play
+        // this is a collision, not a graft: proceeding would silently
+        // drop the root input's contribution for the key.
         let overlaps_root_selection = merged_query
             .items
             .iter()

--- a/grovedb/src/query/mod.rs
+++ b/grovedb/src/query/mod.rs
@@ -1622,11 +1622,29 @@ pub(crate) fn reject_unserved_instance_limits_in_query(
                 .to_string(),
         )),
         1 => {
-            if grove_version.grovedb_versions.element.path_query_push == 0 {
-                return Err(Error::CorruptedCodeExecution(
-                    "grove version table serves per-instance limits but selects the v0 \
-                     path_query_push engine, which cannot account for them",
-                ));
+            // The engine selector is validated exactly: the dispatcher
+            // supports [0, 1], so an unknown future value must be a
+            // typed version error here too — otherwise a limited query
+            // that happens to match no data would silently succeed
+            // while the same table errors once data matches, making
+            // version validation data-dependent.
+            match grove_version.grovedb_versions.element.path_query_push {
+                0 => {
+                    return Err(Error::CorruptedCodeExecution(
+                        "grove version table serves per-instance limits but selects the v0 \
+                         path_query_push engine, which cannot account for them",
+                    ));
+                }
+                1 => {}
+                version => {
+                    return Err(Error::VersionError(
+                        grovedb_version::error::GroveVersionError::UnknownVersionMismatch {
+                            method: "path_query_push".to_string(),
+                            known_versions: vec![0, 1],
+                            received: version,
+                        },
+                    ));
+                }
             }
             if query.has_zero_instance_limit_anywhere() {
                 return Err(Error::InvalidQuery(

--- a/grovedb/src/tests/per_instance_gate_coverage_tests.rs
+++ b/grovedb/src/tests/per_instance_gate_coverage_tests.rs
@@ -452,3 +452,121 @@ fn public_query_item_wrapper_keeps_the_limit_offset_contract() {
         "query_item must reject a per-instance cap on the queried node"
     );
 }
+
+#[test]
+fn query_item_preflights_the_entire_query() {
+    use grovedb_merk::proofs::query::QueryItem;
+
+    use crate::{element::query::ElementQueryExtensions, query_result_type::QueryResultElement};
+
+    // A per-instance limit hiding in an unmatched conditional branch:
+    // without the recursive preflight, acceptance depended on database
+    // contents (rejected only once stored data made the branch match).
+    let legacy_version = &grovedb_version::version::GROVE_VERSIONS[2];
+    assert_eq!(legacy_version.protocol_version, 3);
+    let db = make_test_grovedb(legacy_version);
+    populate(&db, legacy_version);
+
+    let mut hidden = Query::new_range_full();
+    hidden.limit = Some(1);
+    let mut query = Query::new_range_full();
+    query.add_conditional_subquery(QueryItem::Key(b"zz".to_vec()), None, Some(hidden));
+    let sized_query = SizedQuery::new(query, None, None);
+
+    let mut results: Vec<QueryResultElement> = Vec::new();
+    let mut limit = None;
+    let mut offset = None;
+    let path: [&[u8]; 2] = [DOCS, b"p1"];
+    let result = Element::query_item(
+        &db.db,
+        &QueryItem::RangeFull(..),
+        &mut results,
+        &path,
+        &sized_query,
+        None,
+        &mut limit,
+        &mut offset,
+        Default::default(),
+        QueryResultType::QueryKeyElementPairResultType,
+        |args, grove_version| {
+            use grovedb_costs::CostsExt;
+            Element::basic_push(args, grove_version)
+                .wrap_with_cost(grovedb_costs::OperationCost::default())
+        },
+        legacy_version,
+    );
+    assert!(
+        matches!(result.unwrap(), Err(Error::NotSupported(_))),
+        "query_item must preflight limits in unmatched branches too"
+    );
+}
+
+#[test]
+fn unknown_push_engine_is_rejected_independently_of_data() {
+    // capability = 1 with an unknown engine selector must be a typed
+    // version error even when the query matches nothing — previously a
+    // limited missing-key query returned Ok(empty) because the
+    // dispatcher was never reached, making validation data-dependent.
+    let real = GroveVersion::latest();
+    let db = make_test_grovedb(real);
+    populate(&db, real);
+
+    let mut missing_sub = Query::new_range_full();
+    missing_sub.limit = Some(1);
+    let mut missing = Query::new_single_key(b"no-such-key".to_vec());
+    missing.set_subquery(missing_sub);
+    let path_query = PathQuery::new(vec![DOCS.to_vec()], SizedQuery::new(missing, None, None));
+
+    let mut unknown_engine = real.clone();
+    unknown_engine.grovedb_versions.element.path_query_push = 2;
+    let result = db.query_raw(
+        &path_query,
+        true,
+        true,
+        true,
+        QueryResultType::QueryPathKeyElementTrioResultType,
+        None,
+        &unknown_engine,
+    );
+    assert!(
+        matches!(result.unwrap(), Err(Error::VersionError(_))),
+        "an unknown engine selector must be rejected up front"
+    );
+}
+
+#[test]
+fn subordinate_method_version_slots_still_gate_the_internal_walk() {
+    // The internal helpers are entered directly by the engines, so
+    // their subordinate slots must be validated inside them — a
+    // future/replay table bumping a slot must not silently run today's
+    // semantics.
+    let real = GroveVersion::latest();
+    let db = make_test_grovedb(real);
+    populate(&db, real);
+
+    let mut query = Query::new_range_full();
+    query.set_subquery(Query::new_range_full());
+    let path_query = PathQuery::new(vec![DOCS.to_vec()], SizedQuery::new(query, Some(2), None));
+
+    for doctor in [
+        (|v: &mut GroveVersion| v.grovedb_versions.element.query_item = 1) as fn(&mut GroveVersion),
+        |v| v.grovedb_versions.element.get_query_apply_function = 1,
+        |v| v.grovedb_versions.element.get_path_query = 1,
+    ] {
+        let mut doctored = real.clone();
+        doctor(&mut doctored);
+        let result = db.query_raw(
+            &path_query,
+            true,
+            true,
+            true,
+            QueryResultType::QueryPathKeyElementTrioResultType,
+            None,
+            &doctored,
+        );
+        assert!(
+            matches!(result.unwrap(), Err(Error::VersionError(_))),
+            "a bumped subordinate slot must reject, not run today's semantics"
+        );
+    }
+}

--- a/grovedb/src/tests/per_instance_limit_tests.rs
+++ b/grovedb/src/tests/per_instance_limit_tests.rs
@@ -844,3 +844,235 @@ fn make_empty_grovedb_smoke_for_instance_limit_defaults() {
         .unwrap()
         .expect("plain queries still prove");
 }
+
+#[test]
+fn instance_cap_does_not_truncate_the_parent_walk_in_proofs() {
+    // A parent layer's merk walk must not be truncated by an instance
+    // cap: the cap budgets descendant ROWS, and an empty first child
+    // consumes none of it, so a later populated child still owes rows.
+    // With the cap wrongly applied to the parent walk, the proof
+    // carried only `a_empty` and verified to zero rows while the
+    // trusted read returned `b_full/k0`.
+    let grove_version = GroveVersion::latest();
+    let db = make_test_grovedb(grove_version);
+    use crate::tests::common::EMPTY_PATH;
+    db.insert(
+        EMPTY_PATH,
+        DOCS,
+        Element::empty_tree(),
+        None,
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("insert docs tree");
+    db.insert(
+        [DOCS].as_ref(),
+        b"a_empty",
+        Element::empty_tree(),
+        None,
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("insert empty child");
+    db.insert(
+        [DOCS].as_ref(),
+        b"b_full",
+        Element::empty_tree(),
+        None,
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("insert full child");
+    db.insert(
+        [DOCS, b"b_full".as_slice()].as_ref(),
+        b"k0",
+        Element::new_item(vec![0]),
+        None,
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("insert item");
+
+    let mut root = Query::new_range_full();
+    root.set_subquery(Query::new_range_full());
+    root.limit = Some(1);
+    let path_query = PathQuery::new(vec![DOCS.to_vec()], SizedQuery::new(root, None, None));
+
+    let rows = assert_proved_matches_trusted_read(&db, &path_query, grove_version);
+    assert_eq!(rows, 1, "the populated later sibling still owes its row");
+}
+
+/// Builds `PathQuery` selecting `tree_key` under `path` and descending
+/// with `inner` — the shape the non-Merk (MMR / BulkAppend / Dense)
+/// proof layers are reached through.
+fn non_merk_child_query(tree_key: &[u8], inner: Query) -> PathQuery {
+    let mut root = Query::new_single_key(tree_key.to_vec());
+    root.set_subquery(inner);
+    PathQuery::new(vec![], SizedQuery::new(root, None, None))
+}
+
+#[test]
+fn non_merk_children_honor_their_own_instance_caps_in_proofs() {
+    // The non-Merk proof adapters bypass the recursive frame creation,
+    // so the lower query's own `Query::limit` must be min-composed on
+    // both sides; without it the verifier returned every selected row.
+    let grove_version = GroveVersion::latest();
+    use crate::tests::common::EMPTY_PATH;
+
+    // Dense tree: 10 entries, child cap 3.
+    let db = make_test_grovedb(grove_version);
+    db.insert(
+        EMPTY_PATH,
+        b"dense",
+        Element::empty_dense_tree(4),
+        None,
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("insert dense tree");
+    for i in 0..10u16 {
+        db.dense_tree_insert(
+            EMPTY_PATH,
+            b"dense",
+            format!("v_{i}").into_bytes(),
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("dense insert");
+    }
+    let mut inner = Query::new();
+    inner.insert_range_inclusive(0u16.to_be_bytes().to_vec()..=9u16.to_be_bytes().to_vec());
+    inner.limit = Some(3);
+    let path_query = non_merk_child_query(b"dense", inner);
+    let proof = db
+        .prove_query(&path_query, None, grove_version)
+        .unwrap()
+        .expect("prove dense with child cap");
+    let (_, result_set) =
+        crate::GroveDb::verify_query(&proof, &path_query, grove_version).expect("verify");
+    assert_eq!(result_set.len(), 3, "dense child cap must bound rows");
+
+    // BulkAppendTree: 3 entries, child cap 1 (the reported repro).
+    let db = make_test_grovedb(grove_version);
+    db.insert(
+        EMPTY_PATH,
+        b"bulk",
+        Element::empty_bulk_append_tree(2).expect("valid chunk power"),
+        None,
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("insert bulk tree");
+    for i in 0..3u8 {
+        db.bulk_append(EMPTY_PATH, b"bulk", vec![i], None, grove_version)
+            .unwrap()
+            .expect("bulk append");
+    }
+    let mut inner = Query::new();
+    inner.insert_range(0u64.to_be_bytes().to_vec()..3u64.to_be_bytes().to_vec());
+    inner.limit = Some(1);
+    let path_query = non_merk_child_query(b"bulk", inner);
+    let proof = db
+        .prove_query(&path_query, None, grove_version)
+        .unwrap()
+        .expect("prove bulk with child cap");
+    let (_, result_set) =
+        crate::GroveDb::verify_query(&proof, &path_query, grove_version).expect("verify");
+    assert_eq!(result_set.len(), 1, "bulk child cap must bound rows");
+
+    // MmrTree: 3 leaves, child cap 1.
+    let db = make_test_grovedb(grove_version);
+    db.insert(
+        EMPTY_PATH,
+        b"mmr",
+        Element::empty_mmr_tree(),
+        None,
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("insert mmr tree");
+    for i in 0..3u8 {
+        db.mmr_tree_append(EMPTY_PATH, b"mmr", vec![i], None, grove_version)
+            .unwrap()
+            .expect("mmr append");
+    }
+    let mut inner = Query::new();
+    inner.insert_range_inclusive(0u64.to_be_bytes().to_vec()..=2u64.to_be_bytes().to_vec());
+    inner.limit = Some(1);
+    let path_query = non_merk_child_query(b"mmr", inner);
+    let proof = db
+        .prove_query(&path_query, None, grove_version)
+        .unwrap()
+        .expect("prove mmr with child cap");
+    let (_, result_set) =
+        crate::GroveDb::verify_query(&proof, &path_query, grove_version).expect("verify");
+    assert_eq!(result_set.len(), 1, "mmr child cap must bound rows");
+}
+
+#[test]
+fn empty_bulk_child_range_with_active_cap_does_not_underflow() {
+    // A bulk child query whose positions all sit at or past the stored
+    // count clamps its range empty; with an active cap the layer's
+    // accounting subtracted `0 - start` and panicked in debug builds.
+    let grove_version = GroveVersion::latest();
+    use crate::tests::common::EMPTY_PATH;
+    let db = make_test_grovedb(grove_version);
+    db.insert(
+        EMPTY_PATH,
+        b"bulk",
+        Element::empty_bulk_append_tree(2).expect("valid chunk power"),
+        None,
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("insert bulk tree");
+    for i in 0..3u8 {
+        db.bulk_append(EMPTY_PATH, b"bulk", vec![i], None, grove_version)
+            .unwrap()
+            .expect("bulk append");
+    }
+    let mut inner = Query::new();
+    inner.insert_range(5u64.to_be_bytes().to_vec()..8u64.to_be_bytes().to_vec());
+    let mut path_query = non_merk_child_query(b"bulk", inner);
+    path_query.query.limit = Some(2);
+    let proof = db
+        .prove_query(&path_query, None, grove_version)
+        .unwrap()
+        .expect("an empty child range must prove, not underflow");
+    let (_, result_set) =
+        crate::GroveDb::verify_query(&proof, &path_query, grove_version).expect("verify");
+    assert!(result_set.is_empty(), "nothing stored in the range");
+}
+
+#[test]
+fn merge_refuses_limited_branch_overlapping_the_root_selection() {
+    // A grafted conditional overrides the merged root's default/
+    // terminal semantics for its key — if a root-landing input already
+    // selects that key, proceeding would silently drop its
+    // contribution.
+    let grove_version = GroveVersion::latest();
+
+    let mut root_query = Query::new_single_key(DOCS.to_vec());
+    root_query.set_subquery(Query::new_single_key(b"root-only".to_vec()));
+    let at_root = PathQuery::new_unsized(vec![], root_query);
+
+    let limited = PathQuery::new(
+        vec![DOCS.to_vec()],
+        SizedQuery::new(Query::new_single_key(b"limited".to_vec()), Some(1), None),
+    );
+
+    let result = PathQuery::merge(vec![&at_root, &limited], grove_version);
+    assert!(
+        matches!(&result, Err(Error::NotSupported(message)) if message.contains("collide")),
+        "root-selection overlap must be a collision, got {result:?}"
+    );
+}

--- a/grovedb/src/tests/per_instance_limit_tests.rs
+++ b/grovedb/src/tests/per_instance_limit_tests.rs
@@ -1076,3 +1076,368 @@ fn merge_refuses_limited_branch_overlapping_the_root_selection() {
         "root-selection overlap must be a collision, got {result:?}"
     );
 }
+
+#[test]
+fn merge_acceptance_is_independent_of_input_order() {
+    // A disjoint limited branch must not change whether an unrelated
+    // limit-free overlap merges: limit-free branches merge first (full
+    // machinery), limited grafts come last, so every permutation
+    // derives the same query.
+    let grove_version = GroveVersion::latest();
+
+    let mut root_query = Query::new_single_key(DOCS.to_vec());
+    root_query.set_subquery(Query::new_single_key(b"root-only".to_vec()));
+    let at_root = PathQuery::new_unsized(vec![], root_query);
+
+    let overlapping = PathQuery::new_unsized(
+        vec![DOCS.to_vec()],
+        Query::new_single_key(b"also-docs".to_vec()),
+    );
+
+    let disjoint_limited = PathQuery::new(
+        vec![b"other".to_vec()],
+        SizedQuery::new(Query::new_single_key(b"x".to_vec()), Some(1), None),
+    );
+
+    let merged_a = PathQuery::merge(
+        vec![&at_root, &overlapping, &disjoint_limited],
+        grove_version,
+    )
+    .expect("limit-free overlap must merge regardless of the disjoint limited branch");
+    let merged_b = PathQuery::merge(
+        vec![&at_root, &disjoint_limited, &overlapping],
+        grove_version,
+    )
+    .expect("the permutation must merge identically");
+    assert_eq!(merged_a, merged_b, "permutations must derive one query");
+}
+
+#[test]
+fn descending_child_caps_keep_the_last_positions() {
+    // The specialized adapters must order rows by the query direction
+    // before the cap applies: a descending cap keeps the LAST
+    // positions, not the first ascending ones.
+    let grove_version = GroveVersion::latest();
+    use crate::tests::common::EMPTY_PATH;
+
+    let make_desc_inner = |upper: u64| {
+        let mut inner = Query::new_with_direction(false);
+        inner.insert_range_inclusive(0u64.to_be_bytes().to_vec()..=upper.to_be_bytes().to_vec());
+        inner.limit = Some(1);
+        inner
+    };
+
+    // BulkAppendTree.
+    let db = make_test_grovedb(grove_version);
+    db.insert(
+        EMPTY_PATH,
+        b"bulk",
+        Element::empty_bulk_append_tree(2).expect("valid chunk power"),
+        None,
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("insert bulk tree");
+    for i in 0..3u8 {
+        db.bulk_append(EMPTY_PATH, b"bulk", vec![i], None, grove_version)
+            .unwrap()
+            .expect("bulk append");
+    }
+    let path_query = non_merk_child_query(b"bulk", make_desc_inner(2));
+    let proof = db
+        .prove_query(&path_query, None, grove_version)
+        .unwrap()
+        .expect("prove");
+    let (_, result_set) =
+        crate::GroveDb::verify_query(&proof, &path_query, grove_version).expect("verify");
+    assert_eq!(result_set.len(), 1);
+    assert_eq!(
+        result_set[0].1,
+        2u64.to_be_bytes().to_vec(),
+        "descending bulk cap must keep the last position"
+    );
+
+    // MmrTree.
+    let db = make_test_grovedb(grove_version);
+    db.insert(
+        EMPTY_PATH,
+        b"mmr",
+        Element::empty_mmr_tree(),
+        None,
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("insert mmr tree");
+    for i in 0..3u8 {
+        db.mmr_tree_append(EMPTY_PATH, b"mmr", vec![i], None, grove_version)
+            .unwrap()
+            .expect("mmr append");
+    }
+    let path_query = non_merk_child_query(b"mmr", make_desc_inner(2));
+    let proof = db
+        .prove_query(&path_query, None, grove_version)
+        .unwrap()
+        .expect("prove");
+    let (_, result_set) =
+        crate::GroveDb::verify_query(&proof, &path_query, grove_version).expect("verify");
+    assert_eq!(result_set.len(), 1);
+    assert_eq!(
+        result_set[0].1,
+        2u64.to_be_bytes().to_vec(),
+        "descending mmr cap must keep the last leaf"
+    );
+
+    // DenseAppendOnlyFixedSizeTree (u16 position keys).
+    let db = make_test_grovedb(grove_version);
+    db.insert(
+        EMPTY_PATH,
+        b"dense",
+        Element::empty_dense_tree(4),
+        None,
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("insert dense tree");
+    for i in 0..3u16 {
+        db.dense_tree_insert(
+            EMPTY_PATH,
+            b"dense",
+            format!("v_{i}").into_bytes(),
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("dense insert");
+    }
+    let mut inner = Query::new_with_direction(false);
+    inner.insert_range_inclusive(0u16.to_be_bytes().to_vec()..=2u16.to_be_bytes().to_vec());
+    inner.limit = Some(1);
+    let path_query = non_merk_child_query(b"dense", inner);
+    let proof = db
+        .prove_query(&path_query, None, grove_version)
+        .unwrap()
+        .expect("prove");
+    let (_, result_set) =
+        crate::GroveDb::verify_query(&proof, &path_query, grove_version).expect("verify");
+    assert_eq!(result_set.len(), 1);
+    assert_eq!(
+        result_set[0].1,
+        2u16.to_be_bytes().to_vec(),
+        "descending dense cap must keep the last position"
+    );
+
+    // CommitmentTree (delegates to the BulkAppend machinery).
+    let db = make_test_grovedb(grove_version);
+    db.insert(
+        EMPTY_PATH,
+        b"ct",
+        Element::empty_commitment_tree(11).expect("valid chunk power"),
+        None,
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("insert commitment tree");
+    for i in 0..3u8 {
+        let mut cmx = [0u8; 32];
+        cmx[0] = i;
+        cmx[31] &= 0x7f;
+        let mut rho = [0u8; 32];
+        rho[0] = i;
+        rho[1] = 0xB0;
+        let mut cv_net = [0u8; 32];
+        cv_net[0] = i;
+        cv_net[1] = 0xCC;
+        let mut enc_data = [0u8; 104];
+        enc_data[0] = i;
+        let mut epk = [0u8; 32];
+        epk[0] = i;
+        let mut out_ct = [0u8; 80];
+        out_ct[0] = i;
+        let ciphertext = grovedb_commitment_tree::TransmittedNoteCiphertext::<
+            grovedb_commitment_tree::DashMemo,
+        >::from_parts(
+            epk,
+            grovedb_commitment_tree::NoteBytesData(enc_data),
+            out_ct,
+        );
+        db.commitment_tree_insert(
+            EMPTY_PATH,
+            b"ct",
+            cmx,
+            rho,
+            cv_net,
+            ciphertext,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("commitment tree insert");
+    }
+    let path_query = non_merk_child_query(b"ct", make_desc_inner(2));
+    let proof = db
+        .prove_query(&path_query, None, grove_version)
+        .unwrap()
+        .expect("prove");
+    let (_, result_set) =
+        crate::GroveDb::verify_query(&proof, &path_query, grove_version).expect("verify");
+    assert_eq!(result_set.len(), 1);
+    assert_eq!(
+        result_set[0].1,
+        2u64.to_be_bytes().to_vec(),
+        "descending commitment-tree cap must keep the last position"
+    );
+}
+
+#[test]
+fn sparse_bulk_queries_charge_matched_rows_not_the_span() {
+    // Stored/requested positions 0 and 100 under a global limit of 3:
+    // charging the bounding span exhausted the prover's budget and
+    // omitted the later sibling's layer, which the verifier — charging
+    // per matching row — then rejected as missing.
+    let grove_version = GroveVersion::latest();
+    use crate::tests::common::EMPTY_PATH;
+    let db = make_test_grovedb(grove_version);
+    db.insert(
+        EMPTY_PATH,
+        b"a_bulk",
+        Element::empty_bulk_append_tree(2).expect("valid chunk power"),
+        None,
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("insert bulk tree");
+    for i in 0..101u8 {
+        db.bulk_append(EMPTY_PATH, b"a_bulk", vec![i], None, grove_version)
+            .unwrap()
+            .expect("bulk append");
+    }
+    db.insert(
+        EMPTY_PATH,
+        b"z_tree",
+        Element::empty_tree(),
+        None,
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("insert sibling tree");
+    db.insert(
+        [b"z_tree".as_slice()].as_ref(),
+        b"row",
+        Element::new_item(vec![9]),
+        None,
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("insert sibling row");
+
+    let mut sparse = Query::new();
+    sparse.insert_key(0u64.to_be_bytes().to_vec());
+    sparse.insert_key(100u64.to_be_bytes().to_vec());
+    // Conditional routing: the bulk child gets the sparse position
+    // query; the sibling tree descends into its rows.
+    let mut root = Query::new();
+    root.insert_key(b"a_bulk".to_vec());
+    root.insert_key(b"z_tree".to_vec());
+    root.add_conditional_subquery(
+        grovedb_query::QueryItem::Key(b"a_bulk".to_vec()),
+        None,
+        Some(sparse),
+    );
+    root.add_conditional_subquery(
+        grovedb_query::QueryItem::Key(b"z_tree".to_vec()),
+        None,
+        Some(Query::new_range_full()),
+    );
+    let path_query = PathQuery::new(vec![], SizedQuery::new(root, Some(3), None));
+
+    let proof = db
+        .prove_query(&path_query, None, grove_version)
+        .unwrap()
+        .expect("prove");
+    let (_, result_set) = crate::GroveDb::verify_query(&proof, &path_query, grove_version)
+        .expect("the honest proof must verify — budgets stay in sync");
+    assert_eq!(
+        result_set.len(),
+        3,
+        "two sparse bulk rows plus the sibling row"
+    );
+}
+
+#[test]
+fn empty_parents_are_reported_when_parent_inclusion_is_requested() {
+    // With add_parent_tree_on_subquery, empty and non-empty matched
+    // parents must behave alike: both parent rows are reported (parent
+    // rows stay uncharged — the documented limitation on the flag).
+    let grove_version = GroveVersion::latest();
+    let db = make_test_grovedb(grove_version);
+    use crate::tests::common::EMPTY_PATH;
+    db.insert(
+        EMPTY_PATH,
+        DOCS,
+        Element::empty_tree(),
+        None,
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("insert docs tree");
+    db.insert(
+        [DOCS].as_ref(),
+        b"e_empty",
+        Element::empty_tree(),
+        None,
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("insert empty child");
+    db.insert(
+        [DOCS].as_ref(),
+        b"full",
+        Element::empty_tree(),
+        None,
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("insert full child");
+    db.insert(
+        [DOCS, b"full".as_slice()].as_ref(),
+        b"k0",
+        Element::new_item(vec![0]),
+        None,
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("insert item");
+
+    let mut root = Query::new_range_full();
+    root.set_subquery(Query::new_range_full());
+    root.add_parent_tree_on_subquery = true;
+    let path_query = PathQuery::new(vec![DOCS.to_vec()], SizedQuery::new(root, None, None));
+
+    let proof = db
+        .prove_query(&path_query, None, grove_version)
+        .unwrap()
+        .expect("prove");
+    let (_, result_set) =
+        crate::GroveDb::verify_query(&proof, &path_query, grove_version).expect("verify");
+    let keys: Vec<&[u8]> = result_set
+        .iter()
+        .map(|(_, key, _)| key.as_slice())
+        .collect();
+    assert!(
+        keys.contains(&b"e_empty".as_slice()),
+        "the empty matched parent must be reported, got keys {keys:?}"
+    );
+    assert!(keys.contains(&b"full".as_slice()));
+    assert!(keys.contains(&b"k0".as_slice()));
+}


### PR DESCRIPTION
Follow-up PR for the review comments on #844 (merged) and #845 (merged before its final review-fix push landed — this PR carries those commits).

## P1 fixes reviewed on #845 (cherry-picked; the squash-merge raced past them)

- **Instance caps no longer truncate the parent walk.** A layer with subquery branches runs its merk walk under the **global** budget only: the instance cap counts descendant rows, and an empty first child consumes none of it, so truncating the child enumeration discarded later populated children (prove/verify returned 0 rows where the trusted read returned `b_full/k0`). Pure terminal layers keep `min(global, instance)`; the verifier derives the identical per-layer value.
- That exposed a truncation-masked prover/verifier asymmetry on subquery-matched **empty** trees (prover charged a row incl. instance; verifier charged nothing). Both sides now charge them as empty children — global budget only, mirroring the trusted read's empty-subquery charge.
- The four **non-Merk adapters** (MMR / BulkAppend / Dense / CommitmentTree) min-compose the lower query's own `Query::limit` on both prover and verifier — they bypass recursive frame creation, so a child cap of 1 verified 3 rows.
- The BulkAppend layer accounting **saturates on an empty child range** (positions at/past `total_count` clamped `end` below `start`: debug-panic underflow, ~65k rows charged in release).
- The merge lift treats **overlap with the merged root's own selection** as a collision — a grafted conditional overrides the root query's default/terminal semantics for that key and silently dropped the root-landing input's contribution.

## #844 post-merge follow-ups

- **Versioned serde representation** for `Query`, hand-written and format-aware: a fixed always-present positional layout with a leading `version` (non-self-describing formats round-trip; cross-generation payloads fail cleanly), flat base-compatible JSON for versions 1–2 (old readers keep serving everything they can serve), and the limit-bearing version 3 **nested under `body`** so a pre-limit reader hard-fails on missing fields instead of silently ignoring the unknown `limit` key and decoding an unlimited query. Unknown flat keys are refused; canonical version claims enforced. Cross-generation writer/reader tests cover both directions in both format families.
- `Element::query_item` runs the recursive whole-query preflight — an unmatched limited conditional previously made acceptance depend on database contents.
- The internal walk helpers validate their **subordinate method-version slots** (`element.query_item`, `element.get_query_apply_function`, `element.get_path_query`) which the wrapper-only checks stopped covering after the refactor; doctored-slot tests pin all three.
- Both coherence gates **exact-match the `path_query_push` selector**: an unknown engine value is a typed `UnknownVersionMismatch` up front, independent of whether any data matches.

Full workspace suite: 5156 passed / 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added version-aware query serialization for compatible JSON and binary representations across query versions.
  - Added validation for unsupported query versions and unknown fields.

- **Bug Fixes**
  - Improved query-limit enforcement across nested queries, proofs, empty results, and specialized data structures.
  - Corrected limit handling for sparse and descending queries.
  - Prevented silent data loss when limited queries overlap merged results.
  - Added clearer failures for unsupported or unknown query engine versions.

- **Tests**
  - Expanded coverage for serialization compatibility, query limits, proof behavior, merges, and version validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->