### PR TITLE
fix: canonical row order from the MMR and dense standalone verifiers; validate limited non-Merk pages (#854)

### DIFF
--- a/grovedb-dense-fixed-sized-merkle-tree/src/proof/tests.rs
+++ b/grovedb-dense-fixed-sized-merkle-tree/src/proof/tests.rs
@@ -1808,4 +1808,113 @@ mod proof_tests {
             );
         }
     }
+
+    /// Issue #854: the order the proof carries its entries in is not
+    /// authenticated (the root binds the position→value map), so every
+    /// verifier must surface the canonical ascending order — a permuted
+    /// proof yields the same root AND the same sequence, leaving a
+    /// caller's limit/truncation nothing to be steered by.
+    mod canonical_entry_order {
+        use super::*;
+
+        fn permuted_proofs(honest: &DenseTreeProof) -> Vec<(&'static str, DenseTreeProof)> {
+            let mut reversed = honest.clone();
+            reversed.entries.reverse();
+            let mut shuffled = honest.clone();
+            let n = shuffled.entries.len();
+            shuffled.entries.swap(0, n - 1);
+            shuffled.entries.swap(1, n / 2);
+            vec![
+                ("honest", honest.clone()),
+                ("reversed", reversed),
+                ("shuffled", shuffled),
+            ]
+        }
+
+        #[test]
+        fn verify_for_query_yields_ascending_positions_for_any_proof_order() {
+            let tree = make_tree_h3_full();
+            let (height, count) = (tree.height(), tree.count());
+            let expected_root = tree
+                .root_hash(GroveVersion::latest())
+                .unwrap()
+                .expect("root hash");
+            let mut query = Query::new();
+            query.insert_range_inclusive(vec![1]..=vec![5]);
+            let honest = DenseTreeProof::generate_for_query(&tree, &query)
+                .unwrap()
+                .expect("generate_for_query should succeed");
+            assert_eq!(honest.entries.len(), 5);
+
+            for (label, proof) in permuted_proofs(&honest) {
+                let (root, entries) = proof
+                    .verify_for_query::<Vec<(u16, Vec<u8>)>>(&query, height, count)
+                    .unwrap_or_else(|e| panic!("{label}: verify_for_query should succeed: {e}"));
+                assert_eq!(root, expected_root, "{label}: root is order-independent");
+                let positions: Vec<u16> = entries.iter().map(|(p, _)| *p).collect();
+                assert_eq!(
+                    positions,
+                    vec![1, 2, 3, 4, 5],
+                    "{label}: ascending positions"
+                );
+                for (pos, value) in &entries {
+                    assert_eq!(value, &vec![*pos as u8], "{label}: value bound to position");
+                }
+
+                // Direction is not a verifier concern: the same ascending
+                // sequence comes back for a descending query too, and the
+                // limit-applying caller reverses it.
+                let mut descending = query.clone();
+                descending.left_to_right = false;
+                let (_, entries) = proof
+                    .verify_for_query::<Vec<(u16, Vec<u8>)>>(&descending, height, count)
+                    .unwrap_or_else(|e| panic!("{label}: descending verify should succeed: {e}"));
+                let positions: Vec<u16> = entries.iter().map(|(p, _)| *p).collect();
+                assert_eq!(
+                    positions,
+                    vec![1, 2, 3, 4, 5],
+                    "{label}: direction-agnostic"
+                );
+            }
+        }
+
+        #[test]
+        fn root_verifiers_yield_ascending_positions_for_any_proof_order() {
+            let tree = make_tree_h4_full();
+            let (height, count) = (tree.height(), tree.count());
+            let expected_root = tree
+                .root_hash(GroveVersion::latest())
+                .unwrap()
+                .expect("root hash");
+            let honest = DenseTreeProof::generate(&tree, &[0, 3, 7, 9, 14])
+                .unwrap()
+                .expect("generate should succeed");
+
+            for (label, proof) in permuted_proofs(&honest) {
+                let entries: Vec<(u16, Vec<u8>)> = proof
+                    .verify_against_expected_root(&expected_root, height, count)
+                    .unwrap_or_else(|e| panic!("{label}: verify_against_expected_root: {e}"));
+                let positions: Vec<u16> = entries.iter().map(|(p, _)| *p).collect();
+                assert_eq!(
+                    positions,
+                    vec![0, 3, 7, 9, 14],
+                    "{label}: ascending positions"
+                );
+
+                let (root, entries) = proof
+                    .verify_and_get_root::<Vec<(u16, Vec<u8>)>>(height, count)
+                    .unwrap_or_else(|e| panic!("{label}: verify_and_get_root: {e}"));
+                assert_eq!(root, expected_root, "{label}: root is order-independent");
+                let positions: Vec<u16> = entries.iter().map(|(p, _)| *p).collect();
+                assert_eq!(
+                    positions,
+                    vec![0, 3, 7, 9, 14],
+                    "{label}: ascending positions"
+                );
+                for (pos, value) in &entries {
+                    assert_eq!(value, &pos.to_be_bytes().to_vec(), "{label}: value bound");
+                }
+            }
+        }
+    }
 }

--- a/grovedb-dense-fixed-sized-merkle-tree/src/verify.rs
+++ b/grovedb-dense-fixed-sized-merkle-tree/src/verify.rs
@@ -18,9 +18,13 @@ impl DenseTreeProof {
     /// `height` and `count` are trusted values obtained from an authenticated
     /// source (e.g. the parent `Element` in Merk).
     ///
-    /// Returns the proved `(position, value)` pairs collected into `C`.
+    /// Returns the proved `(position, value)` pairs collected into `C`,
+    /// yielded in ascending `position` order regardless of the order the
+    /// proof carried them in (see [`verify_and_get_root`]).
     /// `C` can be `Vec<(u16, Vec<u8>)>`, `BTreeMap<u16, Vec<u8>>`,
     /// `HashMap<u16, Vec<u8>>`, or any `FromIterator<(u16, Vec<u8>)>`.
+    ///
+    /// [`verify_and_get_root`]: Self::verify_and_get_root
     pub fn verify_against_expected_root<C>(
         &self,
         expected_root: &[u8; 32],
@@ -52,6 +56,12 @@ impl DenseTreeProof {
     /// This is used when the root hash flows through the Merk child hash
     /// mechanism rather than being stored in the Element.
     ///
+    /// The entries are yielded in ascending `position` order. The sequence
+    /// the proof encoded them in is not authenticated (the root binds the
+    /// position→value map), so it is never surfaced: a caller that pages or
+    /// truncates the result sees the same page for every permutation of the
+    /// same entry set.
+    ///
     /// `C` can be `Vec<(u16, Vec<u8>)>`, `BTreeMap<u16, Vec<u8>>`,
     /// `HashMap<u16, Vec<u8>>`, or any `FromIterator<(u16, Vec<u8>)>`.
     pub fn verify_and_get_root<C>(
@@ -81,8 +91,17 @@ impl DenseTreeProof {
     /// - **Sound**: the proof contains no entries for positions that were not
     ///   requested by the query.
     ///
+    /// The entries are yielded in ascending `position` order, independent of
+    /// the order the proof carried them in (see [`verify_and_get_root`]).
+    /// `query.left_to_right` is not applied here: it selects which end of the
+    /// set a *limit* keeps, and this method applies no limit, so the caller
+    /// that does (GroveDB's lower-layer verifier) reverses the ascending
+    /// sequence for a descending query before truncating.
+    ///
     /// `C` can be `Vec<(u16, Vec<u8>)>`, `BTreeMap<u16, Vec<u8>>`,
     /// `HashMap<u16, Vec<u8>>`, or any `FromIterator<(u16, Vec<u8>)>`.
+    ///
+    /// [`verify_and_get_root`]: Self::verify_and_get_root
     pub fn verify_for_query<C>(
         &self,
         query: &Query,
@@ -277,8 +296,16 @@ impl DenseTreeProof {
         let computed_root =
             recompute_hash(0, capacity, count, &entry_map, &value_hash_map, &hash_map)?;
 
-        // All entry positions validated in-range above; collect into C
-        let entries: C = self.entries.iter().cloned().collect();
+        // All entry positions validated in-range above. Surface them in
+        // canonical (ascending-position) order rather than the order the
+        // proof carried them in: the root binds the position→value map, not
+        // the encoded sequence, so a prover could otherwise permute the
+        // entries without changing the root and steer which ones survive a
+        // caller's limit/truncation (issue #854). Positions are unique
+        // (checked above), so the sort is a total order.
+        let mut ordered: Vec<(u16, Vec<u8>)> = self.entries.clone();
+        ordered.sort_by_key(|(pos, _)| *pos);
+        let entries: C = ordered.into_iter().collect();
 
         Ok((computed_root, entries))
     }

--- a/grovedb-merkle-mountain-range/src/proof.rs
+++ b/grovedb-merkle-mountain-range/src/proof.rs
@@ -470,7 +470,12 @@ impl MmrTreeProof {
     /// * `expected_mmr_root` - The MMR root hash from the parent element
     ///
     /// # Returns
-    /// The verified leaf values as `(leaf_index, value_bytes)` pairs.
+    /// The verified leaf values as `(leaf_index, value_bytes)` pairs in
+    /// ascending `leaf_index` order, deduplicated by index. The order the
+    /// proof *carried* the leaves in is not authenticated (root
+    /// computation sorts by position), so it is never surfaced: a caller
+    /// that pages or truncates the result sees the same page for every
+    /// permutation of the same leaf set.
     pub fn verify(&self, expected_mmr_root: &[u8; 32]) -> Result<VerifiedLeaves> {
         if self.leaves.is_empty() {
             return Err(Error::InvalidProof(
@@ -525,17 +530,7 @@ impl MmrTreeProof {
             ));
         }
 
-        // Deduplicate by leaf_index: the library deduplicates positions
-        // internally, but self.leaves may contain duplicate indices that were
-        // not independently verified. Only return unique leaf entries.
-        let mut seen = BTreeSet::new();
-        let verified_leaves: Vec<(u64, Vec<u8>)> = self
-            .leaves
-            .iter()
-            .filter(|(idx, _)| seen.insert(*idx))
-            .cloned()
-            .collect();
-        Ok(verified_leaves)
+        Ok(self.canonical_leaves())
     }
 
     /// Verify the proof and return the computed MMR root hash along with the
@@ -544,6 +539,12 @@ impl MmrTreeProof {
     /// Unlike [`verify`](Self::verify), this does NOT check against an expected
     /// root — the caller is responsible for validating the root (typically via
     /// the Merk child hash mechanism).
+    ///
+    /// The returned leaves follow the same contract as [`verify`]: ascending
+    /// `leaf_index` order, deduplicated by index, independent of the order
+    /// the proof carried them in.
+    ///
+    /// [`verify`]: Self::verify
     pub fn verify_and_get_root(&self) -> Result<([u8; 32], VerifiedLeaves)> {
         if self.leaves.is_empty() {
             return Err(Error::InvalidProof(
@@ -588,16 +589,29 @@ impl MmrTreeProof {
             Error::InvalidProof(format!("MMR proof root calculation failed: {}", e))
         })?;
 
-        // Deduplicate by leaf_index
+        Ok((root.hash(), self.canonical_leaves()))
+    }
+
+    /// The proof's leaves in their canonical, authenticated order:
+    /// ascending by `leaf_index`, one entry per index.
+    ///
+    /// Root computation (`calculate_peaks_hashes`) sorts the leaves by
+    /// position and keeps the FIRST occurrence of a duplicated position, so
+    /// the leaf set and the surviving value per index are what the root
+    /// binds — the sequence the proof was encoded in is not. Returning that
+    /// sequence would let a prover choose which entries survive a caller's
+    /// limit/truncation without changing the root (issue #854); returning
+    /// the canonical order removes that degree of freedom.
+    fn canonical_leaves(&self) -> VerifiedLeaves {
         let mut seen = BTreeSet::new();
-        let verified_leaves: Vec<(u64, Vec<u8>)> = self
+        let mut leaves: VerifiedLeaves = self
             .leaves
             .iter()
             .filter(|(idx, _)| seen.insert(*idx))
             .cloned()
             .collect();
-
-        Ok((root.hash(), verified_leaves))
+        leaves.sort_by_key(|(idx, _)| *idx);
+        leaves
     }
 
     /// Serialize this proof to bytes using bincode.

--- a/grovedb-merkle-mountain-range/src/tests/test_mmr.rs
+++ b/grovedb-merkle-mountain-range/src/tests/test_mmr.rs
@@ -691,3 +691,98 @@ proptest! {
         test_gen_new_root_from_proof(count);
     }
 }
+
+/// Issue #854: the order the proof carries its leaves in is not
+/// authenticated (root computation sorts by position), so `verify` and
+/// `verify_and_get_root` must surface the canonical ascending order — a
+/// permuted proof yields the same root AND the same sequence, leaving a
+/// caller's limit/truncation nothing to be steered by.
+#[test]
+fn test_mmr_tree_proof_verified_leaves_are_canonically_ordered() {
+    let store = MemStore::default();
+    let mut mmr = MMR::new(0, &store);
+    for i in 0u32..6 {
+        mmr.push(
+            MmrNode::leaf(i.to_le_bytes().to_vec()),
+            GroveVersion::latest(),
+        )
+        .unwrap()
+        .expect("push should succeed");
+    }
+    mmr.commit().unwrap().expect("commit should succeed");
+    let mmr_size = mmr.mmr_size;
+    let root = mmr
+        .get_root(GroveVersion::latest())
+        .unwrap()
+        .expect("get root should succeed");
+    let get_node = |pos: u64| -> crate::Result<Option<MmrNode>> {
+        (&store)
+            .element_at_position(pos)
+            .value
+            .map_err(|e| crate::Error::StoreError(format!("{}", e)))
+    };
+
+    let honest = MmrTreeProof::generate(mmr_size, &[0, 1, 2, 3, 4, 5], get_node)
+        .expect("generate should succeed");
+    let ascending: Vec<u64> = (0..6).collect();
+
+    // Rebuild the same proof with the leaves reversed, and once more with
+    // them shuffled; the proof items (sibling/peak hashes) are unchanged.
+    let mut reversed_leaves = honest.leaves().to_vec();
+    reversed_leaves.reverse();
+    let reversed = MmrTreeProof::new(mmr_size, reversed_leaves, honest.proof_items().to_vec());
+    let mut shuffled_leaves = honest.leaves().to_vec();
+    shuffled_leaves.swap(0, 4);
+    shuffled_leaves.swap(1, 5);
+    shuffled_leaves.swap(2, 3);
+    let shuffled = MmrTreeProof::new(mmr_size, shuffled_leaves, honest.proof_items().to_vec());
+
+    for (label, proof) in [
+        ("honest", &honest),
+        ("reversed", &reversed),
+        ("shuffled", &shuffled),
+    ] {
+        let verified = proof
+            .verify(&root.hash())
+            .unwrap_or_else(|e| panic!("{label}: verify should succeed: {e}"));
+        let indices: Vec<u64> = verified.iter().map(|(idx, _)| *idx).collect();
+        assert_eq!(
+            indices, ascending,
+            "{label}: verify must yield ascending leaf indices"
+        );
+        for (idx, value) in &verified {
+            assert_eq!(
+                value,
+                &(*idx as u32).to_le_bytes().to_vec(),
+                "{label}: value must stay bound to its index"
+            );
+        }
+
+        let (computed_root, verified) = proof
+            .verify_and_get_root()
+            .unwrap_or_else(|e| panic!("{label}: verify_and_get_root should succeed: {e}"));
+        assert_eq!(
+            computed_root,
+            root.hash(),
+            "{label}: root is order-independent"
+        );
+        let indices: Vec<u64> = verified.iter().map(|(idx, _)| *idx).collect();
+        assert_eq!(
+            indices, ascending,
+            "{label}: verify_and_get_root must yield ascending leaf indices"
+        );
+    }
+
+    // A duplicated index keeps its FIRST occurrence (matching what the root
+    // computation hashed) and still lands in canonical order.
+    let mut dup_leaves = honest.leaves().to_vec();
+    dup_leaves.reverse();
+    dup_leaves.push((3, b"never-hashed".to_vec()));
+    let dup = MmrTreeProof::new(mmr_size, dup_leaves, honest.proof_items().to_vec());
+    let verified = dup
+        .verify(&root.hash())
+        .expect("duplicate index is tolerated");
+    let indices: Vec<u64> = verified.iter().map(|(idx, _)| *idx).collect();
+    assert_eq!(indices, ascending);
+    assert_eq!(verified[3].1, 3u32.to_le_bytes().to_vec());
+}

--- a/grovedb/src/tests/mod.rs
+++ b/grovedb/src/tests/mod.rs
@@ -28,6 +28,7 @@ mod commitment_tree_cost_bound_tests;
 mod commitment_tree_tests;
 mod coverage_round7_tests;
 mod non_merk_integrity_audit_tests;
+mod non_merk_limited_page_tests;
 mod per_instance_gate_coverage_tests;
 mod per_instance_limit_tests;
 mod private_document_store_tests;

--- a/grovedb/src/tests/non_merk_limited_page_tests.rs
+++ b/grovedb/src/tests/non_merk_limited_page_tests.rs
@@ -1,0 +1,394 @@
+//! Issue #854 — limited proofs over the non-Merk adapters (MMR, dense,
+//! bulk-append, commitment tree) must select the page the *trusted*
+//! read would: the verifier authenticates the complete position set
+//! and the value bound to each position, but the sequence a proof
+//! carries them in is NOT authenticated. Truncating that sequence to
+//! the limit would let a prover choose which authenticated rows
+//! survive. The verifier therefore orders rows by authenticated
+//! position and the query direction before applying any limit, and
+//! the standalone crate verifiers surface the canonical ascending
+//! order regardless of the order they were handed.
+//!
+//! These tests compare limited and unlimited results against
+//! per-position trusted reads in both directions, then re-run the
+//! same queries on proofs whose lower layer was permuted and require
+//! the identical page.
+
+use grovedb_version::version::GroveVersion;
+
+use crate::{
+    operations::proof::{GroveDBProof, GroveDBProofV1, ProofBytes},
+    tests::{common::EMPTY_PATH, make_test_grovedb, TempGroveDb},
+    Element, GroveDb, PathQuery, Query, SizedQuery,
+};
+
+/// Rows stored per fixture. Chosen so the bulk-append fixture (chunk
+/// power 2 → 4 rows per chunk) spans two completed chunks plus a
+/// partially filled buffer, exercising both halves of its proof.
+const ROWS: u64 = 10;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Kind {
+    Mmr,
+    Dense,
+    Bulk,
+    CommitmentTree,
+}
+
+const ALL_KINDS: [Kind; 4] = [Kind::Mmr, Kind::Dense, Kind::Bulk, Kind::CommitmentTree];
+
+impl Kind {
+    fn key(self) -> &'static [u8] {
+        match self {
+            Kind::Mmr => b"mmr",
+            Kind::Dense => b"dense",
+            Kind::Bulk => b"bulk",
+            Kind::CommitmentTree => b"ct",
+        }
+    }
+
+    /// Position keys: BE u64 for every adapter except the dense tree,
+    /// whose positions are BE u16.
+    fn position_key(self, position: u64) -> Vec<u8> {
+        match self {
+            Kind::Dense => (position as u16).to_be_bytes().to_vec(),
+            _ => position.to_be_bytes().to_vec(),
+        }
+    }
+
+    fn position_from_key(self, key: &[u8]) -> u64 {
+        match self {
+            Kind::Dense => u16::from_be_bytes(key.try_into().expect("dense key is u16")) as u64,
+            _ => u64::from_be_bytes(key.try_into().expect("position key is u64")),
+        }
+    }
+}
+
+fn populate(kind: Kind, grove_version: &GroveVersion) -> TempGroveDb {
+    let db = make_test_grovedb(grove_version);
+    let key = kind.key();
+    let element = match kind {
+        Kind::Mmr => Element::empty_mmr_tree(),
+        Kind::Dense => Element::empty_dense_tree(4),
+        Kind::Bulk => Element::empty_bulk_append_tree(2).expect("valid chunk power"),
+        Kind::CommitmentTree => Element::empty_commitment_tree(11).expect("valid chunk power"),
+    };
+    db.insert(EMPTY_PATH, key, element, None, None, grove_version)
+        .unwrap()
+        .expect("insert tree element");
+    for i in 0..ROWS {
+        match kind {
+            Kind::Mmr => {
+                db.mmr_tree_append(EMPTY_PATH, key, vec![i as u8, 0xA0], None, grove_version)
+                    .unwrap()
+                    .expect("mmr append");
+            }
+            Kind::Dense => {
+                db.dense_tree_insert(
+                    EMPTY_PATH,
+                    key,
+                    format!("dense_{i}").into_bytes(),
+                    None,
+                    grove_version,
+                )
+                .unwrap()
+                .expect("dense insert");
+            }
+            Kind::Bulk => {
+                db.bulk_append(EMPTY_PATH, key, vec![i as u8, 0xB0], None, grove_version)
+                    .unwrap()
+                    .expect("bulk append");
+            }
+            Kind::CommitmentTree => {
+                let i = i as u8;
+                let mut cmx = [0u8; 32];
+                cmx[0] = i;
+                cmx[31] &= 0x7f;
+                let mut rho = [0u8; 32];
+                rho[0] = i;
+                rho[1] = 0xB0;
+                let mut cv_net = [0u8; 32];
+                cv_net[0] = i;
+                cv_net[1] = 0xCC;
+                let mut enc_data = [0u8; 104];
+                enc_data[0] = i;
+                let mut epk = [0u8; 32];
+                epk[0] = i;
+                let mut out_ct = [0u8; 80];
+                out_ct[0] = i;
+                let ciphertext = grovedb_commitment_tree::TransmittedNoteCiphertext::<
+                    grovedb_commitment_tree::DashMemo,
+                >::from_parts(
+                    epk,
+                    grovedb_commitment_tree::NoteBytesData(enc_data),
+                    out_ct,
+                );
+                db.commitment_tree_insert(
+                    EMPTY_PATH,
+                    key,
+                    cmx,
+                    rho,
+                    cv_net,
+                    ciphertext,
+                    None,
+                    grove_version,
+                )
+                .unwrap()
+                .expect("commitment tree insert");
+            }
+        }
+    }
+    db
+}
+
+/// The trusted, non-proof read of one position.
+fn trusted_value(
+    db: &TempGroveDb,
+    kind: Kind,
+    position: u64,
+    grove_version: &GroveVersion,
+) -> Vec<u8> {
+    let key = kind.key();
+    let read = match kind {
+        Kind::Mmr => db.mmr_tree_get_value(EMPTY_PATH, key, position, None, grove_version),
+        Kind::Dense => db.dense_tree_get(EMPTY_PATH, key, position as u16, None, grove_version),
+        Kind::Bulk => db.bulk_get_value(EMPTY_PATH, key, position, None, grove_version),
+        Kind::CommitmentTree => {
+            db.commitment_tree_get_value(EMPTY_PATH, key, position, None, grove_version)
+        }
+    };
+    read.unwrap()
+        .expect("trusted read")
+        .unwrap_or_else(|| panic!("{kind:?}: position {position} must exist"))
+}
+
+/// `[0, ROWS)` at the tree's path, walked in `left_to_right` order,
+/// capped by the GLOBAL `SizedQuery::limit`.
+fn page_query(kind: Kind, left_to_right: bool, limit: Option<u16>) -> PathQuery {
+    let mut inner = Query::new_with_direction(left_to_right);
+    inner.insert_range_inclusive(kind.position_key(0)..=kind.position_key(ROWS - 1));
+    let mut root = Query::new_single_key(kind.key().to_vec());
+    root.set_subquery(inner);
+    PathQuery::new(vec![], SizedQuery::new(root, limit, None))
+}
+
+/// What the trusted read semantics select: positions in query
+/// direction, first `limit` of them.
+fn expected_positions(left_to_right: bool, limit: Option<u16>) -> Vec<u64> {
+    let mut positions: Vec<u64> = (0..ROWS).collect();
+    if !left_to_right {
+        positions.reverse();
+    }
+    if let Some(limit) = limit {
+        positions.truncate(limit as usize);
+    }
+    positions
+}
+
+/// Verify a proof and return `(root_hash, [(position, value)])`.
+fn verified_page(
+    proof: &[u8],
+    query: &PathQuery,
+    kind: Kind,
+    grove_version: &GroveVersion,
+) -> Result<([u8; 32], Vec<(u64, Vec<u8>)>), crate::Error> {
+    let (root_hash, rows) = GroveDb::verify_query(proof, query, grove_version)?;
+    let page = rows
+        .into_iter()
+        .map(|(path, key, element)| {
+            assert_eq!(path, vec![kind.key().to_vec()], "row path is the tree path");
+            let value = match element {
+                Some(Element::Item(value, _)) => value,
+                other => panic!("{kind:?}: expected an Item row, got {other:?}"),
+            };
+            (kind.position_from_key(&key), value)
+        })
+        .collect();
+    Ok((root_hash, page))
+}
+
+fn decode_envelope(proof: &[u8]) -> GroveDBProof {
+    bincode::decode_from_slice(
+        proof,
+        bincode::config::standard()
+            .with_big_endian()
+            .with_limit::<{ 256 * 1024 * 1024 }>(),
+    )
+    .expect("decode envelope")
+    .0
+}
+
+fn reencode_envelope(decoded: GroveDBProof) -> Vec<u8> {
+    bincode::encode_to_vec(
+        decoded,
+        bincode::config::standard()
+            .with_big_endian()
+            .with_no_limit(),
+    )
+    .expect("re-encode envelope")
+}
+
+fn permuted_mmr_bytes(bytes: &[u8]) -> Vec<u8> {
+    use grovedb_merkle_mountain_range::MmrTreeProof;
+    let honest = MmrTreeProof::decode_from_slice(bytes).expect("decode mmr proof");
+    let mut leaves = honest.leaves().to_vec();
+    leaves.reverse();
+    MmrTreeProof::new(honest.mmr_size(), leaves, honest.proof_items().to_vec())
+        .encode_to_vec()
+        .expect("encode permuted mmr proof")
+}
+
+fn permuted_dense_bytes(bytes: &[u8]) -> Vec<u8> {
+    use grovedb_dense_fixed_sized_merkle_tree::DenseTreeProof;
+    let mut proof = DenseTreeProof::decode_from_slice(bytes).expect("decode dense proof");
+    proof.entries.reverse();
+    proof.encode_to_vec().expect("encode permuted dense proof")
+}
+
+fn permuted_bulk_bytes(bytes: &[u8]) -> Vec<u8> {
+    use grovedb_bulk_append_tree::BulkAppendTreeProof;
+    use grovedb_merkle_mountain_range::MmrTreeProof;
+    let mut proof = BulkAppendTreeProof::decode_from_slice(bytes).expect("decode bulk proof");
+    let mut chunk_leaves = proof.chunk_proof.leaves().to_vec();
+    chunk_leaves.reverse();
+    proof.chunk_proof = MmrTreeProof::new(
+        proof.chunk_proof.mmr_size(),
+        chunk_leaves,
+        proof.chunk_proof.proof_items().to_vec(),
+    );
+    proof.buffer_proof.entries.reverse();
+    proof.encode_to_vec().expect("encode permuted bulk proof")
+}
+
+/// Rebuild `proof` with the lower layer under the tree key carrying its
+/// rows in reverse order. Nothing hashed changes: the position→value
+/// bindings are intact, only the (unauthenticated) sequence moved.
+fn permute_lower_layer(proof: &[u8], kind: Kind) -> Vec<u8> {
+    let mut decoded = decode_envelope(proof);
+    let GroveDBProof::V1(GroveDBProofV1 { root_layer }) = &mut decoded else {
+        panic!("expected a V1 envelope");
+    };
+    let layer = root_layer
+        .lower_layers
+        .get_mut(kind.key())
+        .unwrap_or_else(|| panic!("{kind:?}: lower layer under the tree key"));
+    layer.merk_proof = match (&layer.merk_proof, kind) {
+        (ProofBytes::MMR(bytes), Kind::Mmr) => ProofBytes::MMR(permuted_mmr_bytes(bytes)),
+        (ProofBytes::DenseTree(bytes), Kind::Dense) => {
+            ProofBytes::DenseTree(permuted_dense_bytes(bytes))
+        }
+        (ProofBytes::BulkAppendTree(bytes), Kind::Bulk) => {
+            ProofBytes::BulkAppendTree(permuted_bulk_bytes(bytes))
+        }
+        (ProofBytes::CommitmentTree(bytes), Kind::CommitmentTree) => {
+            let (sinsemilla_root, bulk) = bytes.split_at(32);
+            let mut rebuilt = sinsemilla_root.to_vec();
+            rebuilt.extend(permuted_bulk_bytes(bulk));
+            ProofBytes::CommitmentTree(rebuilt)
+        }
+        _ => panic!("{kind:?}: lower-layer proof bytes are not the adapter's variant"),
+    };
+    reencode_envelope(decoded)
+}
+
+const LIMITS: [Option<u16>; 4] = [None, Some(1), Some(3), Some(7)];
+
+#[test]
+fn limited_pages_match_trusted_reads_in_both_directions() {
+    let grove_version = GroveVersion::latest();
+    for kind in ALL_KINDS {
+        let db = populate(kind, grove_version);
+        for left_to_right in [true, false] {
+            let unlimited_query = page_query(kind, left_to_right, None);
+            let unlimited_proof = db
+                .prove_query(&unlimited_query, None, grove_version)
+                .unwrap()
+                .expect("prove unlimited");
+            let (_, unlimited_page) =
+                verified_page(&unlimited_proof, &unlimited_query, kind, grove_version)
+                    .expect("verify unlimited");
+            assert_eq!(
+                unlimited_page.len(),
+                ROWS as usize,
+                "{kind:?} ltr={left_to_right}: unlimited page is the whole tree"
+            );
+
+            for limit in LIMITS {
+                let query = page_query(kind, left_to_right, limit);
+                let proof = db
+                    .prove_query(&query, None, grove_version)
+                    .unwrap()
+                    .expect("prove");
+                let (_, page) = verified_page(&proof, &query, kind, grove_version).expect("verify");
+
+                let positions: Vec<u64> = page.iter().map(|(p, _)| *p).collect();
+                assert_eq!(
+                    positions,
+                    expected_positions(left_to_right, limit),
+                    "{kind:?} ltr={left_to_right} limit={limit:?}: page positions"
+                );
+                // The limited page is a prefix of the unlimited page …
+                assert_eq!(
+                    page.as_slice(),
+                    &unlimited_page[..page.len()],
+                    "{kind:?} ltr={left_to_right} limit={limit:?}: limited is a prefix of unlimited"
+                );
+                // … and every row carries the trusted value for its position.
+                for (position, value) in &page {
+                    assert_eq!(
+                        value,
+                        &trusted_value(&db, kind, *position, grove_version),
+                        "{kind:?} ltr={left_to_right} limit={limit:?}: value at {position}"
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn permuted_lower_layers_cannot_move_the_page() {
+    // The proof carries the COMPLETE requested set (the limit is applied
+    // by the verifier, not by shrinking the proof), so a prover that
+    // reorders the rows keeps every position/value binding and the
+    // root. The verifier must still hand back the honest page.
+    let grove_version = GroveVersion::latest();
+    for kind in ALL_KINDS {
+        let db = populate(kind, grove_version);
+        for left_to_right in [true, false] {
+            for limit in LIMITS {
+                let query = page_query(kind, left_to_right, limit);
+                let honest_proof = db
+                    .prove_query(&query, None, grove_version)
+                    .unwrap()
+                    .expect("prove");
+                let (honest_root, honest_page) =
+                    verified_page(&honest_proof, &query, kind, grove_version)
+                        .expect("verify honest");
+                assert_eq!(
+                    honest_page.iter().map(|(p, _)| *p).collect::<Vec<_>>(),
+                    expected_positions(left_to_right, limit),
+                );
+
+                let permuted_proof = permute_lower_layer(&honest_proof, kind);
+                assert_ne!(
+                    permuted_proof, honest_proof,
+                    "{kind:?}: the permutation must change the encoded proof"
+                );
+                let (permuted_root, permuted_page) =
+                    verified_page(&permuted_proof, &query, kind, grove_version).unwrap_or_else(
+                        |e| panic!("{kind:?} ltr={left_to_right} limit={limit:?}: {e}"),
+                    );
+                assert_eq!(
+                    permuted_root, honest_root,
+                    "{kind:?}: permuting unauthenticated order keeps the root"
+                );
+                assert_eq!(
+                    permuted_page, honest_page,
+                    "{kind:?} ltr={left_to_right} limit={limit:?}: a permuted proof must \
+                     select the same page as the honest one"
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #854.

## What the audit found

MMR and dense proofs authenticate the *set* of positions and the value bound to each position. The sequence a proof carries those rows in is not hashed. At the audited revision GroveDB's lower-layer verifiers checked the position set for completeness and then truncated the proof's own sequence to the query limit, so a prover could permute the rows and pick which authenticated rows survive a limited query without changing the root.

## State on `develop`

The GroveDB-level ordering was already fixed by #847 (merged after the audited revision): the MMR, bulk-append, dense and commitment-tree lower-layer verifiers sort by authenticated position, reverse for a descending query, and only then apply the limit.

## What this PR does

**Aligns the standalone crate contracts** with the integrated one, which the issue also asks for. Previously both crates handed back rows in whatever order the proof supplied them:

- `grovedb-merkle-mountain-range`: `MmrTreeProof::verify` and `verify_and_get_root` now return leaves in ascending leaf-index order (deduplicated by index, first occurrence kept — the same entry the root computation hashed). Shared `canonical_leaves` helper; documented contract.
- `grovedb-dense-fixed-sized-merkle-tree`: `verify_against_expected_root`, `verify_and_get_root` and `verify_for_query` now yield entries in ascending position order; documented contract, including why `left_to_right` is the limit-applying caller's concern.
- `grovedb-bulk-append-tree` already sorted in `values_in_range`; unchanged.

Any consumer that pages or truncates a standalone verifier's result now sees the same page for every permutation of the same proof.

**Completes the validation the issue lists** (new `grovedb/src/tests/non_merk_limited_page_tests.rs`, plus standalone tests in both crates):

- `limited_pages_match_trusted_reads_in_both_directions`: for MMR, dense, bulk-append and commitment trees, ascending and descending, limits `None / 1 / 3 / 7` under the global `SizedQuery::limit`: the verified page has exactly the positions a trusted read would select, the limited page is a prefix of the unlimited one, and every value equals the per-position trusted read (`mmr_tree_get_value`, `dense_tree_get`, `bulk_get_value`, `commitment_tree_get_value`).
- `permuted_lower_layers_cannot_move_the_page`: decodes the honest proof, reverses the lower layer's rows (MMR leaves; dense entries; both the chunk MMR leaves and the buffer entries for bulk / commitment trees), re-encodes, and requires the identical root hash and page. Confirmed to fail when the sorts are removed on both layers.
- Standalone: reversed and shuffled proofs verify to the same root and the same ascending sequence; a duplicated MMR index keeps the hashed (first) value.

No wire-format or version-gate change: the proof bytes are untouched, only the order verifiers surface already-authenticated rows in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
