### PR TITLE
feat: merge a limited path query below a key another branch already owns

### DIFF
--- a/grovedb/src/query/merge/mod.rs
+++ b/grovedb/src/query/merge/mod.rs
@@ -20,10 +20,12 @@
 //!   becomes its merged branch's per-instance cap (`Query::limit`) —
 //!   exact, because the branch instance executes exactly once — and
 //!   authored per-instance limits ride along on their branches.
-//!   Budgets never blend, so limits merge only as exclusive grafts: a
-//!   limited input landing at the merged root, or two limited branches
-//!   colliding on a key, are refused with typed errors. Offsets are
-//!   still refused.
+//!   Budgets never blend, so limits merge only as exclusive grafts.
+//!   Branches may descend through a selected key whose first matching
+//!   conditional is that exact key, until their paths diverge. A budget
+//!   on a body landing at the merged root, or overlapping selections
+//!   that cannot keep their budgets separate, are refused with typed
+//!   errors. Offsets are still refused.
 //!
 //!   (An intermediate carrying only the direction rules was once gated
 //!   here for `GROVE_V4`; since no grove version ever shipped it, it

--- a/grovedb/src/query/merge/v1.rs
+++ b/grovedb/src/query/merge/v1.rs
@@ -14,10 +14,18 @@
 //!
 //! Budgets never blend, so limits merge only as **exclusive grafts**:
 //!
-//! - a limited input whose whole path is the common path lands *at the
-//!   merged root*, where its query body would merge with the other
-//!   inputs' — refused;
-//! - two limited branches colliding on a key are refused;
+//! - an input whose whole path is the common path lands *at the merged
+//!   root*, where its query body merges with the other inputs': a
+//!   budget at that body (a global limit, or a cap on the body itself)
+//!   is refused, and caps on its own branches are accepted only when
+//!   it is the sole body at the root (so nothing else selects rows
+//!   under those branches);
+//! - a limited branch colliding on a key already owned by another
+//!   grafted branch **descends** into it and grafts where the two
+//!   actually diverge (the same merge, one level down — see
+//!   [`graft_below`]); it is refused only when the bodies would meet,
+//!   or when the key is selected by a range or by the merged root's own
+//!   items, where nothing below can be told apart;
 //! - limit-free inputs merge exactly as v0 does, modulo the direction
 //!   rules above, on the same code path.
 //!
@@ -61,16 +69,26 @@ pub(super) fn merge_v1(path_queries: Vec<&PathQuery>) -> Result<PathQuery, Error
                 "can not merge pathqueries with offsets".to_string(),
             ));
         }
-        let carries_limits = path_query.query.limit.is_some() || path_query.has_instance_limits();
         path_query
             .to_subquery_branch_with_offset_start_index(next_index)
             .and_then(|mut unsized_path_query| {
                 if unsized_path_query.subquery_path.is_none() {
                     // The input lands at the merged root, where its
                     // query body merges with the other root-level
-                    // inputs — budgets cannot blend, so limits are
-                    // refused here.
-                    if carries_limits {
+                    // inputs'. A budget AT that body — a global limit,
+                    // which has nowhere to lift, or a cap on the body
+                    // itself — would have to blend, so it is refused
+                    // here. Caps on the body's own branches are
+                    // exclusive to those branches and ride along, as
+                    // long as nothing else lands at the root beside it
+                    // (checked below, once every input is placed).
+                    let root_body =
+                        *unsized_path_query
+                            .subquery
+                            .ok_or(Error::CorruptedCodeExecution(
+                                "subquery must exist when subquery_path is none in merge",
+                            ))?;
+                    if path_query.query.limit.is_some() || root_body.limit.is_some() {
                         return Err(Error::NotSupported(
                             "can not merge a limited path query that lands at the merged root: \
                              its budget would have to blend with the other queries' result \
@@ -79,11 +97,7 @@ pub(super) fn merge_v1(path_queries: Vec<&PathQuery>) -> Result<PathQuery, Error
                                 .to_string(),
                         ));
                     }
-                    queries_for_common_path_this_level.push(*unsized_path_query.subquery.ok_or(
-                        Error::CorruptedCodeExecution(
-                            "subquery must exist when subquery_path is none in merge",
-                        ),
-                    )?);
+                    queries_for_common_path_this_level.push(root_body);
                 } else {
                     // The lift: an input's global budget becomes its
                     // branch-root query's per-instance cap. Exact,
@@ -108,8 +122,34 @@ pub(super) fn merge_v1(path_queries: Vec<&PathQuery>) -> Result<PathQuery, Error
             })
     })?;
 
-    let mut merged_query = Query::merge_multiple_directional(queries_for_common_path_this_level)
-        .map_err(|e| Error::NotSupported(e.to_string()))?;
+    // Bodies meeting at the merged root become one query, so a cap on
+    // any of their branches would govern rows the other bodies select
+    // under the same keys: several root-landers merge only when none
+    // carries a cap anywhere. (A lone root-lander keeps its branch caps
+    // — this is how a branch that was itself merged from several inputs
+    // comes back through `graft_below`.)
+    if queries_for_common_path_this_level.len() > 1
+        && queries_for_common_path_this_level
+            .iter()
+            .any(|query| query.has_instance_limit_anywhere())
+    {
+        return Err(Error::NotSupported(
+            "can not merge limited path queries whose bodies meet at the merged root: a \
+             branch cap would govern rows the other bodies select; give the limited query a \
+             longer path of its own or merge it separately"
+                .to_string(),
+        ));
+    }
+
+    // A lone root-lander IS the root body — no merge to run, and none
+    // of the merge machinery's gates to trip over the branch caps it
+    // may legitimately carry.
+    let mut merged_query = match queries_for_common_path_this_level.len() {
+        0 => Query::new(),
+        1 => queries_for_common_path_this_level.remove(0),
+        _ => Query::merge_multiple_directional(queries_for_common_path_this_level)
+            .map_err(|e| Error::NotSupported(e.to_string()))?,
+    };
 
     // Add conditional subqueries in a canonical order: every
     // limit-free branch first (through the full merge machinery, which
