### PR TITLE
fix(merk): opaque proof nodes must stay childless (#853)

### DIFF
--- a/docs/book/src/proof-system.md
+++ b/docs/book/src/proof-system.md
@@ -332,6 +332,10 @@ The verifier checks each layer, confirming that:
 1. The layer proof reconstructs to the expected root hash
 2. The root hash matches the value_hash from the parent layer
 3. The top-level root hash matches the known state root
+4. Every opaque node (`Hash`, `HashWithCount`, `HashWithSum`,
+   `HashWithCountAndSum`) is a leaf. These nodes hash to an embedded value that
+   ignores attached children, so a child beneath one would be unauthenticated
+   data; `Tree::attach` refuses to build such a tree.
 
 ## Proof Verification
 

--- a/docs/merk-deep-dive.md
+++ b/docs/merk-deep-dive.md
@@ -127,6 +127,11 @@ Node::Hash(hash: [u8; 32])
 - **Size**: 32 bytes
 - **Use Case**: When you need to verify tree structure but not the data
 - **Example**: Proving a path to a specific key without revealing sibling data
+- **Invariant**: Always a leaf of the proof tree. Its hash is taken verbatim,
+  so the verifier rejects any `Parent`/`Child` op that would attach a child
+  beneath it (the same rule applies to `HashWithCount`, `HashWithSum` and
+  `HashWithCountAndSum`). Otherwise data hung under the node would be invisible
+  to the root-hash check yet still reachable by query and restore traversal.
 
 ### 2. **KVHash**
 ```rust
@@ -326,6 +331,8 @@ Proof contains:
 2. Validate all hash computations
 3. Check for malformed proofs (wrong operation sequences)
 4. Verify aggregate values match individual components
+5. Opaque nodes (`Hash`, `HashWithCount`, `HashWithSum`, `HashWithCountAndSum`)
+   must be childless; `Tree::attach` enforces this for every consumer
 
 ### For Privacy
 1. Use `Hash` nodes to hide irrelevant data

--- a/merk/src/merk/restore.rs
+++ b/merk/src/merk/restore.rs
@@ -999,6 +999,70 @@ mod tests {
         );
     }
 
+    /// Regression for issue #853: a `Node::Hash` chunk-boundary node commits
+    /// only to the hash it carries, so before the fix a chunk could hang a
+    /// forged `KV` beneath it. `verify_chunk` accepted the chunk (the root
+    /// hash still matched) and `write_chunk` persisted the forged row into
+    /// storage even though nothing in the authenticated tree links to it.
+    #[test]
+    fn test_forged_kv_under_hash_boundary_node_is_rejected() {
+        use crate::tree::{kv_hash, node_hash};
+
+        let grove_version = GroveVersion::latest();
+        let left_hash: CryptoHash = [0x11; 32];
+        let right_hash: CryptoHash = [0x22; 32];
+        let root_kv_hash = kv_hash(&[5], &[5]).unwrap();
+        let expected_root = node_hash(&root_kv_hash, &left_hash, &right_hash).unwrap();
+
+        let malicious_chunk = vec![
+            Op::Push(Node::Hash(left_hash)),
+            Op::Push(Node::KV(vec![3], b"forged".to_vec())),
+            // hangs the forged KV under the opaque boundary node
+            Op::Child,
+            Op::Push(Node::KV(vec![5], vec![5])),
+            Op::Parent,
+            Op::Push(Node::Hash(right_hash)),
+            Op::Child,
+        ];
+
+        let storage = TempStorage::new();
+        let tx = storage.start_transaction();
+        let restoration_merk = Merk::open_base(
+            storage
+                .get_immediate_storage_context(SubtreePath::empty(), &tx)
+                .unwrap(),
+            TreeType::NormalTree,
+            None::<&fn(&[u8], &GroveVersion) -> Option<ValueDefinedCostType>>,
+            grove_version,
+        )
+        .unwrap()
+        .unwrap();
+
+        let mut restorer = Restorer::new(restoration_merk, expected_root, None);
+        let result = restorer.process_chunk(
+            &traversal_instruction_as_vec_bytes(&[]),
+            malicious_chunk,
+            grove_version,
+        );
+        assert!(
+            matches!(result, Err(Error::InvalidProofError(_))),
+            "forged KV under a Node::Hash boundary must be rejected, got {result:?}"
+        );
+
+        // Nothing from the rejected chunk may have reached storage.
+        let merk = restorer.into_merk();
+        let forged = merk
+            .get(
+                &[3],
+                true,
+                None::<&fn(&[u8], &GroveVersion) -> Option<ValueDefinedCostType>>,
+                grove_version,
+            )
+            .unwrap()
+            .expect("get should not error");
+        assert!(forged.is_none(), "forged row must not be persisted");
+    }
+
     fn get_node_hash(node: Node) -> Result<CryptoHash, String> {
         match node {
             Node::Hash(hash) => Ok(hash),

--- a/merk/src/proofs/query/aggregate_count/tests.rs
+++ b/merk/src/proofs/query/aggregate_count/tests.rs
@@ -725,9 +725,14 @@ fn shape_walk_rejects_disjoint_hashwithcountandsum_with_children_pcps() {
     let err = result.expect_err(
         "spliced child under Disjoint HashWithCountAndSum must be rejected by shape walk",
     );
+    // Since issue #853 `Tree::attach` refuses to hang anything under an
+    // opaque node, so `execute` rejects this shape before the shape walk
+    // runs. The shape walk's own leaf assertion is retained as defense in
+    // depth, so either message is an acceptable rejection.
     match err {
         Error::InvalidProofError(msg) => assert!(
-            msg.contains("Disjoint position must be a leaf")
+            msg.contains("cannot have children")
+                || msg.contains("Disjoint position must be a leaf")
                 || msg.contains("at a Disjoint position"),
             "unexpected message: {msg}"
         ),
@@ -1456,9 +1461,14 @@ fn shape_walk_rejects_disjoint_hashwithcount_with_children() {
     let bytes = encode_proof(&ops);
     let result = verify_aggregate_count_on_range_proof(&bytes, &inner_range).unwrap();
     let err = result.expect_err("Disjoint HashWithCount with children must be rejected");
+    // Since issue #853 `Tree::attach` refuses to hang anything under an
+    // opaque node, so `execute` rejects this shape before the shape walk
+    // runs. The shape walk's own leaf assertion is retained as defense in
+    // depth, so either message is an acceptable rejection.
     match err {
         Error::InvalidProofError(msg) => assert!(
-            msg.contains("Disjoint position must be a leaf"),
+            msg.contains("cannot have children")
+                || msg.contains("Disjoint position must be a leaf"),
             "unexpected message: {msg}"
         ),
         other => panic!("expected InvalidProofError, got {:?}", other),
@@ -1617,9 +1627,14 @@ fn shape_walk_rejects_contained_hashwithcount_with_children() {
     let bytes = encode_proof(&ops);
     let result = verify_aggregate_count_on_range_proof(&bytes, &inner_range).unwrap();
     let err = result.expect_err("Contained HashWithCount with children must be rejected");
+    // Since issue #853 `Tree::attach` refuses to hang anything under an
+    // opaque node, so `execute` rejects this shape before the shape walk
+    // runs. The shape walk's own leaf assertion is retained as defense in
+    // depth, so either message is an acceptable rejection.
     match err {
         Error::InvalidProofError(msg) => assert!(
-            msg.contains("Contained position must be a leaf"),
+            msg.contains("cannot have children")
+                || msg.contains("Contained position must be a leaf"),
             "unexpected message: {msg}"
         ),
         other => panic!("expected InvalidProofError, got {:?}", other),
@@ -1661,9 +1676,14 @@ fn shape_walk_rejects_contained_hashwithcountandsum_with_children_pcps() {
     let result = verify_aggregate_count_on_range_proof(&bytes, &inner_range).unwrap();
     let err = result
         .expect_err("Contained HashWithCountAndSum with children must be rejected (dual-axis)");
+    // Since issue #853 `Tree::attach` refuses to hang anything under an
+    // opaque node, so `execute` rejects this shape before the shape walk
+    // runs. The shape walk's own leaf assertion is retained as defense in
+    // depth, so either message is an acceptable rejection.
     match err {
         Error::InvalidProofError(msg) => assert!(
-            msg.contains("Contained position must be a leaf"),
+            msg.contains("cannot have children")
+                || msg.contains("Contained position must be a leaf"),
             "unexpected message: {msg}"
         ),
         other => panic!("expected InvalidProofError, got {:?}", other),
@@ -1740,9 +1760,15 @@ fn shape_walk_rejects_non_kvdigestcount_at_boundary() {
     let bytes = encode_proof(&ops);
     let result = verify_aggregate_count_on_range_proof(&bytes, &inner_range).unwrap();
     let err = result.expect_err("non-KVDigestCount at Boundary must be rejected");
+    // The swapped node keeps its children, and since issue #853
+    // `Tree::attach` refuses children under an opaque node, so `execute`
+    // rejects the proof before the shape walk runs. The shape walk's own
+    // Boundary check is retained as defense in depth, so either message
+    // is an acceptable rejection.
     match err {
         Error::InvalidProofError(msg) => assert!(
-            msg.contains("expected KVDigestCount") && msg.contains("Boundary"),
+            msg.contains("cannot have children")
+                || (msg.contains("expected KVDigestCount") && msg.contains("Boundary")),
             "unexpected message: {msg}"
         ),
         other => panic!("expected InvalidProofError, got {:?}", other),

--- a/merk/src/proofs/query/aggregate_count_and_sum/tests.rs
+++ b/merk/src/proofs/query/aggregate_count_and_sum/tests.rs
@@ -473,9 +473,14 @@ fn combined_verifier_rejects_disjoint_leaf_with_children() {
     let bytes = encode_proof(&ops);
     let result = verify_aggregate_count_and_sum_on_range_proof(&bytes, &inner_range).unwrap();
     let err = result.expect_err("Disjoint HashWithCountAndSum with children must be rejected");
+    // Since issue #853 `Tree::attach` refuses to hang anything under an
+    // opaque node, so `execute` rejects this shape before the shape walk
+    // runs. The shape walk's own check is retained as defense in depth,
+    // so either message is an acceptable rejection.
     match err {
         Error::InvalidProofError(msg) => assert!(
-            msg.contains("Disjoint position must be a leaf"),
+            msg.contains("cannot have children")
+                || msg.contains("Disjoint position must be a leaf"),
             "unexpected message: {msg}"
         ),
         other => panic!("expected InvalidProofError, got {:?}", other),
@@ -513,9 +518,14 @@ fn combined_verifier_rejects_contained_leaf_with_children() {
     let bytes = encode_proof(&ops);
     let result = verify_aggregate_count_and_sum_on_range_proof(&bytes, &inner_range).unwrap();
     let err = result.expect_err("Contained HashWithCountAndSum with children must be rejected");
+    // Since issue #853 `Tree::attach` refuses to hang anything under an
+    // opaque node, so `execute` rejects this shape before the shape walk
+    // runs. The shape walk's own check is retained as defense in depth,
+    // so either message is an acceptable rejection.
     match err {
         Error::InvalidProofError(msg) => assert!(
-            msg.contains("Contained position must be a leaf"),
+            msg.contains("cannot have children")
+                || msg.contains("Contained position must be a leaf"),
             "unexpected message: {msg}"
         ),
         other => panic!("expected InvalidProofError, got {:?}", other),
@@ -551,9 +561,14 @@ fn combined_verifier_rejects_non_kvdigestcountsum_at_boundary() {
     let bytes = encode_proof(&ops);
     let result = verify_aggregate_count_and_sum_on_range_proof(&bytes, &inner_range).unwrap();
     let err = result.expect_err("non-KVDigestCountSum at Boundary must be rejected");
+    // Since issue #853 `Tree::attach` refuses to hang anything under an
+    // opaque node, so `execute` rejects this shape before the shape walk
+    // runs. The shape walk's own check is retained as defense in depth,
+    // so either message is an acceptable rejection.
     match err {
         Error::InvalidProofError(msg) => assert!(
-            msg.contains("expected KVDigestCountSum") && msg.contains("Boundary"),
+            msg.contains("cannot have children")
+                || (msg.contains("expected KVDigestCountSum") && msg.contains("Boundary")),
             "unexpected message: {msg}"
         ),
         other => panic!("expected InvalidProofError, got {:?}", other),
@@ -986,9 +1001,14 @@ fn combined_verifier_rejects_hashwithcountandsum_at_boundary_position() {
     let result = verify_aggregate_count_and_sum_on_range_proof(&bytes, &inner_range).unwrap();
     let err =
         result.expect_err("HashWithCountAndSum at a Boundary position must be rejected by Phase 2");
+    // Since issue #853 `Tree::attach` refuses to hang anything under an
+    // opaque node, so `execute` rejects this shape before the shape walk
+    // runs. The shape walk's own check is retained as defense in depth,
+    // so either message is an acceptable rejection.
     match err {
         Error::InvalidProofError(msg) => assert!(
-            msg.contains("expected KVDigestCountSum") && msg.contains("Boundary"),
+            msg.contains("cannot have children")
+                || (msg.contains("expected KVDigestCountSum") && msg.contains("Boundary")),
             "unexpected message: {msg}"
         ),
         other => panic!("expected InvalidProofError, got {:?}", other),

--- a/merk/src/proofs/query/aggregate_sum/tests.rs
+++ b/merk/src/proofs/query/aggregate_sum/tests.rs
@@ -316,9 +316,14 @@ fn shape_walk_rejects_disjoint_hashwithsum_with_children() {
     let bytes = encode_proof(&ops);
     let result = verify_aggregate_sum_on_range_proof(&bytes, &inner_range).unwrap();
     let err = result.expect_err("Disjoint HashWithSum with children must be rejected");
+    // Since issue #853 `Tree::attach` refuses to hang anything under an
+    // opaque node, so `execute` rejects this shape before the shape walk
+    // runs. The shape walk's own leaf assertion is retained as defense in
+    // depth, so either message is an acceptable rejection.
     match err {
         Error::InvalidProofError(msg) => assert!(
-            msg.contains("Disjoint position must be a leaf"),
+            msg.contains("cannot have children")
+                || msg.contains("Disjoint position must be a leaf"),
             "unexpected message: {msg}"
         ),
         other => panic!("expected InvalidProofError, got {:?}", other),
@@ -794,9 +799,14 @@ fn shape_walk_rejects_disjoint_hashwithcountandsum_with_children_pcps() {
     let result = verify_aggregate_sum_on_range_proof(&bytes, &inner_range).unwrap();
     let err = result
         .expect_err("spliced child under Disjoint HashWithCountAndSum (sum side) must be rejected");
+    // Since issue #853 `Tree::attach` refuses to hang anything under an
+    // opaque node, so `execute` rejects this shape before the shape walk
+    // runs. The shape walk's own leaf assertion is retained as defense in
+    // depth, so either message is an acceptable rejection.
     match err {
         Error::InvalidProofError(msg) => assert!(
-            msg.contains("Disjoint position must be a leaf")
+            msg.contains("cannot have children")
+                || msg.contains("Disjoint position must be a leaf")
                 || msg.contains("at a Disjoint position"),
             "unexpected message: {msg}"
         ),
@@ -1040,9 +1050,14 @@ fn shape_walk_rejects_contained_hashwithsum_with_children() {
     let bytes = encode_proof(&ops);
     let result = verify_aggregate_sum_on_range_proof(&bytes, &inner_range).unwrap();
     let err = result.expect_err("Contained HashWithSum with children must be rejected");
+    // Since issue #853 `Tree::attach` refuses to hang anything under an
+    // opaque node, so `execute` rejects this shape before the shape walk
+    // runs. The shape walk's own leaf assertion is retained as defense in
+    // depth, so either message is an acceptable rejection.
     match err {
         Error::InvalidProofError(msg) => assert!(
-            msg.contains("Contained position must be a leaf"),
+            msg.contains("cannot have children")
+                || msg.contains("Contained position must be a leaf"),
             "unexpected message: {msg}"
         ),
         other => panic!("expected InvalidProofError, got {:?}", other),
@@ -1082,9 +1097,14 @@ fn shape_walk_rejects_contained_hashwithcountandsum_with_children_pcps_sum() {
     let err = result.expect_err(
         "Contained HashWithCountAndSum with children must be rejected (sum side, dual-axis)",
     );
+    // Since issue #853 `Tree::attach` refuses to hang anything under an
+    // opaque node, so `execute` rejects this shape before the shape walk
+    // runs. The shape walk's own leaf assertion is retained as defense in
+    // depth, so either message is an acceptable rejection.
     match err {
         Error::InvalidProofError(msg) => assert!(
-            msg.contains("Contained position must be a leaf"),
+            msg.contains("cannot have children")
+                || msg.contains("Contained position must be a leaf"),
             "unexpected message: {msg}"
         ),
         other => panic!("expected InvalidProofError, got {:?}", other),
@@ -1121,9 +1141,14 @@ fn shape_walk_rejects_non_kvdigestsum_at_boundary() {
     let bytes = encode_proof(&ops);
     let result = verify_aggregate_sum_on_range_proof(&bytes, &inner_range).unwrap();
     let err = result.expect_err("non-KVDigestSum at Boundary must be rejected");
+    // Since issue #853 `Tree::attach` refuses to hang anything under an
+    // opaque node, so `execute` rejects this shape before the shape walk
+    // runs. The shape walk's own check is retained as defense in depth,
+    // so either message is an acceptable rejection.
     match err {
         Error::InvalidProofError(msg) => assert!(
-            msg.contains("expected KVDigestSum") && msg.contains("Boundary"),
+            msg.contains("cannot have children")
+                || (msg.contains("expected KVDigestSum") && msg.contains("Boundary")),
             "unexpected message: {msg}"
         ),
         other => panic!("expected InvalidProofError, got {:?}", other),

--- a/merk/src/proofs/query/merk_integration_tests.rs
+++ b/merk/src/proofs/query/merk_integration_tests.rs
@@ -4631,3 +4631,87 @@ fn test_boundaries_in_proof_multiple_ranges() {
         boundaries
     );
 }
+
+/// Regression for issue #853: a `Node::Hash` proof node commits only to the
+/// 32-byte hash it carries — `Tree::hash()` ignores any children that the
+/// `Parent`/`Child` ops hang beneath it. Before the fix a prover could
+/// therefore park a forged `KV` push under a collapsed `Hash` leaf: the
+/// verifier consumed the push (in push order, not tree order) and emitted it
+/// as a result row, while the root hash still matched the honest tree.
+///
+/// The proof below is for the honest 3-node tree `[3] <- [5] -> [7]` and
+/// claims key `[3]` holds `"forged"` while reusing the honest child hashes.
+#[test]
+fn test_forged_row_under_hash_node_is_rejected() {
+    let tree = make_3_node_tree();
+    let expected_root = tree.hash().unwrap();
+    let left_hash = *tree.child_hash(true);
+    let right_hash = *tree.child_hash(false);
+
+    let malicious = [
+        Op::Push(Node::Hash(left_hash)),
+        Op::Push(Node::KV(vec![3], b"forged".to_vec())),
+        // hangs the forged KV as the right child of the opaque Hash leaf
+        Op::Child,
+        Op::Push(Node::KV(vec![5], vec![5])),
+        Op::Parent,
+        Op::Push(Node::Hash(right_hash)),
+        Op::Child,
+    ];
+    let mut bytes = vec![];
+    encode_into(malicious.iter(), &mut bytes);
+
+    let mut query = Query::new();
+    query.insert_key(vec![3]);
+
+    let result = query
+        .verify_proof(bytes.as_slice(), None, true, expected_root)
+        .unwrap();
+    match result {
+        Err(Error::InvalidProofError(msg)) => {
+            assert!(
+                msg.contains("Hash"),
+                "expected the opaque-node childlessness error, got: {msg}"
+            );
+        }
+        Err(other) => panic!("expected InvalidProofError, got {other:?}"),
+        Ok(verified) => panic!(
+            "SECURITY BUG: forged row accepted under a Node::Hash: {:?}",
+            verified.result_set
+        ),
+    }
+}
+
+/// Same shape as [`test_forged_row_under_hash_node_is_rejected`] but the
+/// forged push is parked under the *right* collapsed subtree, using a key
+/// larger than every honest key so the push-ordering check is satisfied.
+#[test]
+fn test_forged_row_under_right_hash_node_is_rejected() {
+    let tree = make_3_node_tree();
+    let expected_root = tree.hash().unwrap();
+    let left_hash = *tree.child_hash(true);
+    let right_hash = *tree.child_hash(false);
+
+    let malicious = [
+        Op::Push(Node::Hash(left_hash)),
+        Op::Push(Node::KV(vec![5], vec![5])),
+        Op::Parent,
+        Op::Push(Node::Hash(right_hash)),
+        Op::Push(Node::KV(vec![9], b"forged".to_vec())),
+        Op::Child,
+        Op::Child,
+    ];
+    let mut bytes = vec![];
+    encode_into(malicious.iter(), &mut bytes);
+
+    let mut query = Query::new();
+    query.insert_key(vec![9]);
+
+    let result = query
+        .verify_proof(bytes.as_slice(), None, true, expected_root)
+        .unwrap();
+    assert!(
+        matches!(result, Err(Error::InvalidProofError(_))),
+        "forged row under a right-side Node::Hash must be rejected, got {result:?}"
+    );
+}

--- a/merk/src/proofs/tree.rs
+++ b/merk/src/proofs/tree.rs
@@ -465,11 +465,47 @@ impl Tree {
         }
     }
 
-    /// Attaches the child to the `Tree`'s given side. Panics if there is
-    /// already a child attached to this side.
+    /// Whether this node's hash is taken verbatim from (or recomputed
+    /// solely from) fields embedded in the node, ignoring any children
+    /// attached to the reconstructed proof tree.
+    ///
+    /// `Hash` carries a finished subtree hash; `HashWithCount`,
+    /// `HashWithSum` and `HashWithCountAndSum` carry the `(kv_hash, left,
+    /// right, ...)` inputs of a finished subtree hash. None of them consult
+    /// `self.left` / `self.right` in [`Tree::hash`], so a child hung beneath
+    /// one would be invisible to the root-hash check.
+    #[cfg(any(feature = "minimal", feature = "verify"))]
+    pub const fn is_opaque(&self) -> bool {
+        matches!(
+            self.node,
+            Node::Hash(_)
+                | Node::HashWithCount(..)
+                | Node::HashWithSum(..)
+                | Node::HashWithCountAndSum(..)
+        )
+    }
+
+    /// Attaches the child to the `Tree`'s given side. Errors if there is
+    /// already a child attached to this side, or if this node is opaque.
+    ///
+    /// Opaque nodes (see [`Tree::is_opaque`]) must stay childless: their
+    /// hash excludes reconstructed children, so anything attached beneath
+    /// them is unauthenticated data that the root-hash check can never
+    /// catch. Query verification consumes pushes in push order and chunk
+    /// restoration walks the reconstructed tree, so without this rule a
+    /// prover could smuggle forged rows into results or storage under a
+    /// hash that still matches the honest root (issue #853).
     #[cfg(any(feature = "minimal", feature = "verify"))]
     pub(crate) fn attach(&mut self, left: bool, child: Self) -> CostResult<(), Error> {
         let mut cost = OperationCost::default();
+
+        if self.is_opaque() {
+            return Err(Error::InvalidProofError(format!(
+                "opaque proof node {} cannot have children: its hash excludes them",
+                self.node
+            )))
+            .wrap_with_cost(cost);
+        }
 
         if self.child(left).is_some() {
             return Err(Error::CorruptedCodeExecution(
@@ -950,6 +986,50 @@ mod test {
         recurse(&tree, 3);
     }
 
+    /// Issue #853: opaque nodes (those whose `hash()` ignores reconstructed
+    /// children) must stay childless, otherwise a prover can hang
+    /// unauthenticated data beneath them without disturbing the root hash.
+    #[test]
+    fn attach_to_opaque_node_is_rejected() {
+        let child = || -> ProofTree { Node::KV(vec![1], vec![1]).into() };
+        let opaque_parents: Vec<ProofTree> = vec![
+            Node::Hash([0; 32]).into(),
+            Node::HashWithCount([0; 32], [0; 32], [0; 32], 1).into(),
+            Node::HashWithSum([0; 32], [0; 32], [0; 32], 1).into(),
+            Node::HashWithCountAndSum([0; 32], [0; 32], [0; 32], 1, 1).into(),
+        ];
+        for mut parent in opaque_parents {
+            let node = parent.node.clone();
+            for left in [true, false] {
+                let result = parent.attach(left, child()).unwrap();
+                assert!(
+                    matches!(result, Err(Error::InvalidProofError(_))),
+                    "attaching a child to {node} must fail, got {result:?}"
+                );
+                assert!(
+                    parent.left.is_none() && parent.right.is_none(),
+                    "{node} must remain childless after a rejected attach"
+                );
+            }
+        }
+    }
+
+    /// `KVHash`-family nodes hash their children, so they legitimately take
+    /// children — the childlessness rule must not over-reach.
+    #[test]
+    fn attach_to_kvhash_node_is_allowed() {
+        let mut parent: ProofTree = Node::KVHash([0; 32]).into();
+        parent
+            .attach(true, Node::KV(vec![1], vec![1]).into())
+            .unwrap()
+            .expect("KVHash takes a left child");
+        parent
+            .attach(false, Node::KV(vec![2], vec![2]).into())
+            .unwrap()
+            .expect("KVHash takes a right child");
+        assert_eq!(parent.height, 2);
+    }
+
     #[test]
     fn layer_iter() {
         let tree = make_7_node_prooftree();
@@ -1347,21 +1427,26 @@ mod test {
         );
     }
 
+    // NOTE (issue #853): the resource-limit tests below build synthetic
+    // chains out of `KVHash` nodes. `KVHash` is keyless (no ordering
+    // constraint) and hashes its children, so it may take children;
+    // opaque `Hash` nodes may not, and `attach` rejects them.
+
     /// Verifies SEC-005 fix: execute() now rejects proofs that exceed
     /// MAX_PROOF_OPS operations.
     ///
-    /// Uses alternating Push(Hash)/Parent pairs to keep the stack depth at
+    /// Uses alternating Push(KVHash)/Parent pairs to keep the stack depth at
     /// 1 while exceeding the total operation count limit.
     #[test]
     fn attack_operation_count_is_limited() {
         let n = super::MAX_PROOF_OPS + 1;
         let mut ops: Vec<Result<Op, Error>> = Vec::with_capacity(n);
-        // Seed with one Hash node
-        ops.push(Ok(Op::Push(Node::Hash([0xAA; 32]))));
+        // Seed with one KVHash node
+        ops.push(Ok(Op::Push(Node::KVHash([0xAA; 32]))));
         // Each (Push, Parent) pair = 2 ops, stack stays at depth 1.
         // The new Hash becomes the parent, the existing tree its left child.
         while ops.len() < n {
-            ops.push(Ok(Op::Push(Node::Hash([0xAA; 32]))));
+            ops.push(Ok(Op::Push(Node::KVHash([0xAA; 32]))));
             ops.push(Ok(Op::Parent));
         }
 
@@ -1400,9 +1485,9 @@ mod test {
         // height reaches 130, exceeding MAX_PROOF_TREE_HEIGHT (128).
         let depth = super::MAX_PROOF_TREE_HEIGHT + 2;
         let mut ops: Vec<Result<Op, Error>> = Vec::new();
-        ops.push(Ok(Op::Push(Node::Hash([0xCC; 32]))));
+        ops.push(Ok(Op::Push(Node::KVHash([0xCC; 32]))));
         for _ in 1..depth {
-            ops.push(Ok(Op::Push(Node::Hash([0xCC; 32]))));
+            ops.push(Ok(Op::Push(Node::KVHash([0xCC; 32]))));
             ops.push(Ok(Op::Parent));
         }
 
@@ -1436,9 +1521,9 @@ mod test {
         let ops_per_chain = 2 * (max_height - 1) - 1;
         while ops.len() + ops_per_chain < max_ops && current_stack_depth < max_stack {
             // Build one chain of height max_height - 1
-            ops.push(Ok(Op::Push(Node::Hash([0xDD; 32]))));
+            ops.push(Ok(Op::Push(Node::KVHash([0xDD; 32]))));
             for _ in 1..(max_height - 1) {
-                ops.push(Ok(Op::Push(Node::Hash([0xDD; 32]))));
+                ops.push(Ok(Op::Push(Node::KVHash([0xDD; 32]))));
                 ops.push(Ok(Op::Parent));
             }
             current_stack_depth += 1;
@@ -1447,12 +1532,12 @@ mod test {
         // Step 2: fill remaining op budget with bare Push(Hash) ops,
         // growing the stack further.
         while ops.len() < max_ops && current_stack_depth < max_stack {
-            ops.push(Ok(Op::Push(Node::Hash([0xEE; 32]))));
+            ops.push(Ok(Op::Push(Node::KVHash([0xEE; 32]))));
             current_stack_depth += 1;
         }
 
         // Step 3: one more Push to exceed whichever limit is tighter.
-        ops.push(Ok(Op::Push(Node::Hash([0xFF; 32]))));
+        ops.push(Ok(Op::Push(Node::KVHash([0xFF; 32]))));
 
         let result = execute(ops.into_iter(), true, |_| Ok(())).unwrap();
         assert!(
@@ -1480,9 +1565,9 @@ mod test {
         // With collapse=true, height stays at 2.
         {
             let mut ops: Vec<Result<Op, Error>> = Vec::new();
-            ops.push(Ok(Op::Push(Node::Hash([0xAA; 32]))));
+            ops.push(Ok(Op::Push(Node::KVHash([0xAA; 32]))));
             for _ in 0..24_999 {
-                ops.push(Ok(Op::Push(Node::Hash([0xAA; 32]))));
+                ops.push(Ok(Op::Push(Node::KVHash([0xAA; 32]))));
                 ops.push(Ok(Op::Parent));
             }
             assert_eq!(ops.len(), 49_999);
@@ -1500,7 +1585,7 @@ mod test {
         {
             let mut ops: Vec<Result<Op, Error>> = Vec::new();
             for _ in 0..10_000 {
-                ops.push(Ok(Op::Push(Node::Hash([0xBB; 32]))));
+                ops.push(Ok(Op::Push(Node::KVHash([0xBB; 32]))));
             }
             // Combine 10,000 → 1: first Parent, then (Child, Parent) pairs
             ops.push(Ok(Op::Parent));
@@ -1524,18 +1609,18 @@ mod test {
             let max_height = super::MAX_PROOF_TREE_HEIGHT; // 92
             let mut ops: Vec<Result<Op, Error>> = Vec::new();
             // Build left chain of height max_height - 1
-            ops.push(Ok(Op::Push(Node::Hash([0xCC; 32]))));
+            ops.push(Ok(Op::Push(Node::KVHash([0xCC; 32]))));
             for _ in 0..(max_height - 2) {
-                ops.push(Ok(Op::Push(Node::Hash([0xCC; 32]))));
+                ops.push(Ok(Op::Push(Node::KVHash([0xCC; 32]))));
                 ops.push(Ok(Op::Parent));
             }
             // Push root and attach left child
-            ops.push(Ok(Op::Push(Node::Hash([0xDD; 32]))));
+            ops.push(Ok(Op::Push(Node::KVHash([0xDD; 32]))));
             ops.push(Ok(Op::Parent));
             // Build right chain of height max_height - 1
-            ops.push(Ok(Op::Push(Node::Hash([0xEE; 32]))));
+            ops.push(Ok(Op::Push(Node::KVHash([0xEE; 32]))));
             for _ in 0..(max_height - 2) {
-                ops.push(Ok(Op::Push(Node::Hash([0xEE; 32]))));
+                ops.push(Ok(Op::Push(Node::KVHash([0xEE; 32]))));
                 ops.push(Ok(Op::Parent));
             }
             // Attach right child


### PR DESCRIPTION
Fixes #853.

## Problem

`Node::Hash`, `HashWithCount`, `HashWithSum` and `HashWithCountAndSum` compute their hash from embedded fields only. `Tree::attach` nevertheless let `Parent`/`Child` ops hang children beneath them, and nothing rejected the resulting shape:

- the query verifier consumes pushes in push order, so a forged `KV` parked under a collapsed `Hash` leaf was emitted as a result row while the root hash still matched the honest tree;
- the chunk restorer walks the reconstructed tree, so the same shape wrote an unauthenticated row into storage.

Both were reproduced at runtime (new tests fail on `develop`): a proof for the honest 3-node tree `[3] <- [5] -> [7]` verifies against the honest root while claiming key `3` holds `"forged"`.

## Fix

`Tree::attach` now refuses to attach anything beneath an opaque node (`Tree::is_opaque`), so every consumer of `execute` inherits the rule: query verification, chunk restore, branch proofs and the aggregate verifiers. The aggregate verifiers' own leaf-shape checks are retained as defense in depth.

No version gate: honest provers never emit an opaque node with children, so no legitimate proof changes acceptance. The merk `execute` path is shared by V0 and V1 and no wire format changes.

## Tests

- `test_forged_row_under_hash_node_is_rejected` / `..._right_hash_node_...`: forged row under a `Hash` node in a query proof.
- `test_forged_kv_under_hash_boundary_node_is_rejected`: forged `KV` under a `Hash` boundary in a restore chunk; nothing reaches storage.
- `attach_to_opaque_node_is_rejected` / `attach_to_kvhash_node_is_allowed`.
- Existing shape-walk tests that spliced children under opaque leaves now accept the earlier `attach` rejection; the proof resource-limit tests build their synthetic chains from `KVHash` instead of `Hash`.

Docs: recorded the invariant in `docs/merk-deep-dive.md` and the book's proof-system chapter.

Local run: merk 726/726, grovedb 2994/2994, rest of workspace 2201/2201 (all-features minus `grovedbg`, whose build script needs network here). Clippy under a local clippy 1.97 reports lints in files this PR does not touch (CI's toolchain is clean); no lints in the changed regions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

