### PR TITLE
feat: flat-subtree drop — O(1) removal of a populated subtree with staged range-tombstone reclamation (#848)

### DIFF
--- a/grovedb-version/src/tests.rs
+++ b/grovedb-version/src/tests.rs
@@ -96,6 +96,26 @@ fn private_document_store_slots_are_gated_to_v4() {
 }
 
 #[test]
+fn flat_drop_slots_are_gated_to_v4() {
+    // The flat-subtree drop family (issue #848) fails closed on every
+    // released version: all slots must be 0 on V1..V3 and 1 on V4.
+    // Changing a V1..V3 value would retroactively enable an O(1) drop of
+    // populated subtrees on a live protocol version — a consensus break.
+    for v in [&GROVE_V1, &GROVE_V2, &GROVE_V3] {
+        let flat_drop = &v.grovedb_versions.operations.flat_drop;
+        assert_eq!(flat_drop.drop_flat_subtree, 0, "v{}", v.protocol_version);
+        assert_eq!(
+            flat_drop.batch_delete_tree_drop_flat, 0,
+            "v{}",
+            v.protocol_version
+        );
+    }
+    let flat_drop = &GROVE_V4.grovedb_versions.operations.flat_drop;
+    assert_eq!(flat_drop.drop_flat_subtree, 1);
+    assert_eq!(flat_drop.batch_delete_tree_drop_flat, 1);
+}
+
+#[test]
 fn grove_versions_ordered_by_protocol_version() {
     for window in GROVE_VERSIONS.windows(2) {
         assert!(window[0].protocol_version < window[1].protocol_version);

--- a/grovedb-version/src/version/grovedb_versions.rs
+++ b/grovedb-version/src/version/grovedb_versions.rs
@@ -179,6 +179,32 @@ pub struct GroveDBOperationsVersions {
     pub average_case: GroveDBOperationsAverageCaseVersions,
     pub worst_case: GroveDBOperationsWorstCaseVersions,
     pub private_document_store: GroveDBOperationsPrivateDocumentStoreVersions,
+    pub flat_drop: GroveDBOperationsFlatDropVersions,
+}
+
+/// Version slots for the flat-subtree drop family (issue #848): O(1)
+/// removal of a populated subtree that is declared to contain no child
+/// subtrees, with storage reclaimed by DB-level range tombstones driven
+/// from a durable redo record.
+///
+/// Like [`GroveDBOperationsPrivateDocumentStoreVersions`], these slots are
+/// **capability gates**, not implementation selectors: slot value `0`
+/// means the operation is unavailable and fails closed with a
+/// version-mismatch error; `1` means the v1 implementation is active.
+/// `GROVE_V1`..`GROVE_V3` hold every slot at `0`; `GROVE_V4` flips them to
+/// `1`.
+///
+/// `GroveDb::flush_pending_prefix_drops` is deliberately ungated: it only
+/// reclaims storage for redo records that a gated operation already
+/// created, never touches the root hash, and is a no-op when no records
+/// exist.
+#[derive(Clone, Debug, Default)]
+pub struct GroveDBOperationsFlatDropVersions {
+    /// The standalone `GroveDb::drop_flat_subtree` operation.
+    pub drop_flat_subtree: FeatureVersion,
+    /// The `SubelementsDeletionBehavior::DropFlat` behavior on batch
+    /// `DeleteTree` ops.
+    pub batch_delete_tree_drop_flat: FeatureVersion,
 }
 
 /// Version slots for the PrivateDocumentStore operation family.

--- a/grovedb-version/src/version/v1.rs
+++ b/grovedb-version/src/version/v1.rs
@@ -6,10 +6,10 @@ use crate::version::{
     grovedb_versions::{
         GroveDBApplyBatchVersions, GroveDBElementMethodVersions,
         GroveDBOperationsAverageCaseVersions, GroveDBOperationsDeleteUpTreeVersions,
-        GroveDBOperationsDeleteVersions, GroveDBOperationsGetVersions,
-        GroveDBOperationsIndexedAxisVersions, GroveDBOperationsInsertVersions,
-        GroveDBOperationsPrivateDocumentStoreVersions, GroveDBOperationsProofVersions,
-        GroveDBOperationsQueryVersions, GroveDBOperationsVersions,
+        GroveDBOperationsDeleteVersions, GroveDBOperationsFlatDropVersions,
+        GroveDBOperationsGetVersions, GroveDBOperationsIndexedAxisVersions,
+        GroveDBOperationsInsertVersions, GroveDBOperationsPrivateDocumentStoreVersions,
+        GroveDBOperationsProofVersions, GroveDBOperationsQueryVersions, GroveDBOperationsVersions,
         GroveDBOperationsWorstCaseVersions, GroveDBPathQueryMethodVersions, GroveDBQueryLimits,
         GroveDBReplicationVersions, GroveDBVersions,
     },
@@ -222,6 +222,12 @@ pub const GROVE_V1: GroveVersion = GroveVersion {
                 insert: 0,
                 get_value: 0,
                 count: 0,
+            },
+            // Flat-subtree drop (issue #848) is unavailable before
+            // GROVE_V4: every slot is 0 and the operations fail closed.
+            flat_drop: GroveDBOperationsFlatDropVersions {
+                drop_flat_subtree: 0,
+                batch_delete_tree_drop_flat: 0,
             },
         },
         aggregate_sum_path_query_methods: GroveDBAggregateSumPathQueryMethodVersions { merge: 0 },

--- a/grovedb-version/src/version/v2.rs
+++ b/grovedb-version/src/version/v2.rs
@@ -6,10 +6,10 @@ use crate::version::{
     grovedb_versions::{
         GroveDBApplyBatchVersions, GroveDBElementMethodVersions,
         GroveDBOperationsAverageCaseVersions, GroveDBOperationsDeleteUpTreeVersions,
-        GroveDBOperationsDeleteVersions, GroveDBOperationsGetVersions,
-        GroveDBOperationsIndexedAxisVersions, GroveDBOperationsInsertVersions,
-        GroveDBOperationsPrivateDocumentStoreVersions, GroveDBOperationsProofVersions,
-        GroveDBOperationsQueryVersions, GroveDBOperationsVersions,
+        GroveDBOperationsDeleteVersions, GroveDBOperationsFlatDropVersions,
+        GroveDBOperationsGetVersions, GroveDBOperationsIndexedAxisVersions,
+        GroveDBOperationsInsertVersions, GroveDBOperationsPrivateDocumentStoreVersions,
+        GroveDBOperationsProofVersions, GroveDBOperationsQueryVersions, GroveDBOperationsVersions,
         GroveDBOperationsWorstCaseVersions, GroveDBPathQueryMethodVersions, GroveDBQueryLimits,
         GroveDBReplicationVersions, GroveDBVersions,
     },
@@ -222,6 +222,12 @@ pub const GROVE_V2: GroveVersion = GroveVersion {
                 insert: 0,
                 get_value: 0,
                 count: 0,
+            },
+            // Flat-subtree drop (issue #848) is unavailable before
+            // GROVE_V4: every slot is 0 and the operations fail closed.
+            flat_drop: GroveDBOperationsFlatDropVersions {
+                drop_flat_subtree: 0,
+                batch_delete_tree_drop_flat: 0,
             },
         },
         aggregate_sum_path_query_methods: GroveDBAggregateSumPathQueryMethodVersions { merge: 0 },

--- a/grovedb-version/src/version/v3.rs
+++ b/grovedb-version/src/version/v3.rs
@@ -6,10 +6,10 @@ use crate::version::{
     grovedb_versions::{
         GroveDBApplyBatchVersions, GroveDBElementMethodVersions,
         GroveDBOperationsAverageCaseVersions, GroveDBOperationsDeleteUpTreeVersions,
-        GroveDBOperationsDeleteVersions, GroveDBOperationsGetVersions,
-        GroveDBOperationsIndexedAxisVersions, GroveDBOperationsInsertVersions,
-        GroveDBOperationsPrivateDocumentStoreVersions, GroveDBOperationsProofVersions,
-        GroveDBOperationsQueryVersions, GroveDBOperationsVersions,
+        GroveDBOperationsDeleteVersions, GroveDBOperationsFlatDropVersions,
+        GroveDBOperationsGetVersions, GroveDBOperationsIndexedAxisVersions,
+        GroveDBOperationsInsertVersions, GroveDBOperationsPrivateDocumentStoreVersions,
+        GroveDBOperationsProofVersions, GroveDBOperationsQueryVersions, GroveDBOperationsVersions,
         GroveDBOperationsWorstCaseVersions, GroveDBPathQueryMethodVersions, GroveDBQueryLimits,
         GroveDBReplicationVersions, GroveDBVersions,
     },
@@ -226,6 +226,12 @@ pub const GROVE_V3: GroveVersion = GroveVersion {
                 insert: 0,
                 get_value: 0,
                 count: 0,
+            },
+            // Flat-subtree drop (issue #848) is unavailable before
+            // GROVE_V4: every slot is 0 and the operations fail closed.
+            flat_drop: GroveDBOperationsFlatDropVersions {
+                drop_flat_subtree: 0,
+                batch_delete_tree_drop_flat: 0,
             },
         },
         aggregate_sum_path_query_methods: GroveDBAggregateSumPathQueryMethodVersions { merge: 0 },

--- a/grovedb-version/src/version/v4.rs
+++ b/grovedb-version/src/version/v4.rs
@@ -97,6 +97,25 @@
 //!   so the slot's `0` value is the in-process mirror of that fail-closed
 //!   decode.
 //!
+//! - `operations.flat_drop.drop_flat_subtree: 1` and
+//!   `operations.flat_drop.batch_delete_tree_drop_flat: 1` — the
+//!   flat-subtree drop family (issue #848): `GroveDb::drop_flat_subtree`
+//!   and the `SubelementsDeletionBehavior::DropFlat` batch behavior remove
+//!   a populated subtree's element from its parent Merk in O(1) —
+//!   no emptiness check, no content sweep — and stage the subtree's
+//!   storage prefixes (primary plus, for indexed primaries, all three
+//!   axis secondaries) in a durable redo record committed atomically with
+//!   the delete. Reclamation happens outside consensus via DB-level range
+//!   tombstones (immediately when GroveDB owns the transaction, at the
+//!   next `flush_pending_prefix_drops` otherwise) and never contributes
+//!   to the operation's returned cost. The caller declares the subtree
+//!   contains no child subtrees; a false declaration leaks the children's
+//!   storage (unreachable, invisible to hashes/proofs/sync) but never
+//!   corrupts state. V1..V3 hold both slots at 0 and fail closed. Gated
+//!   because the drop's cost class (O(1) versus O(contents)) and the
+//!   accepted/rejected outcome for non-empty trees are both
+//!   consensus-observable.
+//!
 //! - `apply_batch.keyless_op_cost_dispatch: 1` — keyless append-only ops
 //!   (`CommitmentTreeInsert`, `MmrTreeAppend`, `BulkAppend`,
 //!   `DenseTreeInsert`) reach the cost dispatch in the estimated-cost batch
@@ -199,10 +218,10 @@ use crate::version::{
     grovedb_versions::{
         GroveDBApplyBatchVersions, GroveDBElementMethodVersions,
         GroveDBOperationsAverageCaseVersions, GroveDBOperationsDeleteUpTreeVersions,
-        GroveDBOperationsDeleteVersions, GroveDBOperationsGetVersions,
-        GroveDBOperationsIndexedAxisVersions, GroveDBOperationsInsertVersions,
-        GroveDBOperationsPrivateDocumentStoreVersions, GroveDBOperationsProofVersions,
-        GroveDBOperationsQueryVersions, GroveDBOperationsVersions,
+        GroveDBOperationsDeleteVersions, GroveDBOperationsFlatDropVersions,
+        GroveDBOperationsGetVersions, GroveDBOperationsIndexedAxisVersions,
+        GroveDBOperationsInsertVersions, GroveDBOperationsPrivateDocumentStoreVersions,
+        GroveDBOperationsProofVersions, GroveDBOperationsQueryVersions, GroveDBOperationsVersions,
         GroveDBOperationsWorstCaseVersions, GroveDBPathQueryMethodVersions, GroveDBQueryLimits,
         GroveDBReplicationVersions, GroveDBVersions,
     },
@@ -430,6 +449,11 @@ pub const GROVE_V4: GroveVersion = GroveVersion {
                 insert: 1,
                 get_value: 1,
                 count: 1,
+            },
+            // Flat-subtree drop (issue #848) activates in GROVE_V4.
+            flat_drop: GroveDBOperationsFlatDropVersions {
+                drop_flat_subtree: 1,
+                batch_delete_tree_drop_flat: 1,
             },
         },
         aggregate_sum_path_query_methods: GroveDBAggregateSumPathQueryMethodVersions { merge: 0 },

--- a/grovedb/src/batch/estimated_costs/average_case_costs.rs
+++ b/grovedb/src/batch/estimated_costs/average_case_costs.rs
@@ -905,6 +905,18 @@ impl<G, SR> TreeCache<G, SR> for AverageCaseTreeCacheKnownPaths {
             } else {
                 None
             };
+            // A flat drop additionally stages a redo record (issue #848);
+            // charged here because the record's size depends on the op's
+            // full path, which the per-op dispatch below does not see.
+            if let GroveOp::DeleteTree(
+                tree_type,
+                crate::batch::SubelementsDeletionBehavior::DropFlat,
+            ) = &op
+            {
+                crate::operations::delete::flat_drop::add_flat_drop_record_put_estimate(
+                    &mut cost, path, &key, tree_type,
+                );
+            }
             cost_return_on_error!(
                 &mut cost,
                 op.average_case_cost(

--- a/grovedb/src/batch/estimated_costs/worst_case_costs.rs
+++ b/grovedb/src/batch/estimated_costs/worst_case_costs.rs
@@ -638,6 +638,18 @@ impl<G, SR> TreeCache<G, SR> for WorstCaseTreeCacheKnownPaths {
         }
 
         for (key, op) in ops_at_path_by_key.into_iter() {
+            // A flat drop additionally stages a redo record (issue #848);
+            // charged here because the record's size depends on the op's
+            // full path, which the per-op dispatch below does not see.
+            if let GroveOp::DeleteTree(
+                tree_type,
+                crate::batch::SubelementsDeletionBehavior::DropFlat,
+            ) = &op
+            {
+                crate::operations::delete::flat_drop::add_flat_drop_record_put_estimate(
+                    &mut cost, path, &key, tree_type,
+                );
+            }
             cost_return_on_error!(
                 &mut cost,
                 op.worst_case_cost(

--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -105,25 +105,65 @@ use crate::{
 /// This enum is attached to each `DeleteTree` operation individually,
 /// replacing the old batch-level `allow_deleting_non_empty_trees` /
 /// `deleting_non_empty_trees_returns_error` flags on `BatchApplyOptions`.
+///
+/// The variants differ along two axes — whether emptiness is checked at
+/// apply time, and what happens to the subtree's storage:
+///
+/// | variant | assumes | emptiness check | contents' storage |
+/// |---|---|---|---|
+/// | `DontCheckWithNoCleanup` | already empty | skipped (proven earlier) | none exist |
+/// | `Error` | may be non-empty | yes → error | delete only proceeds when empty; defensive sweep |
+/// | `Skip` | may be non-empty | yes → skip op | delete only proceeds when empty; defensive sweep |
+/// | `DeleteChildren` | may be non-empty | skipped | cleaned up recursively, O(contents) |
+/// | `DropFlat` | populated, **no child subtrees** | skipped | range-tombstoned via redo record, O(1) |
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub enum SubelementsDeletionBehavior {
-    /// Do not check whether the subtree is empty before deleting, and skip
-    /// post-apply storage cleanup. The tree element is removed from the
-    /// parent Merk unconditionally but no child subtree storage is cleared.
-    /// Callers use this when they have already ensured the subtree is empty
-    /// and want to avoid the I/O cost of both the emptiness check and the
-    /// cleanup phase.
+    /// **Assumes the subtree is already empty.** Skips the apply-time
+    /// emptiness check and the post-apply storage cleanup: the tree
+    /// element is removed from the parent Merk unconditionally, and no
+    /// child storage is touched — because for an empty tree there is
+    /// nothing to clean, skipping is free, not a feature.
+    ///
+    /// This is an I/O optimization for callers that have *just proven*
+    /// emptiness, not a way to abandon contents. The canonical producer is
+    /// GroveDB's own op generation (`delete_operation_for_delete_internal`,
+    /// reached via `delete_operations_for_delete_up_tree_while_empty`),
+    /// which emits this variant only inside its `is_empty` branch — a
+    /// check that also counts same-batch deletes as removed and same-batch
+    /// inserts as making the tree non-empty. The window between that check
+    /// and apply is covered by `verify_consistency_of_operations` (on by
+    /// default), which rejects batches inserting under a deleted path.
+    ///
+    /// Misuse — applying this to a tree that still has contents — removes
+    /// the element anyway and silently orphans the contents' storage:
+    /// unreachable, un-tracked (nothing records the abandoned prefix), and
+    /// permanently leaked, with the stale bytes poisoning the identical
+    /// re-derived prefix if the path is ever re-created. To deliberately
+    /// drop a *populated* tree, use [`Self::DropFlat`] (no child subtrees,
+    /// O(1), storage reclaimed) or [`Self::DeleteChildren`] (recursive
+    /// cleanup, O(contents)).
+    ///
+    /// One exception to "touches no child storage": an indexed primary
+    /// still gets its per-axis secondary namespaces swept, because those
+    /// live outside the primary's prefix and can hold stale rows even when
+    /// the primary is empty. On an empty tree that sweep is a no-op.
+    ///
+    /// Note the non-batching path (`apply_operations_without_batching`)
+    /// maps this to `allow_deleting_non_empty_trees: true`, i.e. a full
+    /// recursive delete — the no-cleanup semantics only hold on the real
+    /// batch path.
     DontCheckWithNoCleanup,
-    /// Check emptiness. If the subtree is non-empty, return
-    /// `Error::DeletingNonEmptyTree`.
+    /// Check emptiness at apply time. If the subtree is non-empty, return
+    /// `Error::DeletingNonEmptyTree` and fail the batch.
     Error,
     /// Do not check whether the subtree is empty before deleting, but
     /// still perform post-apply storage cleanup to remove the child
-    /// subtree's storage (and any nested subtrees). Use this when the
-    /// subtree may contain children that should be recursively cleaned up.
+    /// subtree's storage (and any nested subtrees), walking the structure
+    /// via `find_subtrees` — O(contents). Use this when the subtree may
+    /// contain children that should be recursively cleaned up.
     DeleteChildren,
-    /// Check emptiness. If the subtree is non-empty, silently skip this
-    /// `DeleteTree` operation (no error, no deletion).
+    /// Check emptiness at apply time. If the subtree is non-empty,
+    /// silently skip this `DeleteTree` operation (no error, no deletion).
     Skip,
     /// Flat-subtree drop (issue #848, `GROVE_V4`+): delete the tree
     /// element from its parent Merk unconditionally — no emptiness check,
@@ -140,6 +180,11 @@ pub enum SubelementsDeletionBehavior {
     /// invisible to hashes/proofs/sync) but never corrupts state. The
     /// dropped path must not be re-created before its record drains. See
     /// `operations::delete::flat_drop` for the full contract.
+    ///
+    /// This is the only variant whose contract permits contents: unlike
+    /// [`Self::DontCheckWithNoCleanup`] ("already empty, skip the
+    /// redundant check"), `DropFlat` means "full, drop it anyway — and
+    /// physically reclaim the storage, tracked and crash-safe".
     DropFlat,
 }
 

--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -73,7 +73,10 @@ use grovedb_merk::{
 };
 use grovedb_path::SubtreePath;
 use grovedb_storage::{
-    rocksdb_storage::PrefixedRocksDbTransactionContext, Storage, StorageBatch, StorageContext,
+    rocksdb_storage::{
+        pending_prefix_drops_namespace, PendingPrefixDropRecord, PrefixedRocksDbTransactionContext,
+    },
+    Storage, StorageBatch, StorageContext,
 };
 use grovedb_version::{check_grovedb_v0_with_cost, version::GroveVersion};
 use grovedb_visualize::{Drawer, Visualize};
@@ -122,6 +125,22 @@ pub enum SubelementsDeletionBehavior {
     /// Check emptiness. If the subtree is non-empty, silently skip this
     /// `DeleteTree` operation (no error, no deletion).
     Skip,
+    /// Flat-subtree drop (issue #848, `GROVE_V4`+): delete the tree
+    /// element from its parent Merk unconditionally — no emptiness check,
+    /// no content sweep, O(1) in the subtree's size — and stage the
+    /// subtree's storage prefixes (primary plus, for indexed primaries,
+    /// all three axis secondaries) in a durable redo record committed
+    /// atomically with the batch. Storage is reclaimed outside consensus
+    /// by DB-level range tombstones: immediately after the commit when
+    /// GroveDB owns the transaction, at the caller's next
+    /// `flush_pending_prefix_drops` otherwise.
+    ///
+    /// The caller declares the subtree contains **no child subtrees**; a
+    /// false declaration leaks the children's storage (unreachable,
+    /// invisible to hashes/proofs/sync) but never corrupts state. The
+    /// dropped path must not be re-created before its record drains. See
+    /// `operations::delete::flat_drop` for the full contract.
+    DropFlat,
 }
 
 /// Metadata for non-Merk tree types, carrying tree-type-specific state
@@ -1690,6 +1709,7 @@ fn classify_captured_delete_trees(
     non_merk_delete_paths: &mut Vec<Vec<Vec<u8>>>,
     merk_delete_paths: &mut Vec<Vec<Vec<u8>>>,
     cidx_primary_delete_paths: &mut Vec<Vec<Vec<u8>>>,
+    flat_drop_records: &mut Vec<(Vec<Vec<u8>>, TreeType)>,
 ) {
     for (qualified_path, actual_tree_type) in captures {
         // Ops the pre-scan did not register (e.g. add-on DeleteTree ops
@@ -1724,6 +1744,14 @@ fn classify_captured_delete_trees(
                     }
                     merk_delete_paths.push(qualified_path);
                 }
+            }
+            SubelementsDeletionBehavior::DropFlat => {
+                // No in-batch storage cleanup at all: the drop stages a
+                // durable redo record instead, and reclamation happens
+                // outside consensus via range tombstones. The ACTUAL type
+                // decides whether the record also dooms the per-axis
+                // secondary prefixes.
+                flat_drop_records.push((qualified_path, actual_tree_type));
             }
         }
     }
@@ -5078,6 +5106,24 @@ impl GroveDb {
                             .as_ref()
                             .ok_or(Error::InvalidBatchOperation("delete op is missing a key"))
                     );
+                    // DropFlat is its own operation, not a DeleteOptions
+                    // mapping: the O(1) flat drop with staged storage
+                    // reclamation (issue #848).
+                    if matches!(
+                        subelements_deletion_behavior,
+                        SubelementsDeletionBehavior::DropFlat
+                    ) {
+                        cost_return_on_error!(
+                            &mut cost,
+                            self.drop_flat_subtree(
+                                path_slices.as_slice(),
+                                key.as_slice(),
+                                transaction,
+                                grove_version
+                            )
+                        );
+                        continue;
+                    }
                     // Map the per-op enum to the lower-level DeleteOptions.
                     // DontCheckWithNoCleanup and DeleteChildren both set
                     // allow_deleting_non_empty_trees = true because the
@@ -5442,6 +5488,48 @@ impl GroveDb {
         }
     }
 
+    /// Stage one pending-prefix-drop redo record per captured
+    /// `DeleteTree(_, DropFlat)` deletion into `storage_batch`, so the
+    /// records commit atomically with the batch (issue #848). The ACTUAL
+    /// stored tree type decides whether the record also dooms the per-axis
+    /// secondary prefixes. Reclamation happens after the commit, outside
+    /// consensus — see `operations::delete::flat_drop`.
+    fn stage_flat_drop_records<'db>(
+        &'db self,
+        flat_drop_records: &[(Vec<Vec<u8>>, TreeType)],
+        storage_batch: &'db StorageBatch,
+        tx: &'db Transaction,
+        cost: &mut OperationCost,
+    ) -> Result<(), Error> {
+        for (qualified_path, actual_tree_type) in flat_drop_records {
+            let subtree_path: SubtreePath<Vec<u8>> = qualified_path.as_slice().into();
+            let doomed_prefixes = crate::operations::delete::flat_drop::doomed_prefixes_for_drop(
+                subtree_path,
+                actual_tree_type.is_indexed_primary(),
+                cost,
+            );
+            let record = PendingPrefixDropRecord {
+                primary_prefix: doomed_prefixes[0],
+                path: qualified_path.clone(),
+                doomed_prefixes,
+            };
+            let record_value = record.encode().map_err(Error::StorageError)?;
+            let namespace_ctx = self
+                .db
+                .get_transactional_storage_context_by_subtree_prefix(
+                    *pending_prefix_drops_namespace(),
+                    Some(storage_batch),
+                    tx,
+                )
+                .unwrap_add_cost(cost);
+            namespace_ctx
+                .put_meta(record.primary_prefix, &record_value, None)
+                .unwrap_add_cost(cost)
+                .map_err(Error::StorageError)?;
+        }
+        Ok(())
+    }
+
     /// Pre-apply scan over a batch's `DeleteTree` ops, shared by
     /// `apply_batch_with_element_flags_update` and
     /// `apply_partial_batch_with_element_flags_update`.
@@ -5484,12 +5572,33 @@ impl GroveDb {
                 let mut child_path = op.path.to_path();
                 child_path.push(key.as_slice().to_vec());
 
+                // Capability gate for the flat-drop behavior (issue #848):
+                // fails closed on every version whose slot is not the
+                // active v1 implementation — V1..V3 hold it at 0.
+                if matches!(
+                    subelements_deletion_behavior,
+                    SubelementsDeletionBehavior::DropFlat
+                ) {
+                    cost_return_on_error_no_add!(
+                        cost,
+                        crate::operations::delete::flat_drop::check_flat_drop_enabled(
+                            "apply_batch DeleteTree(DropFlat)",
+                            grove_version
+                                .grovedb_versions
+                                .operations
+                                .flat_drop
+                                .batch_delete_tree_drop_flat,
+                        )
+                    );
+                }
+
                 if capture_actual_types {
                     scan.delete_tree_behaviors
                         .insert(child_path.clone(), *subelements_deletion_behavior);
                     match subelements_deletion_behavior {
                         SubelementsDeletionBehavior::DontCheckWithNoCleanup
-                        | SubelementsDeletionBehavior::DeleteChildren => {
+                        | SubelementsDeletionBehavior::DeleteChildren
+                        | SubelementsDeletionBehavior::DropFlat => {
                             // Nothing to check pre-apply; cleanup paths come
                             // from the captured actual types after apply.
                         }
@@ -5595,12 +5704,13 @@ impl GroveDb {
                                         scan.skipped_delete_paths.insert(child_path);
                                     }
                                     SubelementsDeletionBehavior::DontCheckWithNoCleanup
-                                    | SubelementsDeletionBehavior::DeleteChildren => {
+                                    | SubelementsDeletionBehavior::DeleteChildren
+                                    | SubelementsDeletionBehavior::DropFlat => {
                                         return Err(Error::CorruptedCodeExecution(
                                             "batch delete: DontCheckWithNoCleanup / \
-                                             DeleteChildren behaviors are handled before the \
-                                             non-empty-tree check and must not reach this \
-                                             match arm",
+                                             DeleteChildren / DropFlat behaviors are handled \
+                                             before the non-empty-tree check and must not \
+                                             reach this match arm",
                                         ))
                                         .wrap_with_cost(cost);
                                     }
@@ -5638,6 +5748,18 @@ impl GroveDb {
                     SubelementsDeletionBehavior::DeleteChildren => {
                         // No emptiness check, but still perform post-apply
                         // storage cleanup to remove child subtree storage.
+                    }
+                    SubelementsDeletionBehavior::DropFlat => {
+                        // Unreachable: the capability gate above rejects
+                        // DropFlat whenever `batch_delete_tree_drop_flat`
+                        // is not active, and every version that activates
+                        // it also has `delete_tree_cleanup_type_source >=
+                        // 1`, which routes ops through the capture branch
+                        // instead of this released V1..V3 path.
+                        return Err(Error::CorruptedCodeExecution(
+                            "batch delete: DropFlat behavior reached the V1..V3 scan path",
+                        ))
+                        .wrap_with_cost(cost);
                     }
                     SubelementsDeletionBehavior::Error | SubelementsDeletionBehavior::Skip => {
                         let is_empty = if tree_type.uses_non_merk_data_storage() {
@@ -5730,18 +5852,20 @@ impl GroveDb {
                                     scan.skipped_delete_paths.insert(child_path);
                                     continue;
                                 }
-                                // DontCheckWithNoCleanup / DeleteChildren never
-                                // reach the emptiness-check block above (they
-                                // either skip the check or delete children
-                                // unconditionally). Return a graceful error
-                                // rather than panicking if that invariant is
-                                // ever broken.
+                                // DontCheckWithNoCleanup / DeleteChildren /
+                                // DropFlat never reach the emptiness-check
+                                // block above (they either skip the check or
+                                // delete children unconditionally). Return a
+                                // graceful error rather than panicking if
+                                // that invariant is ever broken.
                                 SubelementsDeletionBehavior::DontCheckWithNoCleanup
-                                | SubelementsDeletionBehavior::DeleteChildren => {
+                                | SubelementsDeletionBehavior::DeleteChildren
+                                | SubelementsDeletionBehavior::DropFlat => {
                                     return Err(Error::CorruptedCodeExecution(
                                         "batch delete: DontCheckWithNoCleanup / DeleteChildren \
-                                         behaviors are handled before the non-empty-tree check \
-                                         and must not reach this match arm",
+                                         / DropFlat behaviors are handled before the \
+                                         non-empty-tree check and must not reach this match \
+                                         arm",
                                     ))
                                     .wrap_with_cost(cost);
                                 }
@@ -5960,12 +6084,26 @@ impl GroveDb {
         // the apply into the cleanup lists (no-op on V1..V3, where the
         // captures are empty and the lists were already built pre-apply from
         // the declared types).
+        let mut flat_drop_records: Vec<(Vec<Vec<u8>>, TreeType)> = Vec::new();
         classify_captured_delete_trees(
             deleted_tree_actual_types,
             &delete_tree_behaviors,
             &mut non_merk_delete_paths,
             &mut merk_delete_paths,
             &mut cidx_primary_delete_paths,
+            &mut flat_drop_records,
+        );
+
+        // Stage flat-drop redo records so they commit atomically with the
+        // batch (issue #848); their storage reclaims after the commit.
+        cost_return_on_error_no_add!(
+            cost,
+            self.stage_flat_drop_records(
+                &flat_drop_records,
+                &storage_batch,
+                tx.as_ref(),
+                &mut cost,
+            )
         );
 
         // Clean up data storage for deleted non-Merk trees.
@@ -6173,7 +6311,19 @@ impl GroveDb {
         //     );
         // }
 
-        tx.commit_local().wrap_with_cost(cost)
+        let owns_tx = tx.is_owned();
+        cost_return_on_error_no_add!(cost, tx.commit_local());
+
+        // Reclaim flat-drop storage right away when this call owns the
+        // just-committed transaction. Best-effort: on failure the redo
+        // records persist and the next flush retries (issue #848). When
+        // the caller owns the transaction, records stay invisible until
+        // the caller commits, and the host flushes afterwards.
+        if owns_tx && !flat_drop_records.is_empty() {
+            let _ = self.flush_pending_prefix_drops(grove_version);
+        }
+
+        Ok(()).wrap_with_cost(cost)
     }
 
     /// Applies a partial batch of operations on GroveDB
@@ -6469,6 +6619,7 @@ impl GroveDb {
 
         // V4+: fold captures from BOTH applies into the cleanup lists
         // (no-op on V1..V3). The overwrite-cleanup paths are unioned below.
+        let mut flat_drop_records: Vec<(Vec<Vec<u8>>, TreeType)> = Vec::new();
         classify_captured_delete_trees(
             partial_deleted_tree_actual_types
                 .into_iter()
@@ -6478,6 +6629,19 @@ impl GroveDb {
             &mut non_merk_delete_paths,
             &mut merk_delete_paths,
             &mut cidx_primary_delete_paths,
+            &mut flat_drop_records,
+        );
+
+        // Stage flat-drop redo records so they commit atomically with the
+        // batch (issue #848); their storage reclaims after the commit.
+        cost_return_on_error_no_add!(
+            cost,
+            self.stage_flat_drop_records(
+                &flat_drop_records,
+                &continue_storage_batch,
+                tx.as_ref(),
+                &mut cost,
+            )
         );
 
         // Clean up data storage for deleted non-Merk trees.
@@ -6674,7 +6838,17 @@ impl GroveDb {
             partial_rekey_churn_bytes.saturating_add(continue_rekey_churn_bytes),
         );
 
-        tx.commit_local().wrap_with_cost(cost)
+        let owns_tx = tx.is_owned();
+        cost_return_on_error_no_add!(cost, tx.commit_local());
+
+        // Reclaim flat-drop storage right away when this call owns the
+        // just-committed transaction (see apply_batch_with_element_flags
+        // _update; issue #848).
+        if owns_tx && !flat_drop_records.is_empty() {
+            let _ = self.flush_pending_prefix_drops(grove_version);
+        }
+
+        Ok(()).wrap_with_cost(cost)
     }
 
     #[cfg(feature = "estimated_costs")]

--- a/grovedb/src/lib.rs
+++ b/grovedb/src/lib.rs
@@ -248,11 +248,14 @@ use grovedb_storage::{Storage, StorageContext};
 use grovedb_version::version::GroveVersion;
 #[cfg(feature = "minimal")]
 use grovedb_visualize::DebugByteVectors;
+/// Telemetry counts from one `flush_pending_prefix_drops` pass — re-exported
+/// so hosts can name the flat-drop reclamation report without reaching into
+/// `operations::delete`.
+#[cfg(feature = "minimal")]
+pub use operations::delete::PendingPrefixDropsReport;
 /// The unified read dispatch's result types. `operations::get` is
 /// crate-private, so without this re-export `run_path_query` would be
 /// callable from outside the crate but its return type unnameable.
-#[cfg(feature = "minimal")]
-pub use operations::delete::PendingPrefixDropsReport;
 #[cfg(feature = "minimal")]
 pub use operations::get::{AxisAggregateValue, PathQueryRun};
 // Gated on `minimal` alone, matching `operations::indexed_tree` itself: the

--- a/grovedb/src/lib.rs
+++ b/grovedb/src/lib.rs
@@ -252,6 +252,8 @@ use grovedb_visualize::DebugByteVectors;
 /// crate-private, so without this re-export `run_path_query` would be
 /// callable from outside the crate but its return type unnameable.
 #[cfg(feature = "minimal")]
+pub use operations::delete::PendingPrefixDropsReport;
+#[cfg(feature = "minimal")]
 pub use operations::get::{AxisAggregateValue, PathQueryRun};
 // Gated on `minimal` alone, matching `operations::indexed_tree` itself: the
 // only APIs that produce an `IndexedTopKPage` are the paginated indexed-axis

--- a/grovedb/src/operations/delete/flat_drop.rs
+++ b/grovedb/src/operations/delete/flat_drop.rs
@@ -1,0 +1,421 @@
+//! Flat-subtree drop (issue #848): O(1) consensus removal of a populated
+//! subtree that is declared to contain no child subtrees, with storage
+//! reclaimed outside consensus via range tombstones.
+//!
+//! # The primitive
+//!
+//! [`GroveDb::drop_flat_subtree`] deletes a subtree's element from its
+//! parent Merk exactly like deleting any single element — the parent's root
+//! hash (and therefore the grove root) is immediately correct, absence is
+//! provable, and the cost is a deterministic function of the element bytes,
+//! its key, the parent Merk's shape, and the path. The subtree's contents
+//! are **never opened, checked, or metered**, which is what makes the cost
+//! O(1) in the subtree's size: dropping a tree of ten million entries
+//! costs the same as dropping a tree of ten.
+//!
+//! Atomically with the delete, a durable redo record
+//! ([`PendingPrefixDropRecord`]) is committed into a reserved namespace of
+//! the meta column family, listing every storage prefix that just became
+//! unreachable: the subtree's own path-derived prefix and, for indexed
+//! primaries, the three per-axis secondary prefixes. Reclamation is then a
+//! handful of DB-level range tombstones per record — O(1) writes that
+//! RocksDB compaction turns into physically reclaimed disk in the
+//! background:
+//!
+//! - when GroveDB owns the transaction (the caller passed `None`), the
+//!   record is drained immediately after the commit, in the same call;
+//! - when the caller owns the transaction, records become visible (and
+//!   drainable) only once the caller commits; the host calls
+//!   [`GroveDb::flush_pending_prefix_drops`] afterwards — or at any later
+//!   point, including after a crash and restart: records survive in the
+//!   database, checkpoints carry them, and draining is idempotent.
+//!
+//! Range tombstones cannot ride RocksDB optimistic transactions, which is
+//! why reclamation is a separate, non-transactional step. It is safe
+//! because the tombstoned prefixes are unreachable from the live element
+//! graph — nothing else ever reads or writes them — and it never
+//! contributes to the operation's returned cost (consistent with callers
+//! that exclude such drops from storage-refund accounting).
+//!
+//! # The flatness contract
+//!
+//! The caller declares that the dropped subtree contains **no child
+//! subtrees**. GroveDB cannot verify this without an O(contents) scan, so
+//! it is a contract, like reference-lifecycle management on `delete`. For
+//! most tree types it holds by construction (non-Merk data trees cannot
+//! contain children; indexed primaries reject generic child writes); only
+//! a plain Merk tree relies on the caller's word. A false declaration
+//! leaks the children's storage — their prefixes are cryptographically
+//! unrelated to the parent's, so the tombstones never touch them and they
+//! remain on disk, unreachable and invisible to hashes, proofs, state
+//! sync, and `verify_grovedb` — but it never corrupts state.
+//!
+//! # Path reuse
+//!
+//! Storage prefixes derive from paths alone, so re-creating a subtree at a
+//! dropped path re-derives the identical prefix. Callers must not
+//! re-create an element at a dropped path before its record has been
+//! drained. As defense in depth the drain re-resolves each record's path
+//! against the live element graph first and skips (rather than tombstones)
+//! any record whose path resolves to a live element — a contract violation
+//! degrades to a bounded, reported storage leak, never to destruction of
+//! live data.
+//!
+//! # Dangling references
+//!
+//! As with every delete operation, incoming references to the dropped
+//! subtree (or anything inside it) become dangling; following one returns
+//! a corrupted-reference error rather than incorrect data. Reference
+//! lifecycle is the caller's responsibility.
+
+use std::collections::HashMap;
+
+use grovedb_costs::{
+    cost_return_on_error, cost_return_on_error_into, cost_return_on_error_no_add,
+    storage_cost::removal::StorageRemovedBytes::BasicStorageRemoval, CostResult, CostsExt,
+    OperationCost,
+};
+use grovedb_element::indexed::IndexAxis;
+use grovedb_merk::{
+    element::{delete::ElementDeleteFromStorageExtensions, tree_type::ElementTreeTypeExtensions},
+    Merk, MerkOptions,
+};
+use grovedb_path::SubtreePath;
+use grovedb_storage::{
+    rocksdb_storage::{
+        pending_prefix_drops_namespace, PendingPrefixDropRecord, PrefixedRocksDbTransactionContext,
+        RocksDbStorage,
+    },
+    Storage, StorageBatch, StorageContext,
+};
+use grovedb_version::{
+    error::GroveVersionError,
+    version::{FeatureVersion, GroveVersion},
+};
+
+use crate::{util::TxRef, Element, Error, GroveDb, TransactionArg};
+
+/// Reject a flat-drop entry point whose capability slot is not active.
+///
+/// Slot `0` (every version before `GROVE_V4`) means the operation is
+/// unavailable; slot `1` is the active v1 implementation. The comparison is
+/// an EXACT match — accepting `slot > 1` would silently run v1 code under a
+/// future protocol version that assigned the slot new semantics.
+pub(crate) fn check_flat_drop_enabled(method: &str, slot: FeatureVersion) -> Result<(), Error> {
+    if slot != 1 {
+        return Err(GroveVersionError::UnknownVersionMismatch {
+            method: method.to_string(),
+            known_versions: vec![1],
+            received: slot,
+        }
+        .into());
+    }
+    Ok(())
+}
+
+/// Compute every storage prefix a dropped subtree owns: its path-derived
+/// primary prefix plus, when the element is an indexed primary, the three
+/// per-axis secondary prefixes (all three unconditionally, matching the
+/// existing delete-path sweep — tombstoning an unused axis namespace is a
+/// no-op).
+pub(crate) fn doomed_prefixes_for_drop<B: AsRef<[u8]>>(
+    subtree_path: SubtreePath<B>,
+    is_indexed_primary: bool,
+    cost: &mut OperationCost,
+) -> Vec<[u8; 32]> {
+    let primary_prefix = RocksDbStorage::build_prefix(subtree_path).unwrap_add_cost(cost);
+    let mut doomed = Vec::with_capacity(if is_indexed_primary { 4 } else { 1 });
+    doomed.push(primary_prefix);
+    if is_indexed_primary {
+        for axis in [IndexAxis::Count, IndexAxis::Sum, IndexAxis::Avg] {
+            doomed.push(
+                RocksDbStorage::secondary_prefix_for(&primary_prefix, axis.tag())
+                    .unwrap_add_cost(cost),
+            );
+        }
+    }
+    doomed
+}
+
+/// Add the deterministic cost of staging one flat-drop redo record to an
+/// estimated-cost accumulation. Average and worst case share the formula:
+/// the record's size is a function of the path's maximum segment lengths
+/// and the declared tree type, both known up front. Mirrors the real cost
+/// charged by `stage_flat_drop_records` / `drop_flat_subtree`: the prefix
+/// derivation hash calls plus the meta put charged at commit
+/// (`AbstractBatchOperation::PutMeta` with `cost_info: None` — one seek
+/// and `paid_key_len + paid_value_len` added bytes).
+#[cfg(feature = "estimated_costs")]
+pub(crate) fn add_flat_drop_record_put_estimate(
+    cost: &mut OperationCost,
+    path: &crate::batch::KeyInfoPath,
+    key: &crate::batch::key_info::KeyInfo,
+    tree_type: &grovedb_merk::tree_type::TreeType,
+) {
+    use grovedb_storage::worst_case_costs::WorstKeyLength;
+    use integer_encoding::VarInt;
+
+    let is_indexed = tree_type.is_indexed_primary();
+    let doomed_count: u32 = if is_indexed { 4 } else { 1 };
+    let segment_lengths: Vec<u32> = path
+        .0
+        .iter()
+        .map(|segment| segment.max_length() as u32)
+        .chain(std::iter::once(key.max_length() as u32))
+        .collect();
+    // `build_prefix` of the dropped subtree's full path: one Blake3 call
+    // per 64-byte block of the path body (segment bytes, the native usize
+    // segment count, one length byte per segment).
+    let body_len: u32 = segment_lengths.iter().sum::<u32>()
+        + std::mem::size_of::<usize>() as u32
+        + segment_lengths.len() as u32;
+    let blocks = if body_len == 0 {
+        1
+    } else {
+        1 + (body_len - 1) / 64
+    };
+    // Plus one single-block hash per axis-secondary prefix derivation.
+    cost.hash_node_calls += blocks + if is_indexed { 3 } else { 0 };
+    // The meta put: key is `namespace ‖ primary_prefix` (64 bytes), value
+    // is the record encoding — version byte, doomed count, the doomed
+    // prefixes, segment count, then length-prefixed segments.
+    let key_len: u32 = 64;
+    let value_len: u32 =
+        2 + 32 * doomed_count + 1 + segment_lengths.iter().map(|len| 1 + len).sum::<u32>();
+    cost.seek_count += 1;
+    cost.storage_cost.added_bytes +=
+        key_len + key_len.required_space() as u32 + value_len + value_len.required_space() as u32;
+}
+
+/// Outcome of one [`GroveDb::flush_pending_prefix_drops`] pass, for
+/// telemetry only — never consensus.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct PendingPrefixDropsReport {
+    /// Records whose doomed prefixes were tombstoned and which were then
+    /// removed from the queue.
+    pub reclaimed_records: u64,
+    /// Records skipped because their path resolves to a live element — a
+    /// dropped path was re-created before its record drained (a caller
+    /// contract violation). Their storage stays leaked and the records
+    /// remain, so the condition keeps being reported.
+    pub skipped_live: u64,
+}
+
+impl GroveDb {
+    /// Drop the subtree element at `path`/`key` in O(1), without opening
+    /// or sweeping its contents, and stage its storage prefixes for
+    /// reclamation. See the [module documentation](self) for the full
+    /// contract: the caller declares the subtree contains **no child
+    /// subtrees**, incoming references dangle, and the dropped path must
+    /// not be re-created before its record drains.
+    ///
+    /// The returned cost covers the parent-Merk delete, upward hash
+    /// propagation, and the redo record's bytes — a deterministic function
+    /// of the element, key, parent shape, and path, independent of the
+    /// subtree's contents. Reclamation itself is unmetered.
+    pub fn drop_flat_subtree<'b, B, P>(
+        &self,
+        path: P,
+        key: &[u8],
+        transaction: TransactionArg,
+        grove_version: &GroveVersion,
+    ) -> CostResult<(), Error>
+    where
+        B: AsRef<[u8]> + 'b,
+        P: Into<SubtreePath<'b, B>>,
+    {
+        let path: SubtreePath<B> = path.into();
+        let mut cost = OperationCost::default();
+
+        cost_return_on_error_no_add!(
+            cost,
+            check_flat_drop_enabled(
+                "drop_flat_subtree",
+                grove_version
+                    .grovedb_versions
+                    .operations
+                    .flat_drop
+                    .drop_flat_subtree,
+            )
+        );
+
+        let tx = TxRef::new(&self.db, transaction);
+        let batch = StorageBatch::new();
+
+        let element = cost_return_on_error!(
+            &mut cost,
+            self.get_raw(path.clone(), key, Some(tx.as_ref()), grove_version)
+        );
+        let Some(dropped_tree_type) = element.tree_type() else {
+            return Err(Error::InvalidInput(
+                "drop_flat_subtree: the element at the given path/key is not a tree",
+            ))
+            .wrap_with_cost(cost);
+        };
+
+        let mut parent_merk = cost_return_on_error!(
+            &mut cost,
+            self.open_transactional_merk_at_path(
+                path.clone(),
+                tx.as_ref(),
+                Some(&batch),
+                grove_version
+            )
+        );
+        // A generic delete out of an indexed primary cannot mirror the
+        // removed child's ordering value into the secondary index — same
+        // rejection as `delete`.
+        cost_return_on_error_no_add!(
+            cost,
+            crate::operations::indexed_tree::reject_generic_write_into_indexed_primary(
+                parent_merk.tree_type,
+                "drop_flat_subtree",
+            )
+        );
+        let parent_tree_type = parent_merk.tree_type;
+
+        // Stage the redo record in the same atomic commit as the delete.
+        let subtree_path_owned = path.derive_owned_with_child(key);
+        let subtree_path_ref = SubtreePath::from(&subtree_path_owned);
+        let doomed_prefixes = doomed_prefixes_for_drop(
+            subtree_path_ref,
+            dropped_tree_type.is_indexed_primary(),
+            &mut cost,
+        );
+        let record = PendingPrefixDropRecord {
+            primary_prefix: doomed_prefixes[0],
+            path: {
+                let mut segments = path.to_vec();
+                segments.push(key.to_vec());
+                segments
+            },
+            doomed_prefixes,
+        };
+        let record_value =
+            cost_return_on_error_no_add!(cost, record.encode().map_err(Error::StorageError));
+        let namespace_ctx = self
+            .db
+            .get_transactional_storage_context_by_subtree_prefix(
+                *pending_prefix_drops_namespace(),
+                Some(&batch),
+                tx.as_ref(),
+            )
+            .unwrap_add_cost(&mut cost);
+        cost_return_on_error!(
+            &mut cost,
+            namespace_ctx
+                .put_meta(record.primary_prefix, &record_value, None)
+                .map_err(Error::StorageError)
+        );
+
+        // The O(1) detach: an ordinary layered delete from the parent Merk.
+        // The child subtree is never opened.
+        cost_return_on_error_into!(
+            &mut cost,
+            Element::delete_with_sectioned_removal_bytes(
+                &mut parent_merk,
+                key,
+                Some(MerkOptions {
+                    base_root_storage_is_free: true
+                }),
+                true,
+                parent_tree_type,
+                &mut |_, removed_key_bytes, removed_value_bytes| {
+                    Ok((
+                        BasicStorageRemoval(removed_key_bytes),
+                        BasicStorageRemoval(removed_value_bytes),
+                    ))
+                },
+                grove_version,
+            )
+        );
+
+        let mut merk_cache: HashMap<SubtreePath<B>, Merk<PrefixedRocksDbTransactionContext>> =
+            HashMap::default();
+        merk_cache.insert(path.clone(), parent_merk);
+        cost_return_on_error!(
+            &mut cost,
+            self.propagate_changes_with_transaction(
+                merk_cache,
+                path,
+                tx.as_ref(),
+                &batch,
+                grove_version,
+            )
+        );
+
+        cost_return_on_error!(
+            &mut cost,
+            self.db
+                .commit_multi_context_batch(batch, Some(tx.as_ref()))
+                .map_err(Into::into)
+        );
+
+        let owns_tx = tx.is_owned();
+        cost_return_on_error_no_add!(cost, tx.commit_local());
+
+        if owns_tx {
+            // Best-effort immediate reclamation. On failure the record
+            // persists and the next flush retries — nothing is lost, so the
+            // committed drop is still reported as success.
+            let _ = self.flush_pending_prefix_drops(grove_version);
+        }
+
+        Ok(()).wrap_with_cost(cost)
+    }
+
+    /// Drain every committed pending-prefix-drop redo record: range-delete
+    /// each record's doomed prefixes across all column families, then
+    /// remove the record. Idempotent and crash-safe — a record is removed
+    /// only after its tombstones are written, and re-tombstoning is a
+    /// no-op. Never touches the root hash; the returned counts are
+    /// telemetry, not consensus.
+    ///
+    /// Records staged inside a still-open caller transaction are invisible
+    /// here (and roll back with it), so a drop can never be reclaimed
+    /// before it is durably committed.
+    ///
+    /// Deliberately not version-gated: it only reclaims storage that a
+    /// gated operation already orphaned, and is a no-op when no records
+    /// exist. Hosts should call it after committing a transaction that
+    /// contained drops, and once at startup to finish reclamation
+    /// interrupted by a crash.
+    pub fn flush_pending_prefix_drops(
+        &self,
+        grove_version: &GroveVersion,
+    ) -> Result<PendingPrefixDropsReport, Error> {
+        let mut report = PendingPrefixDropsReport::default();
+        for record in self.db.pending_prefix_drop_records()? {
+            // Liveness guard: never tombstone a prefix whose path resolves
+            // to a live element (the dropped path was re-created — a caller
+            // contract violation; leak instead of destroying live data).
+            let live = match record.path.split_last() {
+                // A record with an empty path cannot be produced by
+                // `drop_flat_subtree`; treat it as unsafe to act on.
+                None => true,
+                Some((key, parent_segments)) => {
+                    let parent_path: SubtreePath<Vec<u8>> = parent_segments.into();
+                    match self.get_raw(parent_path, key, None, grove_version).unwrap() {
+                        Ok(_) => true,
+                        Err(
+                            Error::PathKeyNotFound(_)
+                            | Error::PathNotFound(_)
+                            | Error::PathParentLayerNotFound(_)
+                            | Error::InvalidParentLayerPath(_),
+                        ) => false,
+                        Err(e) => return Err(e),
+                    }
+                }
+            };
+            if live {
+                report.skipped_live += 1;
+                continue;
+            }
+            self.db.delete_prefix_ranges(&record.doomed_prefixes)?;
+            self.db
+                .remove_pending_prefix_drop_record(&record.primary_prefix)?;
+            report.reclaimed_records += 1;
+        }
+        Ok(report)
+    }
+}

--- a/grovedb/src/operations/delete/mod.rs
+++ b/grovedb/src/operations/delete/mod.rs
@@ -20,6 +20,11 @@ mod average_case;
 mod delete_internal_on_transaction;
 #[cfg(feature = "minimal")]
 mod delete_up_tree;
+/// Flat-subtree drop (issue #848): O(1) removal of a populated subtree
+/// declared to contain no child subtrees, with storage reclaimed outside
+/// consensus via range tombstones driven from durable redo records.
+#[cfg(feature = "minimal")]
+pub mod flat_drop;
 #[cfg(feature = "estimated_costs")]
 mod worst_case;
 
@@ -28,6 +33,8 @@ use std::collections::{BTreeSet, HashMap};
 
 #[cfg(feature = "minimal")]
 pub use delete_up_tree::DeleteUpTreeOptions;
+#[cfg(feature = "minimal")]
+pub use flat_drop::PendingPrefixDropsReport;
 #[cfg(feature = "minimal")]
 use grovedb_costs::{
     cost_return_on_error, cost_return_on_error_no_add,

--- a/grovedb/src/tests/flat_drop_tests.rs
+++ b/grovedb/src/tests/flat_drop_tests.rs
@@ -618,4 +618,136 @@ mod tests {
         assert_eq!(data_namespace_key_count(&db, primary_prefix), 0);
         assert_eq!(data_namespace_key_count(&db, count_secondary), 0);
     }
+
+    #[test]
+    fn apply_operations_without_batching_routes_drop_flat() {
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+        seed_flat_tree(&db, b"flat", 12, grove_version);
+        let prefix = prefix_of(&[TEST_LEAF, b"flat"]);
+
+        let ops = vec![QualifiedGroveDbOp::delete_tree_op(
+            vec![TEST_LEAF.to_vec()],
+            b"flat".to_vec(),
+            TreeType::NormalTree,
+            SubelementsDeletionBehavior::DropFlat,
+        )];
+        db.apply_operations_without_batching(ops, None, None, grove_version)
+            .unwrap()
+            .expect("apply without batching");
+
+        assert!(matches!(
+            db.get_raw([TEST_LEAF].as_ref().into(), b"flat", None, grove_version)
+                .unwrap(),
+            Err(Error::PathKeyNotFound(_))
+        ));
+        assert_grove_verifies(&db, grove_version);
+        // The routed drop_flat_subtree owned its transaction, so
+        // reclamation already ran.
+        assert_eq!(data_namespace_key_count(&db, prefix), 0);
+        assert!(!record_exists(&db, prefix));
+    }
+
+    // ── Estimated costs ─────────────────────────────────────────────────
+
+    /// Both batch estimators must dominate the actual cost of a `DropFlat`
+    /// batch in every dimension — the estimate is the admission bound
+    /// downstream, so an under-estimate would reject already-affordable
+    /// state transitions (or admit under-funded ones).
+    #[cfg(feature = "estimated_costs")]
+    #[test]
+    fn estimates_dominate_actual_for_drop_flat() {
+        use std::collections::HashMap;
+
+        use grovedb_costs::storage_cost::removal::StorageRemovedBytes::NoStorageRemoval;
+        use grovedb_merk::estimated_costs::{
+            average_case_costs::{
+                EstimatedLayerCount::EstimatedLevel, EstimatedLayerInformation,
+                EstimatedLayerSizes::AllSubtrees, EstimatedSumTrees::NoSumTrees,
+            },
+            worst_case_costs::WorstCaseLayerInformation::MaxElementsNumber,
+        };
+
+        use crate::{
+            batch::{
+                estimated_costs::EstimatedCostsType::{AverageCaseCostsType, WorstCaseCostsType},
+                KeyInfoPath,
+            },
+            GroveDb,
+        };
+
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+        seed_flat_tree(&db, b"flat", 5, grove_version);
+
+        let ops = vec![QualifiedGroveDbOp::delete_tree_op(
+            vec![TEST_LEAF.to_vec()],
+            b"flat".to_vec(),
+            TreeType::NormalTree,
+            SubelementsDeletionBehavior::DropFlat,
+        )];
+
+        let mut average_paths = HashMap::new();
+        average_paths.insert(
+            KeyInfoPath(vec![]),
+            EstimatedLayerInformation {
+                tree_type: TreeType::NormalTree,
+                estimated_layer_count: EstimatedLevel(2, false),
+                estimated_layer_sizes: AllSubtrees(32, NoSumTrees, None),
+            },
+        );
+        average_paths.insert(
+            KeyInfoPath::from_known_owned_path(vec![TEST_LEAF.to_vec()]),
+            EstimatedLayerInformation {
+                tree_type: TreeType::NormalTree,
+                estimated_layer_count: EstimatedLevel(4, false),
+                estimated_layer_sizes: AllSubtrees(32, NoSumTrees, None),
+            },
+        );
+        let average = GroveDb::estimated_case_operations_for_batch(
+            AverageCaseCostsType(average_paths),
+            ops.clone(),
+            None,
+            |_cost, _old_flags, _new_flags| Ok(false),
+            |_flags, _removed_key_bytes, _removed_value_bytes| {
+                Ok((NoStorageRemoval, NoStorageRemoval))
+            },
+            grove_version,
+        )
+        .cost_as_result()
+        .expect("average case estimate");
+
+        let mut worst_paths = HashMap::new();
+        worst_paths.insert(KeyInfoPath(vec![]), MaxElementsNumber(4));
+        worst_paths.insert(
+            KeyInfoPath::from_known_owned_path(vec![TEST_LEAF.to_vec()]),
+            MaxElementsNumber(4),
+        );
+        let worst = GroveDb::estimated_case_operations_for_batch(
+            WorstCaseCostsType(worst_paths),
+            ops.clone(),
+            None,
+            |_cost, _old_flags, _new_flags| Ok(false),
+            |_flags, _removed_key_bytes, _removed_value_bytes| {
+                Ok((NoStorageRemoval, NoStorageRemoval))
+            },
+            grove_version,
+        )
+        .cost_as_result()
+        .expect("worst case estimate");
+
+        let actual = db
+            .apply_batch(ops, None, None, grove_version)
+            .cost_as_result()
+            .expect("apply batch");
+
+        assert!(
+            average.worse_or_eq_than(&actual),
+            "average-case estimate must dominate actual;\nestimated {average:?}\nactual {actual:?}",
+        );
+        assert!(
+            worst.worse_or_eq_than(&actual),
+            "worst-case estimate must dominate actual;\nestimated {worst:?}\nactual {actual:?}",
+        );
+    }
 }

--- a/grovedb/src/tests/flat_drop_tests.rs
+++ b/grovedb/src/tests/flat_drop_tests.rs
@@ -14,7 +14,10 @@
 //! - draining is idempotent, resumable after a simulated crash, and
 //!   refuses to tombstone a re-created (live) path — leaking instead of
 //!   destroying;
-//! - both entry points fail closed before `GROVE_V4`.
+//! - both entry points fail closed before `GROVE_V4`;
+//! - absence of the dropped element is provable against the post-drop root
+//!   hash, and references into the dropped subtree dangle with the typed
+//!   corrupted-reference error rather than resolving to stale data.
 
 mod tests {
     use grovedb_costs::OperationCost;
@@ -646,6 +649,104 @@ mod tests {
         // reclamation already ran.
         assert_eq!(data_namespace_key_count(&db, prefix), 0);
         assert!(!record_exists(&db, prefix));
+    }
+
+    // ── Proofs and references ───────────────────────────────────────────
+
+    #[test]
+    fn drop_flat_subtree_absence_is_provable() {
+        use grovedb_merk::proofs::Query;
+
+        use crate::{GroveDb, PathQuery};
+
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+        seed_flat_tree(&db, b"flat", 25, grove_version);
+
+        let mut query = Query::new();
+        query.insert_key(b"flat".to_vec());
+        let path_query = PathQuery::new_unsized(vec![TEST_LEAF.to_vec()], query);
+
+        // Sanity: before the drop the same query proves one result.
+        let proof = db
+            .prove_query(&path_query, None, grove_version)
+            .unwrap()
+            .expect("prove before drop");
+        let (hash, result_set) =
+            GroveDb::verify_query_raw(&proof, &path_query, grove_version).expect("verify");
+        assert_eq!(hash, db.root_hash(None, grove_version).unwrap().unwrap());
+        assert_eq!(result_set.len(), 1);
+
+        db.drop_flat_subtree([TEST_LEAF].as_ref(), b"flat", None, grove_version)
+            .unwrap()
+            .expect("drop");
+
+        // The dropped element's absence is provable against the new root
+        // hash: an empty result set whose proof verifies.
+        let proof = db
+            .prove_query(&path_query, None, grove_version)
+            .unwrap()
+            .expect("prove after drop");
+        let (hash, result_set) =
+            GroveDb::verify_query_raw(&proof, &path_query, grove_version).expect("verify");
+        assert_eq!(hash, db.root_hash(None, grove_version).unwrap().unwrap());
+        assert!(
+            result_set.is_empty(),
+            "dropped key must prove absent, got {result_set:?}"
+        );
+    }
+
+    #[test]
+    fn references_into_a_dropped_subtree_dangle_with_typed_errors() {
+        use crate::{reference_path::ReferencePathType, tests::ANOTHER_TEST_LEAF};
+
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+        seed_flat_tree(&db, b"flat", 5, grove_version);
+
+        db.insert(
+            [ANOTHER_TEST_LEAF].as_ref(),
+            b"ref",
+            Element::new_reference(ReferencePathType::AbsolutePathReference(vec![
+                TEST_LEAF.to_vec(),
+                b"flat".to_vec(),
+                b"key_00000001".to_vec(),
+            ])),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert reference");
+
+        // Sanity: the reference resolves before the drop.
+        assert_eq!(
+            db.get([ANOTHER_TEST_LEAF].as_ref(), b"ref", None, grove_version)
+                .unwrap()
+                .expect("follow reference before drop"),
+            Element::new_item(b"value_bytes_0000".to_vec())
+        );
+
+        db.drop_flat_subtree([TEST_LEAF].as_ref(), b"flat", None, grove_version)
+            .unwrap()
+            .expect("drop");
+
+        // The reference now dangles: following it returns the typed
+        // corrupted-reference error (the target's parent layer is gone),
+        // never stale data. Managing such references is the caller's
+        // responsibility, exactly as with `delete`.
+        let followed = db
+            .get([ANOTHER_TEST_LEAF].as_ref(), b"ref", None, grove_version)
+            .unwrap();
+        assert!(
+            matches!(
+                followed,
+                Err(Error::CorruptedReferencePathParentLayerNotFound(_)
+                    | Error::CorruptedReferencePathKeyNotFound(_)
+                    | Error::CorruptedReferencePathNotFound(_))
+            ),
+            "expected a typed dangling-reference error, got {followed:?}"
+        );
     }
 
     // ── Estimated costs ─────────────────────────────────────────────────

--- a/grovedb/src/tests/flat_drop_tests.rs
+++ b/grovedb/src/tests/flat_drop_tests.rs
@@ -1,0 +1,621 @@
+//! Tests for the flat-subtree drop primitive (issue #848):
+//! `GroveDb::drop_flat_subtree`, the `SubelementsDeletionBehavior::DropFlat`
+//! batch behavior, and `GroveDb::flush_pending_prefix_drops`.
+//!
+//! The invariants under test:
+//! - the drop is O(1) in the subtree's contents (identical cost regardless
+//!   of entry count) and never opens the child subtree;
+//! - the grove is immediately consistent after the drop (element absent,
+//!   `verify_grovedb` clean) while reclamation is still pending;
+//! - reclamation empties every doomed namespace — the primary prefix and,
+//!   for indexed primaries, all three axis-secondary prefixes;
+//! - the redo record commits and rolls back atomically with the drop's
+//!   transaction, and draining is deferred until the caller commits;
+//! - draining is idempotent, resumable after a simulated crash, and
+//!   refuses to tombstone a re-created (live) path — leaking instead of
+//!   destroying;
+//! - both entry points fail closed before `GROVE_V4`.
+
+mod tests {
+    use grovedb_costs::OperationCost;
+    use grovedb_merk::tree_type::TreeType;
+    use grovedb_storage::{
+        rocksdb_storage::{pending_prefix_drops_namespace, RocksDbStorage},
+        RawIterator, Storage, StorageContext,
+    };
+    use grovedb_version::version::{v3::GROVE_V3, GroveVersion};
+
+    use crate::{
+        batch::{QualifiedGroveDbOp, SubelementsDeletionBehavior},
+        tests::{make_test_grovedb, TempGroveDb, TEST_LEAF},
+        Element, Error,
+    };
+
+    /// Number of keys physically present in the data namespace under
+    /// `prefix` (committed state).
+    fn data_namespace_key_count(db: &TempGroveDb, prefix: [u8; 32]) -> usize {
+        let tx = db.db.start_transaction();
+        let ctx = db
+            .db
+            .get_transactional_storage_context_by_subtree_prefix(prefix, None, &tx)
+            .unwrap();
+        let mut iter = ctx.raw_iter();
+        iter.seek_to_first().unwrap();
+        let mut count = 0;
+        while iter.valid().unwrap() {
+            count += 1;
+            iter.next().unwrap();
+        }
+        count
+    }
+
+    /// Whether a pending-prefix-drop redo record exists for `prefix`
+    /// (committed state).
+    fn record_exists(db: &TempGroveDb, prefix: [u8; 32]) -> bool {
+        let tx = db.db.start_transaction();
+        let ctx = db
+            .db
+            .get_transactional_storage_context_by_subtree_prefix(
+                *pending_prefix_drops_namespace(),
+                None,
+                &tx,
+            )
+            .unwrap();
+        ctx.get_meta(prefix)
+            .unwrap()
+            .expect("read record")
+            .is_some()
+    }
+
+    fn prefix_of(path: &[&[u8]]) -> [u8; 32] {
+        RocksDbStorage::build_prefix(path.into()).unwrap()
+    }
+
+    /// A populated flat tree at `[TEST_LEAF]/key` with `entries` items.
+    fn seed_flat_tree(db: &TempGroveDb, key: &[u8], entries: u32, grove_version: &GroveVersion) {
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            key,
+            Element::empty_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert flat tree");
+        for i in 0..entries {
+            db.insert(
+                [TEST_LEAF, key].as_ref(),
+                format!("key_{i:08}").as_bytes(),
+                Element::new_item(b"value_bytes_0000".to_vec()),
+                None,
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("insert item");
+        }
+    }
+
+    fn assert_grove_verifies(db: &TempGroveDb, grove_version: &GroveVersion) {
+        let issues = db
+            .verify_grovedb(None, true, false, grove_version)
+            .expect("verify_grovedb");
+        assert!(issues.is_empty(), "verification issues: {issues:?}");
+    }
+
+    // ── Standalone operation ────────────────────────────────────────────
+
+    #[test]
+    fn drop_flat_subtree_removes_element_and_reclaims_storage() {
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+        seed_flat_tree(&db, b"flat", 50, grove_version);
+
+        let prefix = prefix_of(&[TEST_LEAF, b"flat"]);
+        assert!(data_namespace_key_count(&db, prefix) > 0);
+
+        db.drop_flat_subtree([TEST_LEAF].as_ref(), b"flat", None, grove_version)
+            .unwrap()
+            .expect("drop");
+
+        // The element is provably gone and the grove is consistent.
+        assert!(matches!(
+            db.get_raw([TEST_LEAF].as_ref().into(), b"flat", None, grove_version)
+                .unwrap(),
+            Err(Error::PathKeyNotFound(_))
+        ));
+        assert_grove_verifies(&db, grove_version);
+
+        // GroveDB owned the transaction, so reclamation already ran: the
+        // namespace is physically empty and the redo record is gone.
+        assert_eq!(data_namespace_key_count(&db, prefix), 0);
+        assert!(!record_exists(&db, prefix));
+    }
+
+    #[test]
+    fn drop_flat_subtree_cost_is_independent_of_contents() {
+        let grove_version = GroveVersion::latest();
+
+        let cost_of_drop = |entries: u32| -> OperationCost {
+            let db = make_test_grovedb(grove_version);
+            seed_flat_tree(&db, b"flat", entries, grove_version);
+            db.drop_flat_subtree([TEST_LEAF].as_ref(), b"flat", None, grove_version)
+                .cost_as_result()
+                .expect("drop")
+        };
+
+        let small = cost_of_drop(5);
+        let large = cost_of_drop(500);
+        assert_eq!(
+            small, large,
+            "drop cost must not depend on the subtree's contents"
+        );
+    }
+
+    #[test]
+    fn drop_flat_subtree_rejects_non_tree_elements() {
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"item",
+            Element::new_item(b"value".to_vec()),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert item");
+
+        assert!(matches!(
+            db.drop_flat_subtree([TEST_LEAF].as_ref(), b"item", None, grove_version)
+                .unwrap(),
+            Err(Error::InvalidInput(_))
+        ));
+    }
+
+    #[test]
+    fn drop_flat_subtree_fails_closed_before_v4() {
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+        seed_flat_tree(&db, b"flat", 3, grove_version);
+
+        assert!(matches!(
+            db.drop_flat_subtree([TEST_LEAF].as_ref(), b"flat", None, &GROVE_V3)
+                .unwrap(),
+            Err(Error::VersionError(_))
+        ));
+        // Nothing happened.
+        assert!(db
+            .get_raw([TEST_LEAF].as_ref().into(), b"flat", None, grove_version)
+            .unwrap()
+            .is_ok());
+    }
+
+    // ── Transactions: atomicity and deferred reclamation ────────────────
+
+    #[test]
+    fn drop_flat_subtree_with_caller_transaction_defers_reclamation_until_flush() {
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+        seed_flat_tree(&db, b"flat", 20, grove_version);
+        let prefix = prefix_of(&[TEST_LEAF, b"flat"]);
+
+        let tx = db.start_transaction();
+        db.drop_flat_subtree([TEST_LEAF].as_ref(), b"flat", Some(&tx), grove_version)
+            .unwrap()
+            .expect("drop in tx");
+
+        // Uncommitted: the record is invisible to the drain, so a flush
+        // reclaims nothing and the data is untouched.
+        let report = db
+            .flush_pending_prefix_drops(grove_version)
+            .expect("flush before commit");
+        assert_eq!(report.reclaimed_records, 0);
+        assert_eq!(report.skipped_live, 0);
+        assert!(data_namespace_key_count(&db, prefix) > 0);
+
+        db.commit_transaction(tx).unwrap().expect("commit");
+
+        // Committed but not yet flushed: the grove is consistent, the
+        // orphaned bytes still exist, the record is durable.
+        assert_grove_verifies(&db, grove_version);
+        assert!(data_namespace_key_count(&db, prefix) > 0);
+        assert!(record_exists(&db, prefix));
+
+        let report = db
+            .flush_pending_prefix_drops(grove_version)
+            .expect("flush after commit");
+        assert_eq!(report.reclaimed_records, 1);
+        assert_eq!(data_namespace_key_count(&db, prefix), 0);
+        assert!(!record_exists(&db, prefix));
+
+        // Idempotent: nothing left to do.
+        let report = db.flush_pending_prefix_drops(grove_version).expect("flush");
+        assert_eq!(report.reclaimed_records, 0);
+    }
+
+    #[test]
+    fn drop_flat_subtree_rolls_back_with_the_callers_transaction() {
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+        seed_flat_tree(&db, b"flat", 10, grove_version);
+        let prefix = prefix_of(&[TEST_LEAF, b"flat"]);
+
+        let tx = db.start_transaction();
+        db.drop_flat_subtree([TEST_LEAF].as_ref(), b"flat", Some(&tx), grove_version)
+            .unwrap()
+            .expect("drop in tx");
+        db.rollback_transaction(&tx).expect("rollback");
+        drop(tx);
+
+        // The element, its data, and the absence of any record all reflect
+        // the rollback.
+        assert!(db
+            .get_raw([TEST_LEAF].as_ref().into(), b"flat", None, grove_version)
+            .unwrap()
+            .is_ok());
+        assert!(data_namespace_key_count(&db, prefix) > 0);
+        assert!(!record_exists(&db, prefix));
+        let report = db.flush_pending_prefix_drops(grove_version).expect("flush");
+        assert_eq!(report.reclaimed_records, 0);
+        assert_grove_verifies(&db, grove_version);
+    }
+
+    #[test]
+    fn flush_resumes_after_simulated_crash_between_tombstones_and_record_removal() {
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+        seed_flat_tree(&db, b"flat", 10, grove_version);
+        let prefix = prefix_of(&[TEST_LEAF, b"flat"]);
+
+        // Commit the drop through a caller transaction so no auto-drain
+        // runs and the record persists.
+        let tx = db.start_transaction();
+        db.drop_flat_subtree([TEST_LEAF].as_ref(), b"flat", Some(&tx), grove_version)
+            .unwrap()
+            .expect("drop in tx");
+        db.commit_transaction(tx).unwrap().expect("commit");
+
+        // Simulate a crash after the tombstones were written but before
+        // the record was removed.
+        db.db
+            .delete_prefix_ranges(&[prefix])
+            .expect("manual tombstones");
+        assert_eq!(data_namespace_key_count(&db, prefix), 0);
+        assert!(record_exists(&db, prefix));
+
+        // The next flush redoes the (idempotent) tombstones and completes.
+        let report = db.flush_pending_prefix_drops(grove_version).expect("flush");
+        assert_eq!(report.reclaimed_records, 1);
+        assert!(!record_exists(&db, prefix));
+    }
+
+    #[test]
+    fn flush_skips_a_recreated_path_and_leaks_instead_of_destroying() {
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+        seed_flat_tree(&db, b"flat", 10, grove_version);
+        let prefix = prefix_of(&[TEST_LEAF, b"flat"]);
+
+        let tx = db.start_transaction();
+        db.drop_flat_subtree([TEST_LEAF].as_ref(), b"flat", Some(&tx), grove_version)
+            .unwrap()
+            .expect("drop in tx");
+        db.commit_transaction(tx).unwrap().expect("commit");
+
+        // Contract violation: re-create the dropped path before flushing.
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"flat",
+            Element::empty_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("recreate tree");
+        db.insert(
+            [TEST_LEAF, b"flat"].as_ref(),
+            b"fresh",
+            Element::new_item(b"fresh_value".to_vec()),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert fresh item");
+
+        // The drain must refuse to tombstone the live prefix — repeatedly.
+        for _ in 0..2 {
+            let report = db.flush_pending_prefix_drops(grove_version).expect("flush");
+            assert_eq!(report.reclaimed_records, 0);
+            assert_eq!(report.skipped_live, 1);
+        }
+        // Live reads follow Merk links from the new root, so the fresh data
+        // is intact — the guard turned the violation into a leak, not
+        // destruction.
+        assert_eq!(
+            db.get_raw(
+                [TEST_LEAF, b"flat"].as_ref().into(),
+                b"fresh",
+                None,
+                grove_version
+            )
+            .unwrap()
+            .expect("fresh item survives"),
+            Element::new_item(b"fresh_value".to_vec())
+        );
+        assert!(record_exists(&db, prefix));
+        // And this is exactly why re-creating a dropped path before its
+        // record drains is a contract violation: the old tree's stale nodes
+        // still sit inside the re-derived (identical) prefix, polluting the
+        // new tree's namespace — verification-visible, even though the
+        // root hash and live reads are unaffected.
+        let polluted = db
+            .verify_grovedb(None, true, false, grove_version)
+            .map(|issues| !issues.is_empty())
+            .unwrap_or(true);
+        assert!(
+            polluted,
+            "recreated-path pollution should be visible to verify_grovedb"
+        );
+    }
+
+    // ── Indexed primaries ───────────────────────────────────────────────
+
+    #[test]
+    fn drop_flat_indexed_tree_reclaims_all_axis_secondary_namespaces() {
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"cidx",
+            Element::empty_provable_count_indexed_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert PCIT");
+        for i in 0..10u8 {
+            db.insert_into_count_indexed_tree(
+                [TEST_LEAF, b"cidx"].as_ref(),
+                &[i],
+                Element::new_item(vec![i; 8]),
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("insert row");
+        }
+
+        let primary_prefix = prefix_of(&[TEST_LEAF, b"cidx"]);
+        let secondary_prefixes: Vec<[u8; 32]> = (0..3u8)
+            .map(|axis_tag| {
+                RocksDbStorage::secondary_prefix_for(&primary_prefix, axis_tag).unwrap()
+            })
+            .collect();
+        assert!(data_namespace_key_count(&db, primary_prefix) > 0);
+        // The count axis secondary is populated.
+        assert!(data_namespace_key_count(&db, secondary_prefixes[0]) > 0);
+
+        db.drop_flat_subtree([TEST_LEAF].as_ref(), b"cidx", None, grove_version)
+            .unwrap()
+            .expect("drop PCIT");
+
+        assert_grove_verifies(&db, grove_version);
+        assert_eq!(data_namespace_key_count(&db, primary_prefix), 0);
+        for secondary_prefix in secondary_prefixes {
+            assert_eq!(data_namespace_key_count(&db, secondary_prefix), 0);
+        }
+        assert!(!record_exists(&db, primary_prefix));
+    }
+
+    // ── Aggregate parents ───────────────────────────────────────────────
+
+    #[test]
+    fn drop_flat_sum_tree_under_sum_tree_parent_keeps_aggregates_consistent() {
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"sums",
+            Element::empty_sum_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert sum parent");
+        db.insert(
+            [TEST_LEAF, b"sums"].as_ref(),
+            b"keeper",
+            Element::new_sum_item(5),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert keeper sum item");
+        db.insert(
+            [TEST_LEAF, b"sums"].as_ref(),
+            b"flat_sums",
+            Element::empty_sum_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert child sum tree");
+        for i in 0..4u8 {
+            db.insert(
+                [TEST_LEAF, b"sums", b"flat_sums"].as_ref(),
+                &[i],
+                Element::new_sum_item(10),
+                None,
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("insert child sum item");
+        }
+
+        db.drop_flat_subtree(
+            [TEST_LEAF, b"sums"].as_ref(),
+            b"flat_sums",
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("drop sum child");
+
+        // verify_grovedb recomputes aggregates recursively; a stale parent
+        // sum would surface as an issue.
+        assert_grove_verifies(&db, grove_version);
+        assert_eq!(
+            data_namespace_key_count(&db, prefix_of(&[TEST_LEAF, b"sums", b"flat_sums"])),
+            0
+        );
+    }
+
+    // ── Batch operation ─────────────────────────────────────────────────
+
+    #[test]
+    fn batch_drop_flat_applies_atomically_and_reclaims() {
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+        seed_flat_tree(&db, b"flat", 30, grove_version);
+        let prefix = prefix_of(&[TEST_LEAF, b"flat"]);
+
+        let ops = vec![
+            QualifiedGroveDbOp::insert_or_replace_op(
+                vec![TEST_LEAF.to_vec()],
+                b"sibling".to_vec(),
+                Element::new_item(b"sibling_value".to_vec()),
+            ),
+            QualifiedGroveDbOp::delete_tree_op(
+                vec![TEST_LEAF.to_vec()],
+                b"flat".to_vec(),
+                TreeType::NormalTree,
+                SubelementsDeletionBehavior::DropFlat,
+            ),
+        ];
+        db.apply_batch(ops, None, None, grove_version)
+            .unwrap()
+            .expect("apply batch");
+
+        assert!(matches!(
+            db.get_raw([TEST_LEAF].as_ref().into(), b"flat", None, grove_version)
+                .unwrap(),
+            Err(Error::PathKeyNotFound(_))
+        ));
+        assert_eq!(
+            db.get_raw([TEST_LEAF].as_ref().into(), b"sibling", None, grove_version)
+                .unwrap()
+                .expect("sibling applied"),
+            Element::new_item(b"sibling_value".to_vec())
+        );
+        assert_grove_verifies(&db, grove_version);
+        // Auto-drain ran (GroveDB owned the transaction).
+        assert_eq!(data_namespace_key_count(&db, prefix), 0);
+        assert!(!record_exists(&db, prefix));
+    }
+
+    #[test]
+    fn batch_drop_flat_with_caller_transaction_defers_reclamation() {
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+        seed_flat_tree(&db, b"flat", 15, grove_version);
+        let prefix = prefix_of(&[TEST_LEAF, b"flat"]);
+
+        let tx = db.start_transaction();
+        let ops = vec![QualifiedGroveDbOp::delete_tree_op(
+            vec![TEST_LEAF.to_vec()],
+            b"flat".to_vec(),
+            TreeType::NormalTree,
+            SubelementsDeletionBehavior::DropFlat,
+        )];
+        db.apply_batch(ops, None, Some(&tx), grove_version)
+            .unwrap()
+            .expect("apply batch in tx");
+        db.commit_transaction(tx).unwrap().expect("commit");
+
+        assert!(data_namespace_key_count(&db, prefix) > 0);
+        assert!(record_exists(&db, prefix));
+        let report = db.flush_pending_prefix_drops(grove_version).expect("flush");
+        assert_eq!(report.reclaimed_records, 1);
+        assert_eq!(data_namespace_key_count(&db, prefix), 0);
+        assert_grove_verifies(&db, grove_version);
+    }
+
+    #[test]
+    fn batch_drop_flat_fails_closed_before_v4() {
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+        seed_flat_tree(&db, b"flat", 3, grove_version);
+
+        let ops = vec![QualifiedGroveDbOp::delete_tree_op(
+            vec![TEST_LEAF.to_vec()],
+            b"flat".to_vec(),
+            TreeType::NormalTree,
+            SubelementsDeletionBehavior::DropFlat,
+        )];
+        assert!(matches!(
+            db.apply_batch(ops, None, None, &GROVE_V3).unwrap(),
+            Err(Error::VersionError(_))
+        ));
+        assert!(db
+            .get_raw([TEST_LEAF].as_ref().into(), b"flat", None, grove_version)
+            .unwrap()
+            .is_ok());
+    }
+
+    #[test]
+    fn batch_drop_flat_of_indexed_tree_reclaims_secondaries() {
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"cidx",
+            Element::empty_provable_count_indexed_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert PCIT");
+        for i in 0..5u8 {
+            db.insert_into_count_indexed_tree(
+                [TEST_LEAF, b"cidx"].as_ref(),
+                &[i],
+                Element::new_item(vec![i; 8]),
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("insert row");
+        }
+        let primary_prefix = prefix_of(&[TEST_LEAF, b"cidx"]);
+        let count_secondary = RocksDbStorage::secondary_prefix_for(&primary_prefix, 0).unwrap();
+        assert!(data_namespace_key_count(&db, count_secondary) > 0);
+
+        let ops = vec![QualifiedGroveDbOp::delete_tree_op(
+            vec![TEST_LEAF.to_vec()],
+            b"cidx".to_vec(),
+            TreeType::ProvableCountIndexedTree,
+            SubelementsDeletionBehavior::DropFlat,
+        )];
+        db.apply_batch(ops, None, None, grove_version)
+            .unwrap()
+            .expect("apply batch");
+
+        assert_grove_verifies(&db, grove_version);
+        assert_eq!(data_namespace_key_count(&db, primary_prefix), 0);
+        assert_eq!(data_namespace_key_count(&db, count_secondary), 0);
+    }
+}

--- a/grovedb/src/tests/mod.rs
+++ b/grovedb/src/tests/mod.rs
@@ -61,6 +61,7 @@ mod direct_insert_indexed_tests;
 mod error_display_tests;
 mod estimated_costs_average_case_tests;
 mod estimated_costs_worst_case_tests;
+mod flat_drop_tests;
 mod get_cost_estimator_tests;
 mod grove_query_result_tests;
 mod indexed_axis_keys_only_read_tests;

--- a/grovedb/src/util.rs
+++ b/grovedb/src/util.rs
@@ -18,6 +18,12 @@ impl<'a, 'db> TxRef<'a, 'db> {
         }
     }
 
+    /// Whether this transaction was started locally (and so will really
+    /// commit in `commit_local`) rather than borrowed from the caller.
+    pub(crate) fn is_owned(&self) -> bool {
+        matches!(self, TxRef::Owned(_))
+    }
+
     /// Commit the transaction if it wasn't received from outside
     pub(crate) fn commit_local(self) -> Result<(), Error> {
         match self {

--- a/storage/src/rocksdb_storage.rs
+++ b/storage/src/rocksdb_storage.rs
@@ -39,4 +39,6 @@ pub use storage_context::{
     PrefixedRocksDbTransactionContext,
 };
 
-pub use self::storage::{RocksDbStorage, Tx};
+pub use self::storage::{
+    pending_prefix_drops_namespace, PendingPrefixDropRecord, RocksDbStorage, Tx,
+};

--- a/storage/src/rocksdb_storage/storage.rs
+++ b/storage/src/rocksdb_storage/storage.rs
@@ -901,6 +901,223 @@ impl RocksDbStorage {
             })?;
         Ok(())
     }
+
+    /// Immediately delete every key under each of `prefixes` in all four
+    /// column families using one range tombstone per (prefix, CF) pair.
+    ///
+    /// This is a **DB-level** write that bypasses the transaction machinery:
+    /// RocksDB optimistic transactions cannot carry range deletes, so the
+    /// tombstones commit as soon as this returns. Callers must only pass
+    /// prefixes whose data is unreachable from the live element graph (an
+    /// orphaned subtree namespace after a flat drop); nothing else may ever
+    /// write under such a prefix, which is what makes the non-transactional
+    /// write safe. The operation is idempotent — re-running it after a crash
+    /// is a no-op.
+    ///
+    /// Readers holding an older RocksDB snapshot (state-sync sessions,
+    /// checkpoints) are unaffected: range tombstones are sequence-numbered,
+    /// so reads at an older sequence still see the pre-drop data.
+    pub fn delete_prefix_ranges(&self, prefixes: &[SubtreePrefix]) -> Result<(), Error> {
+        for prefix in prefixes {
+            // Upper bound: the prefix incremented as a 32-byte big-endian
+            // value. Every key `prefix ‖ suffix` sorts below it. An
+            // all-0xFF prefix cannot be incremented, but prefixes are
+            // Blake3 outputs, so that value has probability 1/2^256 —
+            // refuse it rather than wrap to all-zeros and delete the world.
+            let mut upper = *prefix;
+            let mut carried_past_top = true;
+            for byte in upper.iter_mut().rev() {
+                *byte = byte.wrapping_add(1);
+                if *byte != 0 {
+                    carried_past_top = false;
+                    break;
+                }
+            }
+            if carried_past_top {
+                return Err(Error::StorageError(
+                    "delete_prefix_ranges: refusing to range-delete the all-0xFF prefix"
+                        .to_string(),
+                ));
+            }
+            for (name, cf) in [
+                (DEFAULT_COLUMN_FAMILY_NAME, cf_default(&self.db)),
+                (AUX_CF_NAME, cf_aux(&self.db)),
+                (ROOTS_CF_NAME, cf_roots(&self.db)),
+                (META_CF_NAME, cf_meta(&self.db)),
+            ] {
+                self.db
+                    .delete_range_cf(cf, prefix.as_slice(), upper.as_slice())
+                    .map_err(|e| {
+                        Error::StorageError(format!(
+                            "delete_prefix_ranges({name}) delete_range_cf failed: {e}"
+                        ))
+                    })?;
+            }
+        }
+        Ok(())
+    }
+
+    /// List every committed pending-prefix-drop redo record.
+    ///
+    /// Reads the meta column family under
+    /// [`pending_prefix_drops_namespace`]; records staged inside an
+    /// uncommitted transaction are invisible, which is exactly the contract
+    /// the drain relies on (never reclaim a drop that might still roll
+    /// back).
+    pub fn pending_prefix_drop_records(&self) -> Result<Vec<PendingPrefixDropRecord>, Error> {
+        let namespace = pending_prefix_drops_namespace();
+        let mut iter = self.db.raw_iterator_cf(cf_meta(&self.db));
+        iter.seek(namespace.as_slice());
+        let mut records = Vec::new();
+        while iter.valid() {
+            let Some(key) = iter.key() else { break };
+            if !key.starts_with(namespace.as_slice()) {
+                break;
+            }
+            let Some(value) = iter.value() else { break };
+            records.push(PendingPrefixDropRecord::decode(&key[32..], value)?);
+            iter.next();
+        }
+        Ok(records)
+    }
+
+    /// Remove one pending-prefix-drop redo record (DB-level write). Called
+    /// after its doomed prefixes have been tombstoned.
+    pub fn remove_pending_prefix_drop_record(
+        &self,
+        primary_prefix: &SubtreePrefix,
+    ) -> Result<(), Error> {
+        let mut key = pending_prefix_drops_namespace().to_vec();
+        key.extend_from_slice(primary_prefix);
+        self.db.delete_cf(cf_meta(&self.db), key).map_err(|e| {
+            Error::StorageError(format!(
+                "remove_pending_prefix_drop_record delete_cf failed: {e}"
+            ))
+        })
+    }
+}
+
+/// The reserved 32-byte namespace under which pending-prefix-drop redo
+/// records live in the meta column family. Records are keyed
+/// `namespace ‖ primary_prefix`.
+///
+/// The value is `Blake3("grovedb_pending_prefix_drops_v0")`. It cannot
+/// collide with any path-derived prefix (`build_prefix`), axis-derived
+/// secondary prefix (`secondary_prefix_for`), or the root prefix
+/// (`[0u8; 32]`) without a Blake3 preimage/collision, and the meta column
+/// family carries no production data outside this namespace.
+pub fn pending_prefix_drops_namespace() -> &'static SubtreePrefix {
+    static NAMESPACE: std::sync::OnceLock<SubtreePrefix> = std::sync::OnceLock::new();
+    NAMESPACE.get_or_init(|| *blake3::hash(b"grovedb_pending_prefix_drops_v0").as_bytes())
+}
+
+/// A durable redo record for one flat-subtree drop: the storage prefixes
+/// that became unreachable when the subtree's element was deleted from its
+/// parent Merk, plus the subtree's full path for the drain-time liveness
+/// guard.
+///
+/// The record is written in the same atomic commit as the parent-Merk
+/// delete and erased once every doomed prefix has been range-tombstoned,
+/// making reclamation crash-safe and idempotent.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingPrefixDropRecord {
+    /// The dropped subtree's own path-derived prefix; also the record's key
+    /// suffix within the namespace.
+    pub primary_prefix: SubtreePrefix,
+    /// Full path of the dropped subtree (parent path segments plus its key
+    /// as the last segment). Used by the drain to verify the path does not
+    /// resolve to a live element before tombstoning.
+    pub path: Vec<Vec<u8>>,
+    /// Every prefix to range-delete: the primary prefix plus, for indexed
+    /// primaries, the per-axis secondary prefixes.
+    pub doomed_prefixes: Vec<SubtreePrefix>,
+}
+
+impl PendingPrefixDropRecord {
+    /// Wire version byte of the record value encoding.
+    const ENCODING_VERSION: u8 = 0;
+
+    /// Encode the record value:
+    /// `[version(1)] [doomed_count(1)] [doomed_count × 32] [segment_count(1)]
+    /// ([segment_len(1)] [segment_bytes])*`.
+    ///
+    /// Both counts and every segment length must fit in a `u8`; path
+    /// segments are already capped at 255 bytes by `build_prefix`, and the
+    /// doomed set is at most 1 + one prefix per index axis.
+    pub fn encode(&self) -> Result<Vec<u8>, Error> {
+        let doomed_count: u8 = self.doomed_prefixes.len().try_into().map_err(|_| {
+            Error::StorageError("pending-prefix-drop record: too many doomed prefixes".to_string())
+        })?;
+        let segment_count: u8 = self.path.len().try_into().map_err(|_| {
+            Error::StorageError("pending-prefix-drop record: path too deep".to_string())
+        })?;
+        let mut out = Vec::with_capacity(
+            3 + 32 * self.doomed_prefixes.len()
+                + self.path.iter().map(|s| 1 + s.len()).sum::<usize>(),
+        );
+        out.push(Self::ENCODING_VERSION);
+        out.push(doomed_count);
+        for prefix in &self.doomed_prefixes {
+            out.extend_from_slice(prefix);
+        }
+        out.push(segment_count);
+        for segment in &self.path {
+            let len: u8 = segment.len().try_into().map_err(|_| {
+                Error::StorageError(
+                    "pending-prefix-drop record: path segment over 255 bytes".to_string(),
+                )
+            })?;
+            out.push(len);
+            out.extend_from_slice(segment);
+        }
+        Ok(out)
+    }
+
+    /// Decode a record from its key suffix (the primary prefix) and value.
+    pub fn decode(key_suffix: &[u8], value: &[u8]) -> Result<Self, Error> {
+        let corrupt =
+            |what: &str| Error::StorageError(format!("corrupt pending-prefix-drop record: {what}"));
+        let primary_prefix: SubtreePrefix = key_suffix
+            .try_into()
+            .map_err(|_| corrupt("key suffix is not 32 bytes"))?;
+        fn take<'v>(rest: &mut &'v [u8], n: usize, what: &str) -> Result<&'v [u8], Error> {
+            if rest.len() < n {
+                return Err(Error::StorageError(format!(
+                    "corrupt pending-prefix-drop record: {what}"
+                )));
+            }
+            let (head, tail) = rest.split_at(n);
+            *rest = tail;
+            Ok(head)
+        }
+        let mut rest = value;
+        let version = take(&mut rest, 1, "missing version byte")?[0];
+        if version != Self::ENCODING_VERSION {
+            return Err(corrupt("unknown encoding version"));
+        }
+        let doomed_count = take(&mut rest, 1, "missing doomed count")?[0] as usize;
+        let mut doomed_prefixes = Vec::with_capacity(doomed_count);
+        for _ in 0..doomed_count {
+            let prefix: SubtreePrefix = take(&mut rest, 32, "truncated doomed prefix")?
+                .try_into()
+                .expect("split_at returned exactly 32 bytes");
+            doomed_prefixes.push(prefix);
+        }
+        let segment_count = take(&mut rest, 1, "missing segment count")?[0] as usize;
+        let mut path = Vec::with_capacity(segment_count);
+        for _ in 0..segment_count {
+            let len = take(&mut rest, 1, "missing segment length")?[0] as usize;
+            path.push(take(&mut rest, len, "truncated path segment")?.to_vec());
+        }
+        if !rest.is_empty() {
+            return Err(corrupt("trailing bytes"));
+        }
+        Ok(Self {
+            primary_prefix,
+            path,
+            doomed_prefixes,
+        })
+    }
 }
 
 impl<'db> Storage<'db> for RocksDbStorage {
@@ -1056,6 +1273,117 @@ mod tests {
         RawIterator, Storage, StorageContext,
     };
     use grovedb_path::SubtreePath;
+
+    #[test]
+    fn pending_prefix_drop_record_roundtrip() {
+        let record = PendingPrefixDropRecord {
+            primary_prefix: [7u8; 32],
+            path: vec![b"contracts".to_vec(), vec![], b"bucket_17".to_vec()],
+            doomed_prefixes: vec![[7u8; 32], [8u8; 32], [9u8; 32], [10u8; 32]],
+        };
+        let encoded = record.encode().expect("encode");
+        let decoded =
+            PendingPrefixDropRecord::decode(&record.primary_prefix, &encoded).expect("decode");
+        assert_eq!(decoded, record);
+
+        // Corruption is rejected, not misread.
+        assert!(PendingPrefixDropRecord::decode(&[7u8; 31], &encoded).is_err());
+        assert!(PendingPrefixDropRecord::decode(&record.primary_prefix, &encoded[..5]).is_err());
+        let mut trailing = encoded.clone();
+        trailing.push(0);
+        assert!(PendingPrefixDropRecord::decode(&record.primary_prefix, &trailing).is_err());
+        let mut wrong_version = encoded;
+        wrong_version[0] = 1;
+        assert!(PendingPrefixDropRecord::decode(&record.primary_prefix, &wrong_version).is_err());
+    }
+
+    #[test]
+    fn pending_prefix_drops_namespace_is_domain_separated() {
+        let namespace = pending_prefix_drops_namespace();
+        assert_eq!(
+            namespace,
+            blake3::hash(b"grovedb_pending_prefix_drops_v0").as_bytes()
+        );
+        // Never the root prefix.
+        assert_ne!(namespace, &[0u8; 32]);
+    }
+
+    #[test]
+    fn delete_prefix_ranges_is_scoped_to_the_given_prefixes() {
+        let storage = TempStorage::new();
+        let db = &storage.db;
+
+        let doomed: SubtreePrefix = [3u8; 32];
+        let survivor: SubtreePrefix = [4u8; 32];
+        for prefix in [&doomed, &survivor] {
+            for cf in [cf_default(db), cf_aux(db), cf_roots(db), cf_meta(db)] {
+                let mut key = prefix.to_vec();
+                key.extend_from_slice(b"some_key");
+                db.put_cf(cf, &key, b"value").expect("put");
+            }
+        }
+
+        storage.delete_prefix_ranges(&[doomed]).expect("delete");
+
+        for (name, cf) in [
+            (DEFAULT_COLUMN_FAMILY_NAME, cf_default(db)),
+            (AUX_CF_NAME, cf_aux(db)),
+            (ROOTS_CF_NAME, cf_roots(db)),
+            (META_CF_NAME, cf_meta(db)),
+        ] {
+            let mut doomed_key = doomed.to_vec();
+            doomed_key.extend_from_slice(b"some_key");
+            assert!(
+                db.get_cf(cf, &doomed_key).expect("get").is_none(),
+                "doomed key survived in {name}"
+            );
+            let mut survivor_key = survivor.to_vec();
+            survivor_key.extend_from_slice(b"some_key");
+            assert!(
+                db.get_cf(cf, &survivor_key).expect("get").is_some(),
+                "survivor key was deleted in {name}"
+            );
+        }
+    }
+
+    #[test]
+    fn pending_prefix_drop_records_listing_and_removal() {
+        let storage = TempStorage::new();
+        let db = &storage.db;
+
+        assert!(storage
+            .pending_prefix_drop_records()
+            .expect("list")
+            .is_empty());
+
+        let record_a = PendingPrefixDropRecord {
+            primary_prefix: [1u8; 32],
+            path: vec![b"a".to_vec()],
+            doomed_prefixes: vec![[1u8; 32]],
+        };
+        let record_b = PendingPrefixDropRecord {
+            primary_prefix: [2u8; 32],
+            path: vec![b"b".to_vec()],
+            doomed_prefixes: vec![[2u8; 32], [22u8; 32]],
+        };
+        for record in [&record_a, &record_b] {
+            let mut key = pending_prefix_drops_namespace().to_vec();
+            key.extend_from_slice(&record.primary_prefix);
+            db.put_cf(cf_meta(db), &key, record.encode().expect("encode"))
+                .expect("put");
+        }
+        // An unrelated meta key outside the namespace is not a record.
+        db.put_cf(cf_meta(db), b"unrelated", b"noise").expect("put");
+
+        let records = storage.pending_prefix_drop_records().expect("list");
+        assert_eq!(records, vec![record_a.clone(), record_b.clone()]);
+
+        storage
+            .remove_pending_prefix_drop_record(&record_a.primary_prefix)
+            .expect("remove");
+        let records = storage.pending_prefix_drop_records().expect("list");
+        assert_eq!(records, vec![record_b]);
+    }
 
     #[test]
     fn flush_persists_all_column_families() {


### PR DESCRIPTION
Implements the O(1) drop of a populated subtree requested by #848, specialized to the case platform actually has (confirmed on the issue discussion): **the dropped subtree is declared to contain no child subtrees.** That declaration collapses the issue's two-phase detach-and-sweep design — no discovery walk, no sweep queue, no budgeted background pass — because every doomed storage prefix is derivable up front: the subtree's own `blake3(path)` prefix plus, for indexed primaries, the three axis secondaries at `blake3(prefix ‖ axis_tag)`. The flatness contract holds by construction for non-Merk data trees and indexed primaries; only a plain Merk tree relies on the caller's word, and a false declaration leaks the children's storage (unreachable, invisible to hashes/proofs/sync/verify) but never corrupts state.

## Consensus side (GROVE_V4, fail-closed)

- **`GroveDb::drop_flat_subtree(path, key, tx, version)`** — an ordinary layered delete of the subtree's element from its parent Merk. The child subtree is **never opened**, so cost is a deterministic function of (element bytes, key, parent shape, path) and independent of the subtree's contents — dropping ten million entries costs the same as dropping ten (pinned by test). Atomically with the delete (same `StorageBatch`), one durable **redo record** is staged into a reserved namespace of the meta column family (unused in production since 2022, outside the root hash), carrying the subtree's full path and the doomed prefixes.
- **`SubelementsDeletionBehavior::DropFlat`** on batch `DeleteTree` ops — same semantics through `apply_batch` / `apply_partial_batch` / `apply_operations_without_batching`, classified from the captured **actual** stored type (the V4 old-value observer), so a declared/stored indexed mismatch cannot slip through. Average/worst-case estimates are extended by the record put's deterministic cost (estimation is replay-critical, and the new behavior only exists under V4, so the estimate lands with the op).
- Version gating follows the PDS capability-gate pattern: `operations.flat_drop.{drop_flat_subtree, batch_delete_tree_drop_flat}` are `0` (fail closed) on V1..V3, `1` on V4, pinned by `grovedb-version` tests.

## Reclamation (outside consensus, telemetry only)

- **`RocksDbStorage::delete_prefix_ranges`** — one DB-level range tombstone per (prefix, CF) across all four column families. RocksDB optimistic transactions cannot carry `DeleteRange` (and the rocksdb crate only implements it for non-transactional write batches), so tombstones are written **after** the commit: immediately in the same call when GroveDB owns the transaction, otherwise at the host's next **`GroveDb::flush_pending_prefix_drops`**.
- **Crash safety**: records survive restarts and checkpoints; draining re-issues (idempotent) tombstones before removing the record, so a crash between the two just redoes the tombstones. Records staged inside an uncommitted caller transaction are invisible to the drain and roll back with it.
- **Liveness guard**: before tombstoning, the drain re-resolves the record's path against the live element graph. A record whose path resolves to a live element (a re-created dropped path — a documented contract violation, same class as dangling references) is **skipped and reported** (`skipped_live`), degrading the violation to a bounded leak instead of destroying live data. The recreate-path test also documents the deeper reason for the contract: stale nodes under the re-derived identical prefix pollute the new tree's namespace, visibly to `verify_grovedb`.
- Reclamation never contributes to the operation's returned cost, consistent with platform excluding TTL'd subtrees from storage-refund accounting.

## Orphan invisibility (issue requirement 5) — holds by construction

Verified against the actual code paths before designing this: state sync enumerates subtrees by walking the element graph from the root on both source and target, so unreachable prefixes are never requested or shipped; `verify_grovedb` recurses from the root Merk; every iterator is prefix-scoped; the meta CF is outside the root hash, so nodes at different reclamation progress have identical root hashes. RocksDB checkpoints carry both the orphans and the records, so a reopened checkpoint resumes reclamation; a state-synced replica starts orphan-free with an empty queue. Range tombstones are sequence-numbered, so readers holding older snapshots (state-sync sessions, checkpoints) still see pre-drop data.

## What this deliberately does not do

The issue's fully general two-phase design (drop of subtrees with **nested** children at any depth, via a persistent sweep queue with budgeted structure discovery) is out of scope here — platform's TTL time-range buckets are flat. The redo-record format and reserved namespace are exactly the bones that design would need (a nested-capable sweep would extend the record with a state machine and cursor), so nothing here paints us into a corner if the general case is ever needed.

## Host integration (drive-abci)

- Drop inside the block's transaction batch via `DeleteTree(_, DropFlat)`.
- After committing the block's transaction, call `flush_pending_prefix_drops` (also once at startup, to finish reclamation interrupted by a crash). It is deliberately ungated: a no-op when no records exist, never touches the root hash.
- Never re-create a dropped path before its record drains (time-range bucket paths embed the window start, so this holds naturally).

## Tests

- Storage: record codec round-trip + corruption rejection, namespace domain separation, range-delete scoping (survivor prefixes untouched across all CFs), record listing/removal.
- Version: gate slots pinned 0/0/0/1 across V1..V4.
- GroveDB (14 integration tests): content-independent drop cost (5 vs 500 entries, byte-identical `OperationCost`), full reclamation incl. all three axis-secondary namespaces for indexed primaries, provable absence + clean `verify_grovedb` while reclamation is pending, tx atomicity (commit-deferred drain, rollback leaves no record and no tombstones), flush idempotence, simulated crash between tombstones and record removal, recreate-path poisoning (guard skips, fresh data survives, pollution is verify-visible), batch atomicity with sibling ops, fail-closed on GROVE_V3 for both entry points, sum-parent aggregate consistency.
- Full workspace suite: **5180 passed, 0 failed** (nextest, all features).

Closes #848 for the flat case; if the nested-subtree generalization is still wanted later, I'd suggest a follow-up issue referencing the record format introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added O(1) flat-subtree deletion for populated subtrees in GroveDB V4 and later.
  * Added batch deletion support using the flat-drop behavior.
  * Added crash-safe, deferred storage reclamation with retryable cleanup reporting.
  * Added safeguards for recreated or still-live paths.

* **Compatibility**
  * Flat-subtree deletion is disabled and fails safely on GroveDB V1–V3.

* **Tests**
  * Added coverage for deletion, cleanup, transactions, crash recovery, indexing, consistency, and version gating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->