@@ -166,15 +206,55 @@ pub(super) fn merge_v1(path_queries: Vec<&PathQuery>) -> Result<PathQuery, Error
         let mut subquery_path =
             subquery_path.ok_or(Error::CorruptedCodeExecution("subquery path must exist"))?;
         let key = subquery_path.remove(0); // must exist
+        let rest_of_path = if subquery_path.is_empty() {
+            None
+        } else {
+            Some(subquery_path)
+        };
+
+        // A branch grafted earlier — limit-free through the machinery,
+        // or an exclusive limited graft — may already own this exact
+        // key. Budgets still never blend: the two are merged one level
+        // down, where they either diverge onto exclusive keys of their
+        // own or are refused because their bodies would meet.
+        let owned_by_exact_key = merged_query
+            .conditional_subquery_branches
+            .as_ref()
+            .is_some_and(|branches| branches.contains_key(&QueryItem::Key(key.clone())));
+        let selected_by_a_range = merged_query
+            .items
+            .iter()
+            .any(|item| item.contains(key.as_slice()) && *item != QueryItem::Key(key.clone()));
+        if owned_by_exact_key && !selected_by_a_range {
+            let branches = merged_query.conditional_subquery_branches.as_mut().ok_or(
+                Error::CorruptedCodeExecution(
+                    "conditional branches must exist when one owns the key",
+                ),
+            )?;
+            let existing = branches.get(&QueryItem::Key(key.clone())).cloned().ok_or(
+                Error::CorruptedCodeExecution("the owning conditional branch must exist"),
+            )?;
+            let grafted = graft_below(
+                &common_path,
+                &key,
+                existing,
+                SubqueryBranch {
+                    subquery_path: rest_of_path,
+                    subquery,
+                },
+            )?;
+            branches.insert(QueryItem::Key(key), grafted);
+            continue;
+        }
 
         // Budgets never blend: a limit-carrying branch merges only as
         // an exclusive graft. Overlap with the merged root's own
         // selection (assessed BEFORE this branch's item is inserted —
         // the graft's own `Key` would otherwise always match) or with
-        // any already-merged conditional would need the two sides'
-        // bodies — and budgets — merged, which is refused by design.
-        // Only the actually colliding structures are consulted, so a
-        // disjoint limited branch cannot change another branch's
+        // a conditional that selects the key by a range would need the
+        // two sides' bodies — and budgets — merged, which is refused by
+        // design. Only the actually colliding structures are consulted,
+        // so a disjoint limited branch cannot change another branch's
         // acceptance.
         let collides = merged_query
             .items
@@ -192,11 +272,6 @@ pub(super) fn merge_v1(path_queries: Vec<&PathQuery>) -> Result<PathQuery, Error
             )));
         }
         merged_query.insert_item(QueryItem::Key(key.clone()));
-        let rest_of_path = if subquery_path.is_empty() {
-            None
-        } else {
-            Some(subquery_path)
-        };
         merged_query.add_conditional_subquery(
             QueryItem::Key(key),
             rest_of_path,
@@ -210,4 +285,63 @@ pub(super) fn merge_v1(path_queries: Vec<&PathQuery>) -> Result<PathQuery, Error
     merged_query.left_to_right = shared_direction;
 
     Ok(PathQuery::new_unsized(common_path, merged_query))
+}
+
+/// Merge a limited branch into the branch that already owns its first
+/// key, one level down.
+///
+/// Both branches are rebuilt as path queries rooted at `common_path +
+/// [key]` and run through the same merge: their remaining paths either
+/// diverge — each lands on an exclusive key of its own, exactly as it
+/// would have had the common path been one level deeper — or they do
+/// not, and the merge refuses them there (a body landing at that root,
+/// or a further collision that never diverges) with the root-landing
+/// and collision rules above. The result is the owning branch's
+/// replacement: its subquery path is whatever the two still share below
+/// `key`, and its subquery is the merged body. Lifted limits are already
+/// per-instance caps on the leaf bodies, so the descent carries no
+/// global limit to lift twice.
+fn graft_below(
+    common_path: &[Vec<u8>],
+    key: &[u8],
+    existing: SubqueryBranch,
+    incoming: SubqueryBranch,
+) -> Result<SubqueryBranch, Error> {
+    let base: Vec<Vec<u8>> = common_path
+        .iter()
+        .cloned()
+        .chain(std::iter::once(key.to_vec()))
+        .collect();
+    let as_path_query = |branch: SubqueryBranch| -> Result<PathQuery, Error> {
+        let SubqueryBranch {
+            subquery_path,
+            subquery,
+        } = branch;
+        let query = subquery.ok_or(Error::NotSupported(
+            "can not descend into a conditional branch that carries no subquery".to_string(),
+        ))?;
+        let path: Vec<Vec<u8>> = base
+            .iter()
+            .cloned()
+            .chain(subquery_path.unwrap_or_default())
+            .collect();
+        Ok(PathQuery::new_unsized(path, *query))
+    };
+    let existing = as_path_query(existing)?;
+    let incoming = as_path_query(incoming)?;
+    let merged = merge_v1(vec![&existing, &incoming]).map_err(|error| match error {
+        Error::NotSupported(message) => Error::NotSupported(format!(
+            "can not merge limited path queries whose branches collide at key {} and do \
+             not diverge below it: {}",
+            hex_to_ascii(key),
+            message
+        )),
+        other => other,
+    })?;
+    let PathQuery { path, query } = merged;
+    let below = path[base.len()..].to_vec();
+    Ok(SubqueryBranch {
+        subquery_path: if below.is_empty() { None } else { Some(below) },
+        subquery: Some(Box::new(query.query)),
+    })
 }

