### PR TITLE
fix: descending limited append-layer reads keep the highest positions (#855)

### DIFF
--- a/grovedb-bulk-append-tree/src/proof/mod.rs
+++ b/grovedb-bulk-append-tree/src/proof/mod.rs
@@ -539,6 +539,15 @@ impl BulkAppendTreeProof {
     /// Returns matched `(global_position, value)` pairs collected into `C`.
     /// `C` can be `Vec<(u64, Vec<u8>)>`, `BTreeMap<u64, Vec<u8>>`,
     /// `HashMap<u64, Vec<u8>>`, or any `FromIterator<(u64, Vec<u8>)>`.
+    ///
+    /// The pairs are yielded in the query's direction — ascending
+    /// positions for `left_to_right`, descending otherwise — and
+    /// `query.limit` (when set) caps the yield to the FIRST `limit`
+    /// pairs of that ordering. So a descending limited query returns the
+    /// highest matched positions, exactly as the GroveDB verifier and a
+    /// direct tree read would. Completeness is still checked against the
+    /// full query ranges before the cap applies: the proof must carry
+    /// every matched position, not merely the window it yields.
     pub fn verify_against_query<C>(
         &self,
         expected_state_root: &[u8; 32],
@@ -635,7 +644,16 @@ impl BulkAppendTreeProof {
             }
         }
 
+        // Order by the trusted query direction BEFORE applying the
+        // cap, so a descending limit keeps the highest positions rather
+        // than truncating the ascending order to its lowest ones.
         values.sort_by_key(|(pos, _)| *pos);
+        if !query.left_to_right {
+            values.reverse();
+        }
+        if let Some(limit) = query.limit {
+            values.truncate(limit as usize);
+        }
         Ok(values.into_iter().collect())
     }
 

--- a/grovedb-bulk-append-tree/src/proof/tests.rs
+++ b/grovedb-bulk-append-tree/src/proof/tests.rs
@@ -34,7 +34,7 @@ mod proof_tests {
 
     /// Helper: build a range query [start..end).
     fn range_query(start: u64, end: u64) -> Query {
-        let mut q = Query::default();
+        let mut q = Query::new();
         q.items
             .push(QueryItem::Range(pos_bytes(start)..pos_bytes(end)));
         q
@@ -42,7 +42,7 @@ mod proof_tests {
 
     /// Helper: build a full-range query.
     fn full_range_query() -> Query {
-        let mut q = Query::default();
+        let mut q = Query::new();
         q.items.push(QueryItem::RangeFull(..));
         q
     }
@@ -215,7 +215,7 @@ mod proof_tests {
         let query = full_range_query();
         let proof = BulkAppendTreeProof::generate(&query, &tree).expect("generate proof");
 
-        let mut verify_query = Query::default();
+        let mut verify_query = Query::new();
         verify_query.items.push(QueryItem::Key(pos_bytes(1)));
         verify_query.items.push(QueryItem::Key(pos_bytes(5)));
         verify_query.items.push(QueryItem::Key(pos_bytes(8)));
@@ -230,6 +230,124 @@ mod proof_tests {
     }
 
     #[test]
+    fn test_verify_against_query_descending_yields_highest_positions_first() {
+        // height=2, chunk size 4. 10 values -> 2 completed chunks + 2 buffer.
+        // A descending query must yield the SAME set as its ascending
+        // twin, in reverse order — positions from both chunk blobs and
+        // the dense buffer interleave correctly.
+        let height = 2u8;
+        let values: Vec<Vec<u8>> = (0..10u32)
+            .map(|i| format!("v_{}", i).into_bytes())
+            .collect();
+        let (state_root, tree) = build_test_tree(height, &values);
+        let total_count = tree.total_count;
+
+        let mut asc = range_query(2, 9);
+        asc.left_to_right = true;
+        let mut desc = range_query(2, 9);
+        desc.left_to_right = false;
+
+        let proof = BulkAppendTreeProof::generate(&desc, &tree).expect("generate proof");
+
+        let asc_vals: Vec<(u64, Vec<u8>)> = proof
+            .verify_against_query(&state_root, height, total_count, &asc)
+            .expect("verify ascending");
+        let desc_vals: Vec<(u64, Vec<u8>)> = proof
+            .verify_against_query(&state_root, height, total_count, &desc)
+            .expect("verify descending");
+
+        let asc_positions: Vec<u64> = asc_vals.iter().map(|(p, _)| *p).collect();
+        let desc_positions: Vec<u64> = desc_vals.iter().map(|(p, _)| *p).collect();
+        assert_eq!(asc_positions, (2..9).collect::<Vec<u64>>());
+        assert_eq!(desc_positions, (2..9).rev().collect::<Vec<u64>>());
+        for (p, v) in &desc_vals {
+            assert_eq!(v, &format!("v_{}", p).into_bytes());
+        }
+    }
+
+    #[test]
+    fn test_verify_against_query_limit_applies_after_direction() {
+        // The cap keeps the FIRST `limit` rows of the directed order: the
+        // lowest positions ascending, the HIGHEST positions descending.
+        // Before this was applied the descending limited read handed back
+        // the opposite end of the range (issue #855).
+        let height = 2u8;
+        let values: Vec<Vec<u8>> = (0..10u32)
+            .map(|i| format!("v_{}", i).into_bytes())
+            .collect();
+        let (state_root, tree) = build_test_tree(height, &values);
+        let total_count = tree.total_count;
+
+        let proof =
+            BulkAppendTreeProof::generate(&full_range_query(), &tree).expect("generate proof");
+
+        let mut asc = full_range_query();
+        asc.left_to_right = true;
+        asc.limit = Some(3);
+        let asc_vals: Vec<(u64, Vec<u8>)> = proof
+            .verify_against_query(&state_root, height, total_count, &asc)
+            .expect("verify ascending limited");
+        assert_eq!(
+            asc_vals.iter().map(|(p, _)| *p).collect::<Vec<u64>>(),
+            vec![0, 1, 2]
+        );
+
+        let mut desc = full_range_query();
+        desc.left_to_right = false;
+        desc.limit = Some(3);
+        let desc_vals: Vec<(u64, Vec<u8>)> = proof
+            .verify_against_query(&state_root, height, total_count, &desc)
+            .expect("verify descending limited");
+        assert_eq!(
+            desc_vals.iter().map(|(p, _)| *p).collect::<Vec<u64>>(),
+            vec![9, 8, 7],
+            "descending limit must keep the highest positions"
+        );
+        assert_eq!(desc_vals[0].1, b"v_9".to_vec());
+
+        // A limit wider than the match set is a no-op.
+        let mut wide = full_range_query();
+        wide.left_to_right = false;
+        wide.limit = Some(50);
+        let wide_vals: Vec<(u64, Vec<u8>)> = proof
+            .verify_against_query(&state_root, height, total_count, &wide)
+            .expect("verify wide limit");
+        assert_eq!(wide_vals.len(), 10);
+        assert_eq!(wide_vals[0].0, 9);
+        assert_eq!(wide_vals[9].0, 0);
+    }
+
+    #[test]
+    fn test_verify_against_query_limit_does_not_relax_completeness() {
+        // The cap only trims what is YIELDED; the proof must still carry
+        // every matched position. A proof generated for a narrower query
+        // than the one verified against is rejected even when the limit
+        // would have hidden the missing tail.
+        let height = 2u8;
+        let values: Vec<Vec<u8>> = (0..10u32)
+            .map(|i| format!("v_{}", i).into_bytes())
+            .collect();
+        let (state_root, tree) = build_test_tree(height, &values);
+        let total_count = tree.total_count;
+
+        // Proves only chunk 0 (positions 0..4).
+        let narrow_proof =
+            BulkAppendTreeProof::generate(&range_query(0, 4), &tree).expect("generate proof");
+
+        // Ascending limit 2 over the full range would yield positions 0
+        // and 1 — both present — but chunk 1 and the buffer are missing.
+        let mut asc = full_range_query();
+        asc.limit = Some(2);
+        let err = narrow_proof
+            .verify_against_query::<Vec<(u64, Vec<u8>)>>(&state_root, height, total_count, &asc)
+            .expect_err("limit must not hide missing positions");
+        assert!(
+            matches!(err, BulkAppendError::InvalidProof(_)),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[test]
     fn test_verify_against_query_empty_result() {
         // Query beyond total_count — positions clamped, returns empty
         let height = 2u8;
@@ -240,7 +358,7 @@ mod proof_tests {
         let query = range_query(0, 1);
         let proof = BulkAppendTreeProof::generate(&query, &tree).expect("generate proof");
 
-        let mut far_query = Query::default();
+        let mut far_query = Query::new();
         far_query.items.push(QueryItem::Key(pos_bytes(100)));
 
         let vals: Vec<(u64, Vec<u8>)> = proof
@@ -317,7 +435,7 @@ mod proof_tests {
         // BulkAppendTree has no count commitment in its node hash, so the
         // index-resolution helper must reject AggregateCountOnRange
         // outright rather than silently fall through.
-        let mut query = Query::default();
+        let mut query = Query::new();
         query.items.push(QueryItem::AggregateCountOnRange(Box::new(
             QueryItem::Range(pos_bytes(0)..pos_bytes(5)),
         )));
@@ -336,7 +454,7 @@ mod proof_tests {
     fn test_query_to_ranges_rejects_aggregate_sum_on_range() {
         // Same rationale as count: BulkAppendTree has no sum commitment
         // either, so AggregateSumOnRange is rejected at index resolution.
-        let mut query = Query::default();
+        let mut query = Query::new();
         query
             .items
             .push(QueryItem::AggregateSumOnRange(Box::new(QueryItem::Range(
@@ -355,7 +473,7 @@ mod proof_tests {
 
     #[test]
     fn test_query_to_ranges_merges_clamps_and_filters() {
-        let mut query = Query::default();
+        let mut query = Query::new();
         query
             .items
             .push(QueryItem::Range(pos_bytes(2)..pos_bytes(5))); // [2,5)
@@ -396,7 +514,7 @@ mod proof_tests {
         let values: Vec<Vec<u8>> = (0..5u32).map(|i| format!("z_{}", i).into_bytes()).collect();
         let (state_root, tree) = build_test_tree(height, &values);
 
-        let mut query = Query::default();
+        let mut query = Query::new();
         query.items.push(QueryItem::Key(pos_bytes(4))); // only buffer position
         let proof = BulkAppendTreeProof::generate(&query, &tree).expect("generate proof");
 
@@ -514,7 +632,7 @@ mod proof_tests {
         let (state_root, tree) = build_test_tree(height, &values);
 
         // Proof includes only global position 4 (buffer local pos 0).
-        let mut single = Query::default();
+        let mut single = Query::new();
         single.items.push(QueryItem::Key(pos_bytes(4)));
         let proof = BulkAppendTreeProof::generate(&single, &tree).expect("generate proof");
 
@@ -535,7 +653,7 @@ mod proof_tests {
         let values: Vec<Vec<u8>> = vec![b"a".to_vec()];
         let (_state_root, tree) = build_test_tree(height, &values);
 
-        let mut query = Query::default();
+        let mut query = Query::new();
         query.items.push(QueryItem::Key(Vec::new())); // invalid: length must be 1..=8
 
         let err =
@@ -745,7 +863,7 @@ mod proof_tests {
         let (state_root, tree) = build_test_tree(height, &values);
         let total_count = tree.total_count;
 
-        let mut query = Query::default();
+        let mut query = Query::new();
         query
             .items
             .push(QueryItem::RangeInclusive(pos_bytes(2)..=pos_bytes(6)));
@@ -775,7 +893,7 @@ mod proof_tests {
         let (state_root, tree) = build_test_tree(height, &values);
         let total_count = tree.total_count;
 
-        let mut query = Query::default();
+        let mut query = Query::new();
         query.items.push(QueryItem::RangeFrom(pos_bytes(6)..));
 
         let proof = BulkAppendTreeProof::generate(&query, &tree).expect("generate proof");
@@ -803,7 +921,7 @@ mod proof_tests {
 
         // RangeAfter (5..), positions > 5 -> 6,7,8
         {
-            let mut query = Query::default();
+            let mut query = Query::new();
             query.items.push(QueryItem::RangeAfter(pos_bytes(5)..));
 
             let proof = BulkAppendTreeProof::generate(&query, &tree).expect("generate proof");
@@ -817,7 +935,7 @@ mod proof_tests {
 
         // RangeToInclusive (..=2), positions 0,1,2
         {
-            let mut query = Query::default();
+            let mut query = Query::new();
             query
                 .items
                 .push(QueryItem::RangeToInclusive(..=pos_bytes(2)));
@@ -834,7 +952,7 @@ mod proof_tests {
 
         // RangeAfterToInclusive (3..=6], positions 4,5,6
         {
-            let mut query = Query::default();
+            let mut query = Query::new();
             query.items.push(QueryItem::RangeAfterToInclusive(
                 pos_bytes(3)..=pos_bytes(6),
             ));
@@ -858,7 +976,7 @@ mod proof_tests {
 
         // RangeInclusive: s >= e after clamping (line 76)
         {
-            let mut q = Query::default();
+            let mut q = Query::new();
             q.items
                 .push(QueryItem::RangeInclusive(pos_bytes(10)..=pos_bytes(12)));
             let ranges =
@@ -871,7 +989,7 @@ mod proof_tests {
 
         // RangeFrom: s >= total_count (line 89)
         {
-            let mut q = Query::default();
+            let mut q = Query::new();
             q.items.push(QueryItem::RangeFrom(pos_bytes(5)..));
             let ranges = super::super::query_to_ranges(&q, total_count).expect("RangeFrom oob");
             assert!(
@@ -882,7 +1000,7 @@ mod proof_tests {
 
         // RangeTo: e == 0 (line 96)
         {
-            let mut q = Query::default();
+            let mut q = Query::new();
             q.items.push(QueryItem::RangeTo(..pos_bytes(0)));
             let ranges = super::super::query_to_ranges(&q, total_count).expect("RangeTo e=0");
             assert!(
@@ -896,7 +1014,7 @@ mod proof_tests {
         // but min(total_count) gives 1 which is > 0, so we can't hit e==0 this
         // way unless total_count is 0. Use total_count=0 for this variant.
         {
-            let mut q = Query::default();
+            let mut q = Query::new();
             q.items.push(QueryItem::RangeToInclusive(..=pos_bytes(5)));
             let ranges = super::super::query_to_ranges(&q, 0).expect("RangeToInclusive empty tree");
             assert!(
@@ -907,7 +1025,7 @@ mod proof_tests {
 
         // RangeAfter: s >= total_count (line 112)
         {
-            let mut q = Query::default();
+            let mut q = Query::new();
             q.items.push(QueryItem::RangeAfter(pos_bytes(4)..));
             let ranges = super::super::query_to_ranges(&q, total_count).expect("RangeAfter oob");
             assert!(
@@ -918,7 +1036,7 @@ mod proof_tests {
 
         // RangeAfterTo: s >= e (line 120)
         {
-            let mut q = Query::default();
+            let mut q = Query::new();
             q.items
                 .push(QueryItem::RangeAfterTo(pos_bytes(5)..pos_bytes(3)));
             let ranges =
@@ -931,7 +1049,7 @@ mod proof_tests {
 
         // RangeAfterToInclusive: s >= e (line 130)
         {
-            let mut q = Query::default();
+            let mut q = Query::new();
             q.items.push(QueryItem::RangeAfterToInclusive(
                 pos_bytes(10)..=pos_bytes(8),
             ));

--- a/grovedb/src/tests/append_layer_direction_tests.rs
+++ b/grovedb/src/tests/append_layer_direction_tests.rs
@@ -1,0 +1,395 @@
+//! Runtime validation for issue #855: a descending, limited read of a
+//! BulkAppendTree / CommitmentTree layer must hand back the SAME window
+//! from the direct read, the generated proof, and the verified result.
+//!
+//! The append-only layers store rows by position, and their proof
+//! extraction sorts positions ascending. The verifier orders the rows by
+//! the query's trusted direction BEFORE consuming the shared limit, so a
+//! descending cap keeps the highest positions (the last appended rows)
+//! rather than truncating the ascending order to its lowest ones. These
+//! tests pin that across chunk blobs and the dense buffer, for both
+//! `SizedQuery::limit` (global) and `Query::limit` (per-instance), and
+//! compare every window against the canonical direct range read.
+
+use grovedb_version::version::GroveVersion;
+
+use crate::{
+    query_result_type::QueryResultType,
+    tests::{common::EMPTY_PATH, make_test_grovedb, TempGroveDb},
+    Element, GroveDb, PathQuery, Query, SizedQuery,
+};
+
+/// Chunk size 4: ten entries span two completed chunks plus a two-entry
+/// dense buffer, so a window can straddle both storage regions.
+const CHUNK_POWER: u8 = 2;
+const ENTRY_COUNT: u64 = 10;
+const BULK_KEY: &[u8] = b"bulk";
+const CT_KEY: &[u8] = b"ct";
+
+#[derive(Clone, Copy)]
+enum Layer {
+    Bulk,
+    Commitment,
+}
+
+impl Layer {
+    fn key(self) -> &'static [u8] {
+        match self {
+            Layer::Bulk => BULK_KEY,
+            Layer::Commitment => CT_KEY,
+        }
+    }
+
+    fn name(self) -> &'static str {
+        match self {
+            Layer::Bulk => "bulk",
+            Layer::Commitment => "commitment",
+        }
+    }
+}
+
+fn pos_key(position: u64) -> Vec<u8> {
+    position.to_be_bytes().to_vec()
+}
+
+fn make_db(layer: Layer, grove_version: &GroveVersion) -> TempGroveDb {
+    let db = make_test_grovedb(grove_version);
+    match layer {
+        Layer::Bulk => {
+            db.insert(
+                EMPTY_PATH,
+                BULK_KEY,
+                Element::empty_bulk_append_tree(CHUNK_POWER).expect("valid chunk power"),
+                None,
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("insert bulk tree");
+            for i in 0..ENTRY_COUNT {
+                db.bulk_append(
+                    EMPTY_PATH,
+                    BULK_KEY,
+                    format!("bulk_{i}").into_bytes(),
+                    None,
+                    grove_version,
+                )
+                .unwrap()
+                .expect("bulk append");
+            }
+        }
+        Layer::Commitment => {
+            db.insert(
+                EMPTY_PATH,
+                CT_KEY,
+                Element::empty_commitment_tree(CHUNK_POWER).expect("valid chunk power"),
+                None,
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("insert commitment tree");
+            for i in 0..ENTRY_COUNT {
+                let i = i as u8;
+                let mut cmx = [0u8; 32];
+                cmx[0] = i;
+                let mut rho = [0u8; 32];
+                rho[0] = i;
+                rho[1] = 0xB0;
+                let mut cv_net = [0u8; 32];
+                cv_net[0] = i;
+                cv_net[1] = 0xCC;
+                let mut enc_data = [0u8; 104];
+                enc_data[0] = i;
+                let mut epk = [0u8; 32];
+                epk[0] = i;
+                let mut out_ct = [0u8; 80];
+                out_ct[0] = i;
+                let ciphertext = grovedb_commitment_tree::TransmittedNoteCiphertext::<
+                    grovedb_commitment_tree::DashMemo,
+                >::from_parts(
+                    epk,
+                    grovedb_commitment_tree::NoteBytesData(enc_data),
+                    out_ct,
+                );
+                db.commitment_tree_insert(
+                    EMPTY_PATH,
+                    CT_KEY,
+                    cmx,
+                    rho,
+                    cv_net,
+                    ciphertext,
+                    None,
+                    grove_version,
+                )
+                .unwrap()
+                .expect("commitment tree insert");
+            }
+        }
+    }
+    db
+}
+
+/// The canonical direct read: every `(position, value)` of the layer,
+/// ascending, straight from storage.
+fn direct_all(db: &TempGroveDb, layer: Layer, grove_version: &GroveVersion) -> Vec<(u64, Vec<u8>)> {
+    let page = match layer {
+        Layer::Bulk => db
+            .bulk_get_range(EMPTY_PATH, BULK_KEY, 0, u16::MAX, None, grove_version)
+            .unwrap()
+            .expect("bulk range read"),
+        Layer::Commitment => db
+            .commitment_tree_get_range(EMPTY_PATH, CT_KEY, 0, u16::MAX, None, grove_version)
+            .unwrap()
+            .expect("commitment tree range read"),
+    };
+    assert_eq!(page.total_count, ENTRY_COUNT);
+    assert_eq!(page.entries.len() as u64, ENTRY_COUNT);
+    page.entries
+}
+
+/// Which side of a query carries the cap.
+#[derive(Clone, Copy, Debug)]
+enum Cap {
+    /// `SizedQuery::limit` on the whole path query.
+    Global(u16),
+    /// `Query::limit` on the layer's own subquery (per-instance).
+    Instance(u16),
+}
+
+/// Builds `root[key] -> inner` where `inner` selects `[start, end)` of
+/// the layer in `left_to_right` order under `cap`.
+fn window_query(layer: Layer, start: u64, end: u64, left_to_right: bool, cap: Cap) -> PathQuery {
+    let mut inner = Query::new_with_direction(left_to_right);
+    inner.insert_range(pos_key(start)..pos_key(end));
+    let mut global = None;
+    match cap {
+        Cap::Global(limit) => global = Some(limit),
+        Cap::Instance(limit) => inner.limit = Some(limit),
+    }
+    let mut root = Query::new_single_key(layer.key().to_vec());
+    root.set_subquery(inner);
+    PathQuery::new(vec![], SizedQuery::new(root, global, None))
+}
+
+/// What a correct read of `[start, end)` in `left_to_right` order capped
+/// at `limit` rows must return, derived from the direct read alone.
+fn expected_window(
+    all: &[(u64, Vec<u8>)],
+    start: u64,
+    end: u64,
+    left_to_right: bool,
+    limit: u16,
+) -> Vec<(u64, Vec<u8>)> {
+    let mut rows: Vec<(u64, Vec<u8>)> = all
+        .iter()
+        .filter(|(p, _)| *p >= start && *p < end)
+        .cloned()
+        .collect();
+    if !left_to_right {
+        rows.reverse();
+    }
+    rows.truncate(limit as usize);
+    rows
+}
+
+/// Proves `path_query`, verifies it against the live root, and returns
+/// the verified rows as `(position, value)` in result order.
+fn proved_window(
+    db: &TempGroveDb,
+    path_query: &PathQuery,
+    grove_version: &GroveVersion,
+) -> Vec<(u64, Vec<u8>)> {
+    let proof = db
+        .prove_query(path_query, None, grove_version)
+        .unwrap()
+        .expect("prove");
+    let (root_hash, result_set) =
+        GroveDb::verify_query(&proof, path_query, grove_version).expect("verify");
+    assert_eq!(
+        root_hash,
+        db.root_hash(None, grove_version).unwrap().unwrap(),
+        "verified root must be the database root"
+    );
+    result_set
+        .into_iter()
+        .map(|(path, key, element)| {
+            assert_eq!(path.len(), 1, "rows live one level below the root");
+            let position = u64::from_be_bytes(key.as_slice().try_into().expect("8-byte position"));
+            let value = match element.expect("every row carries its element") {
+                Element::Item(bytes, _) => bytes,
+                other => panic!("append-layer rows are items, got {other:?}"),
+            };
+            (position, value)
+        })
+        .collect()
+}
+
+/// The trusted (non-proof) read of the same path query.
+fn trusted_window(
+    db: &TempGroveDb,
+    path_query: &PathQuery,
+    grove_version: &GroveVersion,
+) -> Result<Vec<(u64, Vec<u8>)>, crate::Error> {
+    let (elements, _) = db
+        .query_raw(
+            path_query,
+            true,
+            true,
+            true,
+            QueryResultType::QueryPathKeyElementTrioResultType,
+            None,
+            grove_version,
+        )
+        .unwrap()?;
+    Ok(elements
+        .to_path_key_elements()
+        .into_iter()
+        .map(|(_, key, element)| {
+            let position = u64::from_be_bytes(key.as_slice().try_into().expect("8-byte position"));
+            let value = match element {
+                Element::Item(bytes, _) => bytes,
+                other => panic!("append-layer rows are items, got {other:?}"),
+            };
+            (position, value)
+        })
+        .collect())
+}
+
+/// Windows that straddle the storage regions: the full tree, a span
+/// crossing both chunk boundaries, the second chunk into the buffer, and
+/// a chunk-interior span.
+const WINDOWS: [(u64, u64); 4] = [(0, ENTRY_COUNT), (2, 9), (5, ENTRY_COUNT), (1, 3)];
+
+fn check_layer(layer: Layer) {
+    let grove_version = GroveVersion::latest();
+    let db = make_db(layer, grove_version);
+    let all = direct_all(&db, layer, grove_version);
+    for (position, value) in &all {
+        assert!(
+            !value.is_empty(),
+            "{}: position {position} has a value",
+            layer.name()
+        );
+    }
+
+    for (start, end) in WINDOWS {
+        for left_to_right in [true, false] {
+            for limit in [1u16, 3, 200] {
+                for cap in [Cap::Global(limit), Cap::Instance(limit)] {
+                    let path_query = window_query(layer, start, end, left_to_right, cap);
+                    let expected = expected_window(&all, start, end, left_to_right, limit);
+                    let proved = proved_window(&db, &path_query, grove_version);
+                    let context = format!(
+                        "{} [{start}, {end}) left_to_right={left_to_right} {cap:?}",
+                        layer.name()
+                    );
+                    assert_eq!(
+                        proved, expected,
+                        "{context}: verified proof rows must be the direct read's window"
+                    );
+
+                    // The proof must carry the whole selected span, not
+                    // only the yielded window: verifying the SAME proof
+                    // against the uncapped query in either direction
+                    // still succeeds and returns every selected row.
+                    let proof = db
+                        .prove_query(&path_query, None, grove_version)
+                        .unwrap()
+                        .expect("prove");
+                    for uncapped_dir in [true, false] {
+                        let uncapped =
+                            window_query(layer, start, end, uncapped_dir, Cap::Global(u16::MAX));
+                        let (_, rows) = GroveDb::verify_query(&proof, &uncapped, grove_version)
+                            .unwrap_or_else(|e| panic!("{context}: uncapped verify failed: {e}"));
+                        assert_eq!(
+                            rows.len() as u64,
+                            end - start,
+                            "{context}: the proof carries the whole selected span"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn bulk_descending_limited_proofs_return_the_direct_reads_window() {
+    check_layer(Layer::Bulk);
+}
+
+#[test]
+fn commitment_descending_limited_proofs_return_the_direct_reads_window() {
+    check_layer(Layer::Commitment);
+}
+
+#[test]
+fn descending_window_is_the_reverse_of_its_ascending_twin() {
+    // A descending capped read is the LAST rows of the ascending
+    // uncapped read, reversed — never a prefix of it.
+    let grove_version = GroveVersion::latest();
+    for layer in [Layer::Bulk, Layer::Commitment] {
+        let db = make_db(layer, grove_version);
+        let asc = proved_window(
+            &db,
+            &window_query(layer, 0, ENTRY_COUNT, true, Cap::Global(u16::MAX)),
+            grove_version,
+        );
+        assert_eq!(asc.len() as u64, ENTRY_COUNT);
+        for limit in [1u16, 4, 7] {
+            for cap in [Cap::Global(limit), Cap::Instance(limit)] {
+                let desc = proved_window(
+                    &db,
+                    &window_query(layer, 0, ENTRY_COUNT, false, cap),
+                    grove_version,
+                );
+                let tail: Vec<(u64, Vec<u8>)> =
+                    asc.iter().rev().take(limit as usize).cloned().collect();
+                assert_eq!(
+                    desc,
+                    tail,
+                    "{} {cap:?}: descending cap keeps the highest positions",
+                    layer.name()
+                );
+                assert_ne!(
+                    desc.first().map(|(p, _)| *p),
+                    Some(0),
+                    "{} {cap:?}: a descending cap must not start at position 0",
+                    layer.name()
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn trusted_reads_of_append_layers_never_disagree_with_verified_proofs() {
+    // The trusted read engine (`query_raw`) does not descend into the
+    // append-only layers: their position rows are served by the
+    // dedicated range reads (`bulk_get_range` /
+    // `commitment_tree_get_range`, compared above) and by proofs. What
+    // must hold is that the trusted engine never hands back a
+    // DIFFERENT window from the verified proof — it may refuse the
+    // shape or yield nothing, but it must not serve the opposite end
+    // of the range in either direction under either cap kind.
+    let grove_version = GroveVersion::latest();
+    for layer in [Layer::Bulk, Layer::Commitment] {
+        let db = make_db(layer, grove_version);
+        for left_to_right in [true, false] {
+            for cap in [Cap::Global(3), Cap::Instance(3)] {
+                let path_query = window_query(layer, 0, ENTRY_COUNT, left_to_right, cap);
+                let proved = proved_window(&db, &path_query, grove_version);
+                assert_eq!(proved.len(), 3);
+                if let Ok(trusted) = trusted_window(&db, &path_query, grove_version) {
+                    assert!(
+                        trusted.is_empty() || trusted == proved,
+                        "{} left_to_right={left_to_right} {cap:?}: trusted read served a \
+                         different window ({trusted:?}) from the verified proof ({proved:?})",
+                        layer.name()
+                    );
+                }
+            }
+        }
+    }
+}

--- a/grovedb/src/tests/mod.rs
+++ b/grovedb/src/tests/mod.rs
@@ -12,6 +12,7 @@ mod aggregate_count_query_tests;
 mod aggregate_sum_carrier_query_tests;
 mod aggregate_sum_query_tests;
 mod append_family_cost_bound_tests;
+mod append_layer_direction_tests;
 mod append_storage_accounting_tests;
 mod batch_coverage_tests;
 mod batch_delete_tree_tests;


### PR DESCRIPTION
Closes #855.

## What the audit found

Bulk range extraction sorts positions ascending, and a limit applied to that order returns the FIRST positions even when the query is descending — the opposite end of the requested range.

## State on `develop`

The audited snapshot (`2fa0f133`) predates #847, which made the GroveDB V1 verifier order the MMR / BulkAppend / Dense / CommitmentTree rows by the query direction before consuming the shared limit. The GroveDB proof path was already correct; what was missing was the runtime validation the issue lists, plus the crate-level helper the issue names as root control.

## Changes

- **`BulkAppendTreeProof::verify_against_query`** (grovedb-bulk-append-tree): the collected values now follow `query.left_to_right` and honour `query.limit`, so a descending limited query yields the highest positions — the same window the GroveDB verifier and a direct read return. Completeness is still checked against the full ranges before the cap, so a limit cannot hide a missing tail (pinned by a test).
- **Crate tests** built queries with `Query::default()`, whose derived `left_to_right` is `false`; they now use `Query::new()` so the "ascending" fixtures really are ascending.
- **New `grovedb/src/tests/append_layer_direction_tests.rs`** — the validation the audit left outstanding. For BulkAppendTree and CommitmentTree with entries spanning two completed chunks plus the dense buffer: every window × direction × cap kind (`SizedQuery::limit` and per-instance `Query::limit`) is proved, verified against the live root, and compared to the direct range read (`bulk_get_range` / `commitment_tree_get_range`). The same proof is then re-verified uncapped in both directions to show it carries the whole selected span. A separate test pins that a descending cap is the reverse tail of the ascending read, never its prefix.

## Noted, not changed

The trusted `query_raw` engine does not descend into append-only layers (it yields no rows there in either direction). That is a pre-existing read-engine gap unrelated to ordering; the new trusted-read test only pins that it never serves a different window from the proof.

## Verification

- `cargo test -p grovedb-bulk-append-tree`: 120 passed.
- `cargo test -p grovedb --all-features` for the new module plus the per-instance-limit, bulk, commitment, dense and MMR suites: 251 passed.
- Clippy (`--all-features --all-targets -D warnings`) reports nothing in the changed files; the remaining hits are pre-existing in untouched test files under the local clippy 1.97.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected descending queries with limits so they return the highest matching results first.
  * Ensured query limits only restrict returned results and do not weaken completeness validation.
  * Improved consistency between direct reads, generated proofs, and verified results across storage regions.

* **Tests**
  * Added coverage for descending, limited reads across append and commitment tree layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->