### PR TITLE
fix: synthesized split bodies walk in the merged branches' direction

### DIFF
--- a/grovedb-query/src/merge.rs
+++ b/grovedb-query/src/merge.rs
@@ -6,6 +6,21 @@ use crate::{
 };
 
 impl SubqueryBranch {
+    /// The walk direction two branch bodies agree on: the direction of
+    /// whichever bodies exist when they agree, ascending when neither
+    /// exists or they disagree (the merge's direction rule only governs
+    /// the inputs' roots, so a disagreement below them stays as authored).
+    fn shared_direction(ours: Option<&Query>, theirs: Option<&Query>) -> bool {
+        match (ours, theirs) {
+            (Some(ours), Some(theirs)) if ours.left_to_right == theirs.left_to_right => {
+                ours.left_to_right
+            }
+            (Some(ours), None) => ours.left_to_right,
+            (None, Some(theirs)) => theirs.left_to_right,
+            _ => true,
+        }
+    }
+
     fn merge_subquery(
         &self,
         other_default_branch_subquery: Option<Box<Query>>,
@@ -124,8 +139,15 @@ impl SubqueryBranch {
                         // conditional subquery for each key
 
                         // We need to create a new subquery that will hold the conditional
-                        // subqueries
-                        let mut merged_query = Query::new();
+                        // subqueries. It walks in the direction the two bodies share:
+                        // a merge that later descends into this branch (see
+                        // grovedb's `graft_below`) rebuilds it as an input and checks
+                        // its direction against the others', so a default here would
+                        // refuse descending compositions their ascending twins accept.
+                        let mut merged_query = Query::new_with_direction(Self::shared_direction(
+                            self.subquery.as_deref(),
+                            other.subquery.as_deref(),
+                        ));
 
                         // The key is also removed from the path as it is no needed in the subquery
                         let left_top_key = left_path_leftovers.remove(0);

--- a/grovedb/src/tests/per_instance_limit_tests.rs
+++ b/grovedb/src/tests/per_instance_limit_tests.rs
@@ -1847,3 +1847,55 @@ fn merge_nested_limited_grafts_is_independent_of_all_input_permutations() {
         );
     }
 }
+
+#[test]
+fn merge_descends_into_a_synthesized_split_in_either_direction() {
+    // Two limit-free branches that diverge below `p1` make the merge
+    // synthesize the body at `docs/p1`; a limited branch on `p2` then
+    // collides at `docs` and descends into that branch. The synthesized
+    // body must walk in the inputs' direction, or the descent refuses the
+    // descending composition while accepting its ascending twin.
+    let grove_version = GroveVersion::latest();
+    let db = make_test_grovedb(grove_version);
+    populate_nested_parents(&db, grove_version);
+
+    for left_to_right in [true, false] {
+        let mut full = Query::new_range_full();
+        full.left_to_right = left_to_right;
+        let unlimited = |path: &[&[u8]]| {
+            PathQuery::new_unsized(path.iter().map(|key| key.to_vec()).collect(), full.clone())
+        };
+        let a = unlimited(&[DOCS, b"p1", b"a"]);
+        let b = unlimited(&[DOCS, b"p1", b"b"]);
+        let other = unlimited(&[b"other"]);
+        let p2 = PathQuery::new(
+            vec![DOCS.to_vec(), b"p2".to_vec()],
+            SizedQuery::new(full.clone(), Some(1), None),
+        );
+
+        // The merged query walks keys in order, so the trusted reads of
+        // the inputs concatenated in walk order are what it must return.
+        let walk_order: [&PathQuery; 4] = if left_to_right {
+            [&a, &b, &p2, &other]
+        } else {
+            [&other, &p2, &b, &a]
+        };
+        let mut expected = Vec::new();
+        for input in walk_order {
+            expected.extend(run(&db, input, grove_version).0);
+        }
+        assert_eq!(
+            expected.len(),
+            7,
+            "two rows under a and b, one under p2, two under other"
+        );
+
+        let merged = PathQuery::merge(vec![&a, &b, &other, &p2], grove_version)
+            .unwrap_or_else(|e| panic!("left_to_right={left_to_right}: {e}"));
+        assert_eq!(run(&db, &merged, grove_version).0, expected);
+        assert_eq!(
+            assert_proved_matches_trusted_read(&db, &merged, grove_version),
+            expected.len(),
+        );
+    }
+}


### PR DESCRIPTION
## Issue being fixed or feature implemented

When two conditional branches diverge below a shared key, `SubqueryBranch::merge` synthesizes the query body at the split with `Query::new()`, which walks ascending whatever the bodies it joins do. Since #850 that body can become a merge input of its own: a limited branch colliding at the key above it descends (`graft_below`), the owning branch is rebuilt as a path query, and the direction rule compares the synthesized ascending body against the incoming descending one and refuses:

```
can not merge limited path queries whose branches collide at key docs and do not diverge below it:
can not merge path queries with conflicting directions (left_to_right differs)
```

The identical composition with ascending inputs merges fine, so acceptance depended on nothing but the inputs' direction. Platform hit it with a descending feed page (`$createdAt desc`) plus a cross-contract lookup (which lifts the common path to the root) plus a limited lookup under the page's own contract.

```mermaid
flowchart TD
    subgraph inputs["inputs, all descending, common path = root"]
        A["A  [docs, p1, a]<br/>limit-free"]
        B["B  [docs, p1, b]<br/>limit-free"]
        O["other  [other]<br/>limit-free"]
        C["C  [docs, p2]<br/>limit 1"]
    end
    R(["merged root<br/>direction: desc"])
    R -- "other" --> OB["other's body"]
    R -- "docs" --> S["synthesized split at [docs, p1]<br/>before: ascending<br/>after: desc (the bodies' direction)"]
    S -- "a" --> AB["A's body, desc"]
    S -- "b" --> BB["B's body, desc"]
    C -. "collides at docs, descends:<br/>rebuilt split vs C<br/>before: conflicting directions, refused<br/>after: exclusive graft at p2" .-> S
    style S fill:#e8f4ff,stroke:#369
```

## What was done?

The synthesized body takes the direction the two joined bodies share: the direction of whichever exists when only one does, and ascending only when neither exists or they disagree (which the root-level direction rule never allows for authored inputs). One helper, one call site. No wire or version change; every previously accepted merge produces the same query except for this direction bit on synthesized split bodies, which the verifier re-derives identically.

## How Has This Been Tested?

`merge_descends_into_a_synthesized_split_in_either_direction` in `per_instance_limit_tests`: two limit-free branches diverging below `docs/p1`, a limited branch on `docs/p2`, an unrelated root tree, in both directions. The merged read equals the inputs' trusted reads concatenated in walk order (7 rows) and the proof verifies to the same rows. On develop the descending case fails with the error above.

Merge, per-instance-limit and grovedb-query suites green; `cargo clippy -p grovedb-query -p grovedb --all-features -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved merged query behavior when subqueries use different traversal directions.
  * Preserved compatible traversal directions during conditional query merges.
  * Ensured merged queries correctly descend into synthesized split paths in either traversal direction.

* **Tests**
  * Added coverage validating merged results, proofs, and verification for both ascending and descending traversal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->