--- a/grovedb/src/query/merge/v1.rs
+++ b/grovedb/src/query/merge/v1.rs
@@ -20,9 +20,9 @@
 //!   is refused, and caps on its own branches are accepted only when
 //!   it is the sole body at the root (so nothing else selects rows
 //!   under those branches);
-//! - a limited branch colliding on a key already owned by another
-//!   grafted branch **descends** into it and grafts where the two
-//!   actually diverge (the same merge, one level down — see
+//! - a limited branch colliding on a selected key whose first matching
+//!   conditional is that exact key **descends** into it and grafts where
+//!   the two actually diverge (the same merge, one level down — see
 //!   [`graft_below`]); it is refused only when the bodies would meet,
 //!   or when the key is selected by a range or by the merged root's own
 //!   items, where nothing below can be told apart;
@@ -152,9 +152,10 @@ pub(super) fn merge_v1(path_queries: Vec<&PathQuery>) -> Result<PathQuery, Error
     };
 
     // Add conditional subqueries in a canonical order: every
-    // limit-free branch first (through the full merge machinery, which
-    // is still limit-free at that point), then the limit-carrying
-    // branches as exclusive grafts. Without the partition, acceptance
+    // limit-free branch first, then the limit-carrying branches.
+    // Use the full merge machinery only while both sides are limit-free;
+    // a root body with child caps already needs exclusive grafts, even
+    // for incoming limit-free branches. Without the partition, acceptance
     // would depend on input order — a disjoint limited branch
     // processed early would force a later limit-free overlap onto the
     // graft path and refuse it. The partition is deterministic (stable
@@ -171,34 +172,9 @@ pub(super) fn merge_v1(path_queries: Vec<&PathQuery>) -> Result<PathQuery, Error
             .into_iter()
             .partition(&carries_limits);
 
-    for sub_path_query in unlimited_branches {
-        let SubqueryBranch {
-            subquery_path,
-            subquery,
-        } = sub_path_query;
-        let mut subquery_path =
-            subquery_path.ok_or(Error::CorruptedCodeExecution("subquery path must exist"))?;
-        let key = subquery_path.remove(0); // must exist
-        merged_query.insert_item(QueryItem::Key(key.clone()));
-        let rest_of_path = if subquery_path.is_empty() {
-            None
-        } else {
-            Some(subquery_path)
-        };
-        let subquery_branch = SubqueryBranch {
-            subquery_path: rest_of_path,
-            subquery,
-        };
-        // See v0: read modes are rejected in the prelude; propagate
-        // rather than discard if one ever reaches here. The merged
-        // query is still limit-free in this phase, so the machinery's
-        // blanket instance-limit gate cannot misfire.
-        merged_query
-            .merge_conditional_boxed_subquery(QueryItem::Key(key), subquery_branch)
-            .map_err(|e| Error::NotSupported(e.to_string()))?;
-    }
-
-    for sub_path_query in limited_branches {
+    for sub_path_query in unlimited_branches.into_iter().chain(limited_branches) {
+        let use_limit_free_merge =
+            !carries_limits(&sub_path_query) && !merged_query.has_instance_limit_anywhere();
         let SubqueryBranch {
             subquery_path,
             subquery,
@@ -211,21 +187,39 @@ pub(super) fn merge_v1(path_queries: Vec<&PathQuery>) -> Result<PathQuery, Error
         } else {
             Some(subquery_path)
         };
+        if use_limit_free_merge {
+            merged_query.insert_item(QueryItem::Key(key.clone()));
+            merged_query
+                .merge_conditional_boxed_subquery(
+                    QueryItem::Key(key),
+                    SubqueryBranch {
+                        subquery_path: rest_of_path,
+                        subquery,
+                    },
+                )
+                .map_err(|e| Error::NotSupported(e.to_string()))?;
+            continue;
+        }
 
         // A branch grafted earlier — limit-free through the machinery,
         // or an exclusive limited graft — may already own this exact
         // key. Budgets still never blend: the two are merged one level
         // down, where they either diverge onto exclusive keys of their
-        // own or are refused because their bodies would meet.
+        // own or are refused because their bodies would meet. A dormant
+        // conditional does not own an unselected key, and an earlier
+        // matching range takes precedence over a later exact conditional.
+        let exact_key = QueryItem::Key(key.clone());
+        let selected_by_exact_key = merged_query.items.contains(&exact_key);
         let owned_by_exact_key = merged_query
             .conditional_subquery_branches
             .as_ref()
-            .is_some_and(|branches| branches.contains_key(&QueryItem::Key(key.clone())));
+            .and_then(|branches| branches.keys().find(|item| item.contains(key.as_slice())))
+            .is_some_and(|item| *item == exact_key);
         let selected_by_a_range = merged_query
             .items
             .iter()
-            .any(|item| item.contains(key.as_slice()) && *item != QueryItem::Key(key.clone()));
-        if owned_by_exact_key && !selected_by_a_range {
+            .any(|item| item.contains(key.as_slice()) && *item != exact_key);
+        if selected_by_exact_key && owned_by_exact_key && !selected_by_a_range {
             let branches = merged_query.conditional_subquery_branches.as_mut().ok_or(
                 Error::CorruptedCodeExecution(
                     "conditional branches must exist when one owns the key",

--- a/grovedb/src/tests/per_instance_limit_tests.rs
+++ b/grovedb/src/tests/per_instance_limit_tests.rs
@@ -1739,11 +1739,78 @@ fn merge_grafts_an_unlimited_sibling_beside_a_root_branch_cap() {
     }
 }
 
+/// `docs/p1/a/{k0,k1}`, `docs/p1/b/{k0,k1}`, `docs/p2/{k0..k3}` and
+/// `other/{k0,k1}`: a two-level shared prefix under `docs`, plus an
+/// unrelated tree that lifts the common path to the root.
+fn populate_nested_parents(db: &TempGroveDb, grove_version: &GroveVersion) {
+    use crate::tests::common::EMPTY_PATH;
+    populate_parents(db, &[b"p2"], 4, grove_version);
+    db.insert(
+        [DOCS].as_ref(),
+        b"p1",
+        Element::empty_tree(),
+        None,
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("insert p1 tree");
+    for child in [b"a", b"b"] {
+        db.insert(
+            [DOCS, b"p1".as_slice()].as_ref(),
+            child,
+            Element::empty_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert nested child tree");
+        for i in 0..2u8 {
+            db.insert(
+                [DOCS, b"p1".as_slice(), child.as_slice()].as_ref(),
+                &[b'k', b'0' + i],
+                Element::new_item(vec![i]),
+                None,
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("insert nested item");
+        }
+    }
+    db.insert(
+        EMPTY_PATH,
+        b"other",
+        Element::empty_tree(),
+        None,
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("insert other tree");
+    for i in 0..2u8 {
+        db.insert(
+            [b"other".as_slice()].as_ref(),
+            &[b'k', b'0' + i],
+            Element::new_item(vec![i]),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert other item");
+    }
+}
+
 #[test]
 fn merge_nested_limited_grafts_is_independent_of_all_input_permutations() {
     use itertools::Itertools;
 
     let grove_version = GroveVersion::latest();
+    let db = make_test_grovedb(grove_version);
+    populate_nested_parents(&db, grove_version);
+
     let limited = |path: &[&[u8]]| {
         PathQuery::new(
             path.iter().map(|key| key.to_vec()).collect(),
@@ -1756,11 +1823,27 @@ fn merge_nested_limited_grafts_is_independent_of_all_input_permutations() {
         limited(&[DOCS, b"p1", b"b"]),
         PathQuery::new_unsized(vec![b"other".to_vec()], Query::new_range_full()),
     ];
-    let expected = PathQuery::merge(queries.iter().collect(), grove_version)
+
+    // The merged query walks keys in order (`docs` before `other`, `p1`
+    // before `p2`, `a` before `b`), so the trusted reads of the inputs,
+    // concatenated in that order, are exactly what the merge must return:
+    // one capped row under each of `a`, `b` and `p2`, then all of `other`.
+    let mut expected = Vec::new();
+    for input in [&queries[1], &queries[2], &queries[0], &queries[3]] {
+        expected.extend(run(&db, input, grove_version).0);
+    }
+    assert_eq!(expected.len(), 5);
+
+    let canonical = PathQuery::merge(queries.iter().collect(), grove_version)
         .expect("nested limited branches diverge below docs and p1");
     for inputs in queries.iter().permutations(queries.len()) {
         let merged = PathQuery::merge(inputs, grove_version)
             .expect("every ordering must preserve the previously grafted child caps");
-        assert_eq!(merged, expected);
+        assert_eq!(merged, canonical);
+        assert_eq!(run(&db, &merged, grove_version).0, expected);
+        assert_eq!(
+            assert_proved_matches_trusted_read(&db, &merged, grove_version),
+            expected.len(),
+        );
     }
 }

--- a/grovedb/src/tests/per_instance_limit_tests.rs
+++ b/grovedb/src/tests/per_instance_limit_tests.rs
@@ -1597,3 +1597,170 @@ fn merge_still_refuses_limited_branches_that_never_diverge() {
         "a range-selected key cannot host a limited graft, got {result:?}"
     );
 }
+
+#[test]
+fn merge_refuses_a_limited_graft_shadowed_by_a_range_conditional() {
+    let grove_version = GroveVersion::latest();
+    let mut root = Query::new_single_key(DOCS.to_vec());
+    // Conditional branches use the first matching selector. The exact
+    // key exists, but the earlier range is the branch that actually runs.
+    for selector in [
+        crate::QueryItem::RangeFull(..),
+        crate::QueryItem::Key(DOCS.to_vec()),
+    ] {
+        root.add_conditional_subquery(
+            selector,
+            Some(vec![b"p1".to_vec()]),
+            Some(Query::new_range_full()),
+        );
+    }
+    let root = PathQuery::new_unsized(vec![], root);
+    let limited = PathQuery::new(
+        vec![DOCS.to_vec(), b"p2".to_vec()],
+        SizedQuery::new(Query::new_range_full(), Some(2), None),
+    );
+    for inputs in [vec![&root, &limited], vec![&limited, &root]] {
+        let result = PathQuery::merge(inputs, grove_version);
+        assert!(
+            matches!(&result, Err(Error::NotSupported(message)) if message.contains("collide")),
+            "a shadowed branch must not accept a graft that will never run: {result:?}"
+        );
+    }
+}
+
+#[test]
+fn merge_grafts_below_an_exact_conditional_before_a_matching_range() {
+    let grove_version = GroveVersion::latest();
+    let db = make_test_grovedb(grove_version);
+    populate_parents(&db, &[b"p1", b"p2"], 4, grove_version);
+    let mut root = Query::new_single_key(DOCS.to_vec());
+    // The exact branch runs; the later matching range is inactive.
+    for selector in [
+        crate::QueryItem::Key(DOCS.to_vec()),
+        crate::QueryItem::RangeFull(..),
+    ] {
+        root.add_conditional_subquery(
+            selector,
+            Some(vec![b"p1".to_vec()]),
+            Some(Query::new_range_full()),
+        );
+    }
+    let root = PathQuery::new_unsized(vec![], root);
+    let limited = PathQuery::new(
+        vec![DOCS.to_vec(), b"p2".to_vec()],
+        SizedQuery::new(Query::new_range_full(), Some(2), None),
+    );
+    let mut expected = run(&db, &root, grove_version).0;
+    expected.extend(run(&db, &limited, grove_version).0);
+    assert_eq!(expected.len(), 6);
+    for inputs in [vec![&root, &limited], vec![&limited, &root]] {
+        let merged = PathQuery::merge(inputs, grove_version)
+            .expect("the first matching conditional owns the selected key");
+        assert_eq!(run(&db, &merged, grove_version).0, expected);
+        assert_eq!(
+            assert_proved_matches_trusted_read(&db, &merged, grove_version),
+            expected.len(),
+        );
+    }
+}
+
+#[test]
+fn merge_refuses_a_limited_graft_into_an_unselected_conditional() {
+    let grove_version = GroveVersion::latest();
+    let mut root = Query::new_single_key(b"other".to_vec());
+    // Defining a conditional does not select its key. Descending into
+    // this dormant branch would omit p2, or add unwanted p1 rows if we
+    // also selected docs after merging the two branches.
+    root.add_conditional_subquery(
+        crate::QueryItem::Key(DOCS.to_vec()),
+        Some(vec![b"p1".to_vec()]),
+        Some(Query::new_range_full()),
+    );
+    let root = PathQuery::new_unsized(vec![], root);
+    let limited = PathQuery::new(
+        vec![DOCS.to_vec(), b"p2".to_vec()],
+        SizedQuery::new(Query::new_range_full(), Some(2), None),
+    );
+    for inputs in [vec![&root, &limited], vec![&limited, &root]] {
+        let result = PathQuery::merge(inputs, grove_version);
+        assert!(
+            matches!(&result, Err(Error::NotSupported(message)) if message.contains("collide")),
+            "an unselected conditional cannot own the incoming query's key: {result:?}"
+        );
+    }
+}
+
+#[test]
+fn merge_grafts_an_unlimited_sibling_beside_a_root_branch_cap() {
+    let grove_version = GroveVersion::latest();
+    let db = make_test_grovedb(grove_version);
+    populate_parents(&db, &[b"p1", b"p2"], 4, grove_version);
+
+    for left_to_right in [true, false] {
+        for conditional in [true, false] {
+            let mut capped = Query::new_range_full();
+            capped.left_to_right = left_to_right;
+            capped.limit = Some(1);
+            let mut root = Query::new_single_key(b"p1".to_vec());
+            root.left_to_right = left_to_right;
+            if conditional {
+                root.add_conditional_subquery(
+                    crate::QueryItem::Key(b"p1".to_vec()),
+                    None,
+                    Some(capped),
+                );
+            } else {
+                root.set_subquery(capped);
+            }
+            let root = PathQuery::new_unsized(vec![DOCS.to_vec()], root);
+            let mut every_p2 = Query::new_range_full();
+            every_p2.left_to_right = left_to_right;
+            let sibling = PathQuery::new_unsized(vec![DOCS.to_vec(), b"p2".to_vec()], every_p2);
+
+            let mut expected = run(&db, &root, grove_version).0;
+            let mut sibling_rows = run(&db, &sibling, grove_version).0;
+            if left_to_right {
+                expected.append(&mut sibling_rows);
+            } else {
+                sibling_rows.append(&mut expected);
+                expected = sibling_rows;
+            }
+            assert_eq!(expected.len(), 5, "one p1 row and all four p2 rows");
+            for inputs in [vec![&root, &sibling], vec![&sibling, &root]] {
+                let merged = PathQuery::merge(inputs, grove_version)
+                    .expect("an unlimited sibling has no overlap with the root's branch cap");
+                assert_eq!(run(&db, &merged, grove_version).0, expected);
+                assert_eq!(
+                    assert_proved_matches_trusted_read(&db, &merged, grove_version),
+                    expected.len(),
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn merge_nested_limited_grafts_is_independent_of_all_input_permutations() {
+    use itertools::Itertools;
+
+    let grove_version = GroveVersion::latest();
+    let limited = |path: &[&[u8]]| {
+        PathQuery::new(
+            path.iter().map(|key| key.to_vec()).collect(),
+            SizedQuery::new(Query::new_range_full(), Some(1), None),
+        )
+    };
+    let queries = [
+        limited(&[DOCS, b"p2"]),
+        limited(&[DOCS, b"p1", b"a"]),
+        limited(&[DOCS, b"p1", b"b"]),
+        PathQuery::new_unsized(vec![b"other".to_vec()], Query::new_range_full()),
+    ];
+    let expected = PathQuery::merge(queries.iter().collect(), grove_version)
+        .expect("nested limited branches diverge below docs and p1");
+    for inputs in queries.iter().permutations(queries.len()) {
+        let merged = PathQuery::merge(inputs, grove_version)
+            .expect("every ordering must preserve the previously grafted child caps");
+        assert_eq!(merged, expected);
+    }
+}

--- a/grovedb/src/tests/per_instance_limit_tests.rs
+++ b/grovedb/src/tests/per_instance_limit_tests.rs
@@ -1441,3 +1441,159 @@ fn empty_parents_are_reported_when_parent_inclusion_is_requested() {
     assert!(keys.contains(&b"full".as_slice()));
     assert!(keys.contains(&b"k0".as_slice()));
 }
+
+/// A limited input whose first key is already owned by a limit-free
+/// graft descends into it and grafts where the two diverge: `docs/p1`
+/// (every row) and `docs/p2` (two rows) share the `docs` key once an
+/// unrelated input lifts the common path above it, and still prove,
+/// verify and match the trusted read as one query.
+#[test]
+fn merge_grafts_a_limited_branch_below_a_key_a_limit_free_branch_owns() {
+    let grove_version = GroveVersion::latest();
+    let db = make_test_grovedb(grove_version);
+    populate_parents(&db, &[b"p1", b"p2"], 4, grove_version);
+    use crate::tests::common::EMPTY_PATH;
+    db.insert(
+        EMPTY_PATH,
+        b"other",
+        Element::empty_tree(),
+        None,
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("insert other tree");
+    db.insert(
+        [b"other".as_slice()].as_ref(),
+        b"x",
+        Element::new_item(vec![9]),
+        None,
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("insert other item");
+
+    let every_p1 =
+        PathQuery::new_unsized(vec![DOCS.to_vec(), b"p1".to_vec()], Query::new_range_full());
+    let two_of_p2 = PathQuery::new(
+        vec![DOCS.to_vec(), b"p2".to_vec()],
+        SizedQuery::new(Query::new_range_full(), Some(2), None),
+    );
+    let other = PathQuery::new_unsized(
+        vec![b"other".to_vec()],
+        Query::new_single_key(b"x".to_vec()),
+    );
+
+    let merged = PathQuery::merge(vec![&every_p1, &two_of_p2, &other], grove_version)
+        .expect("a limited branch grafts below the key the limit-free branch owns");
+    assert_eq!(merged.query.limit, None, "the merged query stays unsized");
+    let rows = assert_proved_matches_trusted_read(&db, &merged, grove_version);
+    assert_eq!(rows, 4 + 2 + 1, "all of p1, two of p2, the other row");
+
+    // Input order does not decide acceptance: limit-free branches merge
+    // first, so the descent sees the same owning branch either way.
+    let permuted = PathQuery::merge(vec![&two_of_p2, &other, &every_p1], grove_version)
+        .expect("the permutation merges identically");
+    assert_eq!(merged, permuted);
+}
+
+/// Two limited inputs colliding on a key graft below it when their
+/// paths diverge there — each keeps its own instance budget.
+#[test]
+fn merge_grafts_two_limited_branches_that_diverge_below_a_shared_key() {
+    let grove_version = GroveVersion::latest();
+    let db = make_test_grovedb(grove_version);
+    populate_parents(&db, &[b"p1", b"p2"], 4, grove_version);
+    use crate::tests::common::EMPTY_PATH;
+    db.insert(
+        EMPTY_PATH,
+        b"other",
+        Element::empty_tree(),
+        None,
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("insert other tree");
+    db.insert(
+        [b"other".as_slice()].as_ref(),
+        b"x",
+        Element::new_item(vec![9]),
+        None,
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("insert other item");
+
+    let one_of_p1 = PathQuery::new(
+        vec![DOCS.to_vec(), b"p1".to_vec()],
+        SizedQuery::new(Query::new_range_full(), Some(1), None),
+    );
+    let two_of_p2 = PathQuery::new(
+        vec![DOCS.to_vec(), b"p2".to_vec()],
+        SizedQuery::new(Query::new_range_full(), Some(2), None),
+    );
+    let other = PathQuery::new_unsized(
+        vec![b"other".to_vec()],
+        Query::new_single_key(b"x".to_vec()),
+    );
+
+    let merged = PathQuery::merge(vec![&one_of_p1, &two_of_p2, &other], grove_version)
+        .expect("limited branches diverging below a shared key merge");
+    let rows = assert_proved_matches_trusted_read(&db, &merged, grove_version);
+    assert_eq!(rows, 1 + 2 + 1, "one of p1, two of p2, the other row");
+
+    let permuted = PathQuery::merge(vec![&other, &two_of_p2, &one_of_p1], grove_version)
+        .expect("the permutation merges identically");
+    assert_eq!(merged, permuted);
+}
+
+/// The descent is not a licence to blend: two limited inputs on the
+/// SAME full path meet at the descended root and are still refused,
+/// and so is a limited input whose key the merged root selects by a
+/// range.
+#[test]
+fn merge_still_refuses_limited_branches_that_never_diverge() {
+    let grove_version = GroveVersion::latest();
+
+    let one_of_p1 = PathQuery::new(
+        vec![DOCS.to_vec(), b"p1".to_vec()],
+        SizedQuery::new(Query::new_range_full(), Some(1), None),
+    );
+    let two_of_p1 = PathQuery::new(
+        vec![DOCS.to_vec(), b"p1".to_vec()],
+        SizedQuery::new(Query::new_range_full(), Some(2), None),
+    );
+    let other = PathQuery::new_unsized(
+        vec![b"other".to_vec()],
+        Query::new_single_key(b"x".to_vec()),
+    );
+    let result = PathQuery::merge(vec![&one_of_p1, &two_of_p1, &other], grove_version);
+    assert!(
+        matches!(&result, Err(Error::NotSupported(message)) if message.contains("collide")),
+        "limited branches meeting at the same leaf must be refused, got {result:?}"
+    );
+
+    // A limit-free branch and a limited one meeting at the same leaf are
+    // refused too: the limited body would have to merge with the other.
+    let every_p1 =
+        PathQuery::new_unsized(vec![DOCS.to_vec(), b"p1".to_vec()], Query::new_range_full());
+    let result = PathQuery::merge(vec![&every_p1, &two_of_p1, &other], grove_version);
+    assert!(
+        matches!(&result, Err(Error::NotSupported(message)) if message.contains("collide")),
+        "a limited body meeting a limit-free body must be refused, got {result:?}"
+    );
+
+    // The merged root selecting `docs` by a RANGE owns every key under
+    // it at once; nothing below can be told apart, so no descent.
+    let mut ranged_root = Query::new_range_full();
+    ranged_root.set_subquery(Query::new_range_full());
+    let at_root = PathQuery::new_unsized(vec![], ranged_root);
+    let result = PathQuery::merge(vec![&at_root, &two_of_p1], grove_version);
+    assert!(
+        matches!(&result, Err(Error::NotSupported(message)) if message.contains("collide")),
+        "a range-selected key cannot host a limited graft, got {result:?}"
+    );
+}


### PR DESCRIPTION
## Issue being fixed or feature implemented

`PathQuery::merge` (v1, `GROVE_V4`+) grafts a limited input exclusively at the **first key past the common path** and refuses any collision there. That refuses compositions whose inputs merely share that key and diverge right below it:

- a limited page on `post` (an index range, `[…, post, hashtag]`) merged with an unlimited by-id fetch on `post` (`[…, post, 0]`): both graft at key `post`;
- once a third input in another contract lifts the common path up to the root, a limited page and a limited lookup under the same contract graft at the contract-id key.

Budgets never blend in these shapes; the merge just stopped one level too early. Platform's composite document queries (a page plus derived joins / lookups / counts under one proof) hit both cases immediately.

### The collision, before this PR

Two inputs under contract `C`. The by-id fetch has no limit and goes through the full merge machinery first, so it owns key `post` as a conditional branch. The page carries a limit, so it may only graft on an exclusive key. Its first key past the common path is `post` again, and the merge refused it there even though the two only share that one key.

```mermaid
flowchart TD
    subgraph inputs["inputs, common path = [C]"]
        A["A  page<br/>[C, post, hashtag]<br/>limit 20"]
        B["B  by-id fetch<br/>[C, post, 0]<br/>no limit"]
    end
    R(["merged root at [C]"])
    B -- "limit-free: merged first" --> R
    R -- "key post (conditional branch)" --> P["post"]
    P -- "0" --> B2["B's body: the ids"]
    A -. "limited: needs an exclusive key,<br/>but post is already owned" .-> P
    P -. "before: NotSupported" .-> X["refused"]
    style X fill:#fdd,stroke:#c33,color:#600
```

## What was done?

A limited branch colliding on a key that an earlier graft already owns now **descends** into it (`graft_below`): both branches are rebuilt as path queries rooted at `common_path + [key]` and merged with the very same rules, so they either land on exclusive keys of their own or are refused exactly as before (a body meeting the descended root, or a key selected by a range or by the merged root's own items, where nothing below can be told apart). Lifted limits already sit on the leaf bodies as per-instance caps, so the descent lifts nothing twice, and the existing partition (limit-free grafts first, limited grafts last) keeps acceptance independent of input order.

"Owns" follows execution: a key takes the first conditional branch whose selector contains it, in insertion order. So the descent happens only when the merged root selects the key exactly, the first conditional matching it is that exact key, and no range selects it. A conditional shadowed by an earlier range, or one defined for a key the root never selects, would never run, and grafting below it would silently drop the incoming rows, so those shapes refuse instead.

### The descent

The owning branch and the incoming branch become two path queries rooted one level down, at `[C, post]`, and go through `merge_v1` again. There they diverge onto `hashtag` and `0`, so each lands on an exclusive key of its own. The merged branch replaces the one that owned `post`.

```mermaid
flowchart TD
    R(["merged root at [C]"])
    R -- "key post" --> G["graft_below<br/>= merge_v1 rooted at [C, post]"]
    G -- "hashtag (exclusive)" --> A2["A's body<br/>per-instance cap 20<br/>(the lifted limit)"]
    G -- "0 (exclusive)" --> B2["B's body<br/>the ids, no cap"]
    style G fill:#e8f4ff,stroke:#369
```

Because the descent is the same merge, it recurses on its own: if the two still collide on the next key, that key's owner descends again, until the branches diverge or a refusal rule fires.

### Where each limited input goes now

```mermaid
flowchart TD
    S["limited input<br/>(global limit or branch caps)"] --> Q1{"path == common path?<br/>(lands at the merged root)"}
    Q1 -- yes --> Q2{"global limit, or a cap<br/>on the root body itself?"}
    Q2 -- yes --> X1["refused:<br/>budget would blend at the root"]
    Q2 -- "no (caps only on its branches)" --> Q3{"other bodies at the root too?"}
    Q3 -- yes --> X2["refused:<br/>a branch cap would govern<br/>rows the other bodies select"]
    Q3 -- no --> OK1["accepted: it IS the root body,<br/>caps ride along"]
    Q1 -- no --> K["first key K past the common path"]
    K --> Q4{"root selects K exactly,<br/>the first conditional matching K<br/>is that exact key,<br/>and no range selects K?"}
    Q4 -- yes --> D["graft_below:<br/>rebuild both at common + [K],<br/>merge_v1 again"]
    D --> Q5{"branches diverge below K?"}
    Q5 -- yes --> OK2["accepted: exclusive keys<br/>one level down"]
    Q5 -- no --> X3["refused:<br/>bodies would meet"]
    Q4 -- no --> Q6{"K selected by the root,<br/>inside a range, or matched<br/>by any conditional?"}
    Q6 -- yes --> X4["refused:<br/>nothing below can be told apart"]
    Q6 -- no --> OK3["accepted: exclusive graft at K<br/>(unchanged from before)"]
    style X1 fill:#fdd,stroke:#c33,color:#600
    style X2 fill:#fdd,stroke:#c33,color:#600
    style X3 fill:#fdd,stroke:#c33,color:#600
    style X4 fill:#fdd,stroke:#c33,color:#600
    style OK1 fill:#dfd,stroke:#393,color:#040
    style OK2 fill:#dfd,stroke:#393,color:#040
    style OK3 fill:#dfd,stroke:#393,color:#040
```

The root-landing rule is the one refinement outside `graft_below`: it used to refuse any root-lander carrying any limit. A root-lander whose caps sit on its own branches is now accepted when it is the sole body at the root. That is exactly how a branch merged one level down comes back through `graft_below`: the rebuilt path query for the owning branch lands at the descended root carrying the caps its leaves already had. Once the root body carries caps, a limit-free branch also takes the exclusive-graft path rather than the full merge machinery (whose instance-limit gate would otherwise refuse it), so an unlimited sibling beside a capped root body merges.

### The multi-contract case (a composite proof)

Three inputs: a limited page under contract `C1`, a limit-free per-post count under `C1`, and a limit-free profile lookup under contract `C2`. The common path is the tree root, so `C1` is the first key for two of them. The two limit-free inputs graft first and own `C1` and `C2`; the page then descends into `C1`, where `post` and `like` diverge.

```mermaid
flowchart TD
    R(["merged root"])
    R -- "C1" --> C1["graft_below at [C1]"]
    R -- "C2" --> C2["C2"]
    C1 -- "post" --> P["post"]
    P -- "hashtag" --> PH["page body<br/>cap 20"]
    C1 -- "like" --> L["like"]
    L -- "byPost" --> LC["count trees<br/>no cap"]
    C2 -- "profile" --> PR["profile"]
    PR -- "owner" --> PO["profile body<br/>no cap"]
    style C1 fill:#e8f4ff,stroke:#369
```

### Still refused

Same shapes, same answers as before, now reached one level down:

- two limited bodies that never diverge (both end at the same leaf: the descended merge finds two root-landers with caps);
- a limited body meeting a limit-free one at the same leaf (a cap would govern rows the other body selects);
- a key selected by a range rather than an exact key (rows under it cannot be attributed to one branch);
- a key whose first matching conditional is an earlier range (the exact-key branch is shadowed and never runs);
- a key the root defines a conditional for but never selects (a dormant branch; descending would drop the incoming rows, selecting it would add rows the root never asked for).

No wire or version change: the merge slot is unchanged, the verifier re-runs the same merge, and every previously accepted merge produces the identical query.

## How Has This Been Tested?

New tests in `per_instance_limit_tests`:

- `merge_grafts_a_limited_branch_below_a_key_a_limit_free_branch_owns`: proves, verifies and matches the trusted read; input-order independent
- `merge_grafts_two_limited_branches_that_diverge_below_a_shared_key`: same, with both branches limited
- `merge_still_refuses_limited_branches_that_never_diverge`: two limited bodies at one leaf, a limited body meeting a limit-free one, and a range-selected key all still refuse
- `merge_refuses_a_limited_graft_shadowed_by_a_range_conditional` and `merge_refuses_a_limited_graft_into_an_unselected_conditional`: the two ownership refusals above, both input orders
- `merge_grafts_below_an_exact_conditional_before_a_matching_range`: an exact conditional ahead of a matching range does own the key; proves and verifies
- `merge_grafts_an_unlimited_sibling_beside_a_root_branch_cap`: both directions, conditional and default subquery; proves and verifies
- `merge_nested_limited_grafts_is_independent_of_all_input_permutations`: a two-level shared prefix plus an unrelated root tree, every input permutation; identical merged query, identical read to the concatenated trusted reads, proves and verifies

Existing merge / per-instance-limit / merge-versioning suites unchanged and green; `cargo clippy -p grovedb --all-features -- -D warnings` clean; verify-only build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Query merging now supports limited branches that share an exact key but diverge beneath it.
  - Each limited branch preserves its own result limit during merging.
  - Merging remains rejected when branches do not diverge or when the shared key is selected by a range.

- **Tests**
  - Added coverage for compatible limited-branch merges and cases that must continue to be rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
