### PR TITLE
fix: references commit to the terminal's stored bytes on every path (#858)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renamed `prove_internal` to `prove_query_non_serialized` for clarity (#373)
 
 ### Fixed
-- A reference whose terminal is a `NonCounted`-wrapped item now commits to the terminal's stored bytes (wrapper included) on every path. Direct insert (`GROVE_V4`+, `add_element_on_transaction: 2`), `verify_grovedb` and the V1 prover use the new commitment-preserving `follow_reference_as_stored`, matching what the batch resolver always hashed; `follow_reference` stays the looked-through presentation read. Offset-paginated proof rows resolved through a reference may surface the wrapped target (`CountOffsetReturnedItem::resolved_from_reference`) (#858)
+- Direct and batch references to `NonCounted`-wrapped items now commit to identical stored terminal bytes on `GROVE_V4` (`add_element_on_transaction: 2`). `verify_grovedb` and V1 proof generation select the terminal representation matching each reference's stored commitment, preserving older direct-write hashes across upgrades. Offset-paginated proof rows resolved through a reference may surface the wrapped target (`CountOffsetReturnedItem::resolved_from_reference`) (#858)
 - Corrected proof verification logic in GroveDb (#371)
 - Added ASCII check before appending string to hex display for better visualization (#376)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renamed `prove_internal` to `prove_query_non_serialized` for clarity (#373)
 
 ### Fixed
+- A reference whose terminal is a `NonCounted`-wrapped item now commits to the terminal's stored bytes (wrapper included) on every path. Direct insert (`GROVE_V4`+, `add_element_on_transaction: 2`), `verify_grovedb` and the V1 prover use the new commitment-preserving `follow_reference_as_stored`, matching what the batch resolver always hashed; `follow_reference` stays the looked-through presentation read. Offset-paginated proof rows resolved through a reference may surface the wrapped target (`CountOffsetReturnedItem::resolved_from_reference`) (#858)
 - Corrected proof verification logic in GroveDb (#371)
 - Added ASCII check before appending string to hex display for better visualization (#376)
 

--- a/docs/book/src/reference-system.md
+++ b/docs/book/src/reference-system.md
@@ -287,10 +287,17 @@ GroveDB exposes two resolvers over the same loop:
 
 The distinction matters because a reference node's `value_hash` combines the
 hash of the reference's own bytes with the hash of the terminal's **stored**
-bytes (see below). Every producer or checker of that hash — direct insert on
-`GROVE_V4`+, the batch reference resolver, `verify_grovedb`, and the V1 prover —
-uses the stored form, so a reference written directly and the same reference
+bytes (see below). Direct insert on `GROVE_V4`+ and the batch reference resolver
+use the stored form, so a reference written directly and the same reference
 applied in a batch commit the same root and verify with the same proof.
+
+References written directly before `GROVE_V4` committed to the unwrapped
+terminal instead. Those existing commitments remain valid: the V1 prover
+(including paginated proofs) and `verify_grovedb` select the unwrapped terminal
+only if its combined hash matches the reference node's stored commitment.
+Otherwise they use the stored terminal. This works for mixed write histories
+and after an upgrade without rewriting data or changing roots. A changed
+terminal that matches neither representation still fails verification.
 
 ## Cycle Detection
 

--- a/docs/book/src/reference-system.md
+++ b/docs/book/src/reference-system.md
@@ -273,6 +273,25 @@ pub fn follow_reference(...) -> CostResult<ResolvedReference, Error> {
 }
 ```
 
+### Presentation vs. commitment
+
+GroveDB exposes two resolvers over the same loop:
+
+- `follow_reference` — the **presentation** read used by `get` and queries. The
+  terminal is returned looked-through: a `NonCounted`-wrapped item comes back as
+  the inner item.
+- `follow_reference_as_stored` — the **commitment-preserving** read. The terminal
+  is returned exactly as stored, wrapper included. Wrappers are still looked
+  through to decide whether to keep hopping (a `NonCounted(Reference)` is
+  followed), but they are never stripped from the terminal.
+
+The distinction matters because a reference node's `value_hash` combines the
+hash of the reference's own bytes with the hash of the terminal's **stored**
+bytes (see below). Every producer or checker of that hash — direct insert on
+`GROVE_V4`+, the batch reference resolver, `verify_grovedb`, and the V1 prover —
+uses the stored form, so a reference written directly and the same reference
+applied in a batch commit the same root and verify with the same proof.
+
 ## Cycle Detection
 
 The `visited` HashSet tracks all paths we've seen. If we encounter a path we've

--- a/grovedb-version/src/version/v4.rs
+++ b/grovedb-version/src/version/v4.rs
@@ -331,11 +331,13 @@ pub const GROVE_V4: GroveVersion = GroveVersion {
                 insert: 0,
                 insert_on_transaction: 0,
                 insert_without_transaction: 0,
-                // v1: non-batch insert writes CountSumTree / ProvableCountTree /
-                // ProvableCountSumTree as layered subtrees, consistent with the
-                // batch path. GROVE_V1 / GROVE_V2 keep v0 (Op::Put) to preserve
-                // the protocol-v11 consensus root (testnet block 245,344).
-                add_element_on_transaction: 1,
+                // v2: a directly inserted Reference binds the value hash of its
+                // terminal's STORED bytes (wrapper included for a NonCounted
+                // terminal), matching what the batch reference resolver has
+                // always committed to. v1 (GROVE_V3) hashed the looked-through
+                // terminal, so direct and batch writes of the same reference
+                // disagreed on the root (issue #858).
+                add_element_on_transaction: 2,
                 add_element_without_transaction: 0,
                 insert_if_not_exists: 0,
                 insert_if_not_exists_return_existing_element: 0,

--- a/grovedb/src/lib.rs
+++ b/grovedb/src/lib.rs
@@ -2703,18 +2703,15 @@ impl GroveDb {
                             hex_to_ascii(&key)
                         )))?;
 
+                    let self_actual_value_hash = value_hash(&kv_value).unwrap();
                     let referenced_value_hash = {
                         let full_path = path_from_reference_path_type(
                             reference_path.clone(),
                             &path.to_vec(),
                             Some(&key),
                         )?;
-                        // Commitment-preserving: the reference binds its
-                        // terminal's stored bytes, wrapper included (the
-                        // same representation the batch resolver and the
-                        // V1 prover use). Looking through the wrapper here
-                        // would report every batch-written reference to a
-                        // NonCounted item as corrupt.
+                        // Resolve the stored terminal, then preserve whichever
+                        // representation this existing reference committed to.
                         let item = self
                             .follow_reference_as_stored(
                                 (full_path.as_slice()).into(),
@@ -2723,12 +2720,17 @@ impl GroveDb {
                                 grove_version,
                             )
                             .unwrap()?;
+                        let item = Self::reference_terminal_as_committed(
+                            item,
+                            &self_actual_value_hash,
+                            &element_value_hash,
+                            grove_version,
+                        )
+                        .unwrap()?;
                         item.value_hash(grove_version).unwrap()?
                     };
 
-                    // Take the current item (reference) hash and combine it with referenced value's
-                    // hash
-                    let self_actual_value_hash = value_hash(&kv_value).unwrap();
+                    // Check the commitment without rewriting the stored reference.
                     let combined_value_hash =
                         combine_hash(&self_actual_value_hash, &referenced_value_hash).unwrap();
 

--- a/grovedb/src/lib.rs
+++ b/grovedb/src/lib.rs
@@ -2709,8 +2709,14 @@ impl GroveDb {
                             &path.to_vec(),
                             Some(&key),
                         )?;
+                        // Commitment-preserving: the reference binds its
+                        // terminal's stored bytes, wrapper included (the
+                        // same representation the batch resolver and the
+                        // V1 prover use). Looking through the wrapper here
+                        // would report every batch-written reference to a
+                        // NonCounted item as corrupt.
                         let item = self
-                            .follow_reference(
+                            .follow_reference_as_stored(
                                 (full_path.as_slice()).into(),
                                 allow_cache,
                                 Some(transaction),

--- a/grovedb/src/operations/get/mod.rs
+++ b/grovedb/src/operations/get/mod.rs
@@ -108,10 +108,45 @@ impl GroveDb {
         }
     }
 
-    /// Return the Element that a reference points to.
+    /// Return the Element that a reference points to, **for presentation**.
     /// If the reference points to another reference, keep following until
     /// base element is reached.
+    ///
+    /// The terminal is returned looked-through: a `NonCounted`-wrapped
+    /// terminal comes back as its inner element, which is what `get` /
+    /// query callers want. Anything that must reproduce the reference's
+    /// *commitment* — the hash a reference node binds — must use
+    /// [`Self::follow_reference_as_stored`] instead: the commitment is the
+    /// terminal's stored bytes, wrapper included, and hashing the unwrapped
+    /// element yields a different value.
     pub fn follow_reference<B: AsRef<[u8]>>(
+        &self,
+        path: SubtreePath<B>,
+        allow_cache: bool,
+        transaction: TransactionArg,
+        grove_version: &GroveVersion,
+    ) -> CostResult<Element, Error> {
+        self.follow_reference_as_stored(path, allow_cache, transaction, grove_version)
+            .map_ok(Element::into_underlying)
+    }
+
+    /// Return the terminal Element of a reference chain **exactly as it is
+    /// stored**, i.e. commitment-preserving.
+    ///
+    /// Wrappers are looked through only to decide whether to keep hopping
+    /// (a `NonCounted(Reference)` is followed like a bare `Reference`); the
+    /// terminal itself is returned with its wrapper intact. This is the
+    /// element whose serialized bytes hash to the merk-stored `value_hash`
+    /// of the terminal node, so `terminal.value_hash()` is the value a
+    /// reference node must combine into its own hash. The batch reference
+    /// resolver (`process_reference` in `batch/mod.rs`) commits to the same
+    /// representation — it either reads the terminal's stored value hash
+    /// directly or hashes the outer element's bytes — so direct writes,
+    /// batch writes, `verify_grovedb` and proof generation all agree.
+    ///
+    /// Use [`Self::follow_reference`] when the caller only needs the value
+    /// the reference denotes.
+    pub fn follow_reference_as_stored<B: AsRef<[u8]>>(
         &self,
         path: SubtreePath<B>,
         allow_cache: bool,
@@ -169,17 +204,22 @@ impl GroveDb {
             // Look through `NonCounted` so a chain that hops via a wrapped
             // reference is followed instead of being returned as a value.
             // `ReferenceWithSumItem` is also followed — the carried sum is
-            // irrelevant to chain destination.
-            match current_element.into_underlying() {
+            // irrelevant to chain destination. The terminal is handed back
+            // untouched (wrapper and all): it is the stored element.
+            let next_hop = match current_element.underlying() {
                 Element::Reference(reference_path, ..)
-                | Element::ReferenceWithSumItem(reference_path, ..) => {
+                | Element::ReferenceWithSumItem(reference_path, ..) => Some(reference_path.clone()),
+                _ => None,
+            };
+            match next_hop {
+                Some(reference_path) => {
                     current_path = cost_return_on_error_into!(
                         &mut cost,
                         path_from_reference_qualified_path_type(reference_path, &current_path)
                             .wrap_with_cost(OperationCost::default())
                     )
                 }
-                other => return Ok(other).wrap_with_cost(cost),
+                None => return Ok(current_element).wrap_with_cost(cost),
             }
             hops_left -= 1;
         }

--- a/grovedb/src/operations/get/mod.rs
+++ b/grovedb/src/operations/get/mod.rs
@@ -18,7 +18,12 @@ use grovedb_costs::{
     cost_return_on_error, cost_return_on_error_into, cost_return_on_error_no_add, CostResult,
     CostsExt, OperationCost,
 };
-use grovedb_merk::{element::get::ElementFetchFromStorageExtensions, error::MerkErrorExt};
+use grovedb_merk::{
+    element::{get::ElementFetchFromStorageExtensions, ElementExt},
+    error::MerkErrorExt,
+    tree::combine_hash,
+    CryptoHash,
+};
 use grovedb_path::SubtreePath;
 use grovedb_storage::StorageContext;
 use grovedb_version::{check_grovedb_v0_with_cost, version::GroveVersion};
@@ -115,10 +120,10 @@ impl GroveDb {
     /// The terminal is returned looked-through: a `NonCounted`-wrapped
     /// terminal comes back as its inner element, which is what `get` /
     /// query callers want. Anything that must reproduce the reference's
-    /// *commitment* — the hash a reference node binds — must use
-    /// [`Self::follow_reference_as_stored`] instead: the commitment is the
-    /// terminal's stored bytes, wrapper included, and hashing the unwrapped
-    /// element yields a different value.
+    /// *commitment* — the hash a reference node binds — must start with
+    /// [`Self::follow_reference_as_stored`] instead. GROVE_V4 writes commit to
+    /// the terminal's stored bytes, wrapper included. Readers of existing nodes
+    /// must also account for legacy direct writes that hashed the inner value.
     pub fn follow_reference<B: AsRef<[u8]>>(
         &self,
         path: SubtreePath<B>,
@@ -141,8 +146,11 @@ impl GroveDb {
     /// reference node must combine into its own hash. The batch reference
     /// resolver (`process_reference` in `batch/mod.rs`) commits to the same
     /// representation — it either reads the terminal's stored value hash
-    /// directly or hashes the outer element's bytes — so direct writes,
-    /// batch writes, `verify_grovedb` and proof generation all agree.
+    /// directly or hashes the outer element's bytes. Direct writes on GROVE_V4
+    /// use that representation too. Proof generation and integrity checks
+    /// additionally select the legacy unwrapped representation when it matches
+    /// an existing reference's committed hash; the current read version does
+    /// not identify which write path originally produced the node.
     ///
     /// Use [`Self::follow_reference`] when the caller only needs the value
     /// the reference denotes.
@@ -224,6 +232,35 @@ impl GroveDb {
             hops_left -= 1;
         }
         Err(Error::ReferenceLimit).wrap_with_cost(cost)
+    }
+
+    /// Select the terminal representation bound by an existing reference.
+    ///
+    /// Pre-V4 direct writes hashed the unwrapped terminal, while batch writes
+    /// and V4 direct writes hash its stored bytes. Both can coexist, even after
+    /// an upgrade, so select the legacy form only when its combined hash matches
+    /// the reference's actual commitment. Otherwise retain the stored form:
+    /// callers still detect a stale reference if neither representation matches.
+    /// This is a read-side compatibility step and must not be used for writes.
+    pub(crate) fn reference_terminal_as_committed(
+        terminal: Element,
+        reference_element_hash: &CryptoHash,
+        committed_value_hash: &CryptoHash,
+        grove_version: &GroveVersion,
+    ) -> CostResult<Element, Error> {
+        let mut cost = OperationCost::default();
+        if terminal.is_wrapped() {
+            let legacy_terminal_hash = cost_return_on_error_into!(
+                &mut cost,
+                terminal.underlying().value_hash(grove_version)
+            );
+            let legacy_commitment = combine_hash(reference_element_hash, &legacy_terminal_hash)
+                .unwrap_add_cost(&mut cost);
+            if &legacy_commitment == committed_value_hash {
+                return Ok(terminal.into_underlying()).wrap_with_cost(cost);
+            }
+        }
+        Ok(terminal).wrap_with_cost(cost)
     }
 
     /// Get Element at specified path and key

--- a/grovedb/src/operations/insert/add_element_on_transaction/mod.rs
+++ b/grovedb/src/operations/insert/add_element_on_transaction/mod.rs
@@ -13,18 +13,25 @@
 //!   `ProvableCountSumTree` are written as a plain value (`Op::Put`). This is the
 //!   behaviour frozen into the live protocol-v11 activation chain (testnet block
 //!   245,344, `transition_to_version_11`). Selected by `GROVE_V1` / `GROVE_V2`.
-//! * **[v1]** — current behaviour. Those three types are written as layered
-//!   subtrees, consistent with the batch insert path (both root hash and fee).
-//!   Selected by `GROVE_V3`+.
+//! * **[v1]** — Those three types are written as layered subtrees, consistent
+//!   with the batch insert path (both root hash and fee). Selected by
+//!   `GROVE_V3`.
+//! * **[v2]** — current behaviour. As v1, but a `Reference` binds the value
+//!   hash of its terminal's **stored** bytes (wrapper included for a
+//!   `NonCounted`-wrapped terminal), matching the batch reference resolver.
+//!   v1 hashed the looked-through terminal, so a directly inserted reference
+//!   to a wrapped item committed a different root than the same reference
+//!   applied in a batch (issue #858). Selected by `GROVE_V4`+.
 //!
-//! The two implementations are otherwise identical; the only difference is which
-//! match arm those three element types fall into. See [v0] / [v1].
+//! The implementations are otherwise identical. See [v0] / [v1] / [v2].
 //!
 //! [v0]: self::v0
 //! [v1]: self::v1
+//! [v2]: self::v2
 
 mod v0;
 mod v1;
+mod v2;
 
 use grovedb_costs::{CostResult, CostsExt, OperationCost};
 use grovedb_merk::Merk;
@@ -77,10 +84,19 @@ impl GroveDb {
                 batch,
                 grove_version,
             ),
+            2 => self.add_element_on_transaction_v2(
+                path,
+                key,
+                element,
+                options,
+                transaction,
+                batch,
+                grove_version,
+            ),
             version => Err(
                 grovedb_version::error::GroveVersionError::UnknownVersionMismatch {
                     method: "add_element_on_transaction".to_string(),
-                    known_versions: vec![0, 1],
+                    known_versions: vec![0, 1, 2],
                     received: version,
                 }
                 .into(),

--- a/grovedb/src/operations/insert/add_element_on_transaction/v2.rs
+++ b/grovedb/src/operations/insert/add_element_on_transaction/v2.rs
@@ -1,0 +1,774 @@
+//! `add_element_on_transaction` — **v2** (current behaviour, `GROVE_V4`+).
+//!
+//! Identical to [`super::v1`] except for how a `Reference` /
+//! `ReferenceWithSumItem` computes the value hash it binds: the terminal of
+//! the chain is resolved with `follow_reference_as_stored`, so the hash is
+//! taken over the terminal's **stored** bytes — wrapper included when the
+//! terminal is a `NonCounted`-wrapped item. That is the representation the
+//! batch reference resolver has always committed to (it reads the terminal's
+//! merk value hash, or hashes the outer element), so from v2 on a reference
+//! written directly and the same reference written through `apply_batch`
+//! produce the same root, pass `verify_grovedb`, and verify in V1 proofs.
+//!
+//! v1 resolved the terminal with the presentation-oriented `follow_reference`,
+//! which looks through the wrapper before hashing; for a wrapped terminal that
+//! bakes `H(inner)` instead of `H(NonCounted(inner))` into the reference node.
+//! `GROVE_V3` is live, so v1 keeps that behaviour (issue #858).
+
+use grovedb_costs::{
+    cost_return_on_error, cost_return_on_error_into, cost_return_on_error_no_add, CostResult,
+    CostsExt, OperationCost,
+};
+use grovedb_element::reference_path::path_from_reference_path_type;
+use grovedb_merk::{
+    element::{
+        costs::ElementCostExtensions, exists::ElementExistsInStorageExtensions,
+        get::ElementFetchFromStorageExtensions, insert::ElementInsertToStorageExtensions,
+        ElementExt,
+    },
+    tree::NULL_HASH,
+    tree_type::TreeType,
+    Merk,
+};
+use grovedb_path::SubtreePath;
+use grovedb_storage::{rocksdb_storage::PrefixedRocksDbTransactionContext, StorageBatch};
+use grovedb_version::version::GroveVersion;
+
+use super::super::InsertOptions;
+use crate::{Element, Error, GroveDb, Transaction};
+
+impl GroveDb {
+    /// `add_element_on_transaction` v1 — see the module documentation.
+    pub(crate) fn add_element_on_transaction_v2<'db, B: AsRef<[u8]>>(
+        &'db self,
+        path: SubtreePath<B>,
+        key: &[u8],
+        element: Element,
+        options: InsertOptions,
+        transaction: &'db Transaction,
+        batch: &'db StorageBatch,
+        grove_version: &GroveVersion,
+    ) -> CostResult<Merk<PrefixedRocksDbTransactionContext<'db>>, Error> {
+        let mut cost = OperationCost::default();
+
+        let mut subtree_to_insert_into = cost_return_on_error!(
+            &mut cost,
+            self.open_transactional_merk_at_path(
+                path.clone(),
+                transaction,
+                Some(batch),
+                grove_version
+            )
+        );
+        // if we don't allow a tree override then we should check
+
+        if options.checks_for_override() {
+            let maybe_element_bytes = cost_return_on_error!(
+                &mut cost,
+                subtree_to_insert_into
+                    .get(
+                        key,
+                        true,
+                        Some(&Element::value_defined_cost_for_serialized_value),
+                        grove_version,
+                    )
+                    .map_err(|e| Error::CorruptedData(e.to_string()))
+            );
+            if let Some(element_bytes) = maybe_element_bytes {
+                if options.validate_insertion_does_not_override {
+                    return Err(Error::OverrideNotAllowed(
+                        "insertion not allowed to override",
+                    ))
+                    .wrap_with_cost(cost);
+                }
+                if options.validate_insertion_does_not_override_tree {
+                    let element = cost_return_on_error_no_add!(
+                        cost,
+                        Element::deserialize(element_bytes.as_slice(), grove_version).map_err(
+                            |_| {
+                                Error::CorruptedData(String::from("unable to deserialize element"))
+                            }
+                        )
+                    );
+                    if element.is_any_tree() {
+                        return Err(Error::OverrideNotAllowed(
+                            "insertion not allowed to override tree",
+                        ))
+                        .wrap_with_cost(cost);
+                    }
+                }
+            }
+        }
+
+        // Dispatch via the underlying element so a NonCounted wrapper takes
+        // the same path as its inner element. The actual `element.insert*`
+        // calls operate on the outer wrapper, which is what we want — the
+        // serialized wrapper bytes go to storage.
+        match element.underlying() {
+            // `ReferenceWithSumItem` shares the reference resolution + proof
+            // shape with `Reference`. The merk feature_type derived from the
+            // element's `sum_value_or_default()` already routes the sum into
+            // any sum-bearing parent; the call site is otherwise identical.
+            Element::Reference(reference_path, ..)
+            | Element::ReferenceWithSumItem(reference_path, ..) => {
+                let path = path.to_vec(); // TODO: need for support for references in path library
+                let reference_path = cost_return_on_error_into!(
+                    &mut cost,
+                    path_from_reference_path_type(reference_path.clone(), &path, Some(key))
+                        .wrap_with_cost(OperationCost::default())
+                );
+
+                // Commitment-preserving resolution: the reference binds the
+                // terminal's stored bytes, wrapper included. This is what
+                // the batch path commits to as well — see the module docs.
+                let referenced_item = cost_return_on_error!(
+                    &mut cost,
+                    self.follow_reference_as_stored(
+                        reference_path.as_slice().into(),
+                        false,
+                        Some(transaction),
+                        grove_version
+                    )
+                );
+
+                let referenced_element_value_hash = cost_return_on_error_into!(
+                    &mut cost,
+                    referenced_item.value_hash(grove_version)
+                );
+
+                cost_return_on_error_into!(
+                    &mut cost,
+                    element.insert_reference(
+                        &mut subtree_to_insert_into,
+                        key,
+                        referenced_element_value_hash,
+                        Some(options.as_merk_options()),
+                        grove_version,
+                    )
+                );
+            }
+            // v1: all tree types — including `CountSumTree` / `ProvableCountTree`
+            // / `ProvableCountSumTree` — are written as layered subtrees. This is
+            // the behaviour selected by `GROVE_V3`+; for `GROVE_V1` / `GROVE_V2`
+            // those three types take the plain-value `Op::Put` arm in
+            // [`super::v0`] instead, to preserve the protocol-v11 consensus root.
+            Element::Tree(value, _)
+            | Element::SumTree(value, ..)
+            | Element::BigSumTree(value, ..)
+            | Element::CountTree(value, ..)
+            | Element::CountSumTree(value, ..)
+            | Element::ProvableCountTree(value, ..)
+            | Element::ProvableCountSumTree(value, ..)
+            | Element::ProvableSumTree(value, ..)
+            | Element::ProvableCountProvableSumTree(value, ..) => {
+                if value.is_some() {
+                    return Err(Error::InvalidCodeExecution(
+                        "a tree should be empty at the moment of insertion when not using batches",
+                    ))
+                    .wrap_with_cost(cost);
+                } else {
+                    cost_return_on_error_into!(
+                        &mut cost,
+                        element.insert_subtree(
+                            &mut subtree_to_insert_into,
+                            key,
+                            NULL_HASH,
+                            Some(options.as_merk_options()),
+                            grove_version
+                        )
+                    );
+                }
+            }
+            // CommitmentTree uses BulkAppendTree internally; the initial child
+            // hash must include the empty sinsemilla root so V1 proof
+            // verification works even before the first append.
+            Element::CommitmentTree(..) => {
+                cost_return_on_error_into!(
+                    &mut cost,
+                    element.insert_subtree(
+                        &mut subtree_to_insert_into,
+                        key,
+                        grovedb_commitment_tree::EMPTY_COMMITMENT_TREE_STATE_ROOT,
+                        Some(options.as_merk_options()),
+                        grove_version
+                    )
+                );
+            }
+            // PrivateDocumentStore: the initial child hash is the empty
+            // state root for the element's committed config (the state root
+            // binds {entry_size, chunk_power}), so V1 proof verification and
+            // verify_grovedb agree even before the first append. Creation is
+            // version-gated and only an empty store may be inserted; entries
+            // are appended via the typed private_document_store_insert path.
+            Element::PrivateDocumentStore(total_count, entry_size, chunk_power, _) => {
+                cost_return_on_error_no_add!(
+                    cost,
+                    crate::operations::private_document_store::validate_private_document_store_creation(
+                        *total_count,
+                        *entry_size,
+                        *chunk_power,
+                        grove_version,
+                    )
+                );
+                // Write-once: creating a store over an existing element is
+                // rejected on the direct path too, matching the batch arm.
+                // A silent overwrite would reset the element to empty while
+                // leaving the old chunk blobs and MMR nodes in the data
+                // namespace.
+                let already_exists = cost_return_on_error_into!(
+                    &mut cost,
+                    element.element_at_key_already_exists(
+                        &mut subtree_to_insert_into,
+                        key,
+                        grove_version,
+                    )
+                );
+                if already_exists {
+                    return Err(Error::InvalidInput(
+                        "a private document store already exists at this key; it is append-only \
+                         and cannot be overwritten",
+                    ))
+                    .wrap_with_cost(cost);
+                }
+                // Deriving the empty root performs two blake3 calls — the
+                // committed-config hash and the composite `pds_state` hash —
+                // neither of which the helper can bill, since it returns a
+                // bare array. Charge them here so creating a store is not
+                // two hashes cheaper than it really is.
+                cost.hash_node_calls = cost.hash_node_calls.saturating_add(2);
+                cost_return_on_error_into!(
+                    &mut cost,
+                    element.insert_subtree(
+                        &mut subtree_to_insert_into,
+                        key,
+                        grovedb_private_document_store::empty_private_document_store_state_root(
+                            *entry_size,
+                            *chunk_power,
+                        ),
+                        Some(options.as_merk_options()),
+                        grove_version
+                    )
+                );
+            }
+            // MmrTree, BulkAppendTree, DenseAppendOnlyFixedSizeTree: initial
+            // insert uses NULL_HASH since these trees start empty.
+            Element::MmrTree(..)
+            | Element::BulkAppendTree(..)
+            | Element::DenseAppendOnlyFixedSizeTree(..) => {
+                cost_return_on_error_into!(
+                    &mut cost,
+                    element.insert_subtree(
+                        &mut subtree_to_insert_into,
+                        key,
+                        NULL_HASH,
+                        Some(options.as_merk_options()),
+                        grove_version
+                    )
+                );
+            }
+            Element::Item(..) | Element::SumItem(..) | Element::ItemWithSumItem(..) => {
+                cost_return_on_error_into!(
+                    &mut cost,
+                    element.insert(
+                        &mut subtree_to_insert_into,
+                        key,
+                        Some(options.as_merk_options()),
+                        grove_version
+                    )
+                );
+            }
+            Element::ProvableCountIndexedTree(primary, secondary, count_value, _) => {
+                let (primary_root_hash, secondary_root_hash) = if primary.is_none()
+                    && secondary.is_none()
+                    && *count_value == 0
+                {
+                    // Empty cidx: both root keys absent AND count
+                    // is zero. NULL_HASH for both Merks.
+                    (NULL_HASH, NULL_HASH)
+                } else {
+                    // Non-empty cidx: REQUIRE both root_keys to be
+                    // Some(_) AND validate them against on-disk
+                    // state. Reject partially-initialized claims
+                    // explicitly:
+                    //   - (None, None, count > 0): a cidx claiming
+                    //     entries but with no roots — would persist
+                    //     a count_value disconnected from any real
+                    //     index content.
+                    //   - (Some, None, _) / (None, Some, _): only
+                    //     one of the two Merks claimed; would
+                    //     persist asymmetric roots that fail H1-A
+                    //     reconstruction.
+                    if primary.is_none() || secondary.is_none() {
+                        return Err(Error::InvalidInput(
+                            "CountIndexedTree direct insertion: non-empty cidx must \
+                                 have BOTH primary_root_key and secondary_root_key set \
+                                 to Some(_); partial state (one None, one Some, or \
+                                 count>0 with no roots) is not permitted",
+                        ))
+                        .wrap_with_cost(cost);
+                    }
+                    // Both roots are Some(_); open and verify they
+                    // match the on-disk state. Mismatch ⇒ the
+                    // element bytes would diverge from on-disk
+                    // state; refuse rather than persist an
+                    // inconsistent root_hash chain.
+                    let child_path_owned = path.derive_owned_with_child(key.to_vec());
+                    let child_path = SubtreePath::from(&child_path_owned);
+                    let primary_merk = cost_return_on_error!(
+                        &mut cost,
+                        self.open_transactional_merk_at_path(
+                            child_path.clone(),
+                            transaction,
+                            Some(batch),
+                            grove_version,
+                        )
+                    );
+                    let (p_hash, p_root_key, p_aggregate) = cost_return_on_error!(
+                        &mut cost,
+                        primary_merk
+                            .root_hash_key_and_aggregate_data()
+                            .map_err(Error::MerkError)
+                    );
+                    if &p_root_key != primary {
+                        return Err(Error::InvalidInput(
+                            "CountIndexedTree direct insertion: provided \
+                                 primary_root_key does not match the existing \
+                                 primary Merk's root key",
+                        ))
+                        .wrap_with_cost(cost);
+                    }
+                    // The aggregate SHAPE must match the variant too:
+                    // `as_count_u64` reads a count out of both
+                    // `ProvableCount` and `ProvableCountAndProvableSum`, so
+                    // without this a PCIT element could be written over a
+                    // populated PCPSIT primary whose count happens to
+                    // match. The element and the on-disk primary would then
+                    // disagree on arity, and the next `verify_grovedb`
+                    // panics rather than erroring.
+                    if p_aggregate.parent_tree_type() != TreeType::ProvableCountTree {
+                        return Err(Error::InvalidInput(
+                            "CountIndexedTree direct insertion: the existing \
+                                 primary Merk is not a provable-count tree; the \
+                                 element variant does not match the stored subtree",
+                        ))
+                        .wrap_with_cost(cost);
+                    }
+                    // In-place conversion guard: a DIFFERENT tree element
+                    // already stored at this key can pass every check above
+                    // (a plain ProvableCountTree's subtree is byte-compatible
+                    // with this variant's primary, so the claimed roots and
+                    // aggregates all match), but the per-axis secondaries
+                    // would start EMPTY over a populated primary — the same
+                    // no-reindex hazard as an axes schema change. Refuse
+                    // the conversion.
+                    let stored_is_other_tree = cost_return_on_error!(
+                        &mut cost,
+                        Element::get_optional(&subtree_to_insert_into, key, true, grove_version)
+                            .map_err(Error::MerkError)
+                    )
+                    .is_some_and(|existing| {
+                        let u = existing.into_underlying();
+                        u.is_any_tree() && !matches!(u, Element::ProvableCountIndexedTree(..))
+                    });
+                    if stored_is_other_tree {
+                        return Err(Error::InvalidInput(
+                            "CountIndexedTree direct insertion: an existing tree of a \
+                                 different type is stored at this key; converting it in place \
+                                 would leave the secondary index empty over a populated \
+                                 primary (no reindex path)",
+                        ))
+                        .wrap_with_cost(cost);
+                    }
+                    // Also bind the claimed count_value to the primary's
+                    // actual aggregate. Without this, a caller could
+                    // supply correct root keys but a forged count that
+                    // then gets hash-committed and propagated into
+                    // ancestor aggregates.
+                    if p_aggregate.as_count_u64() != *count_value {
+                        return Err(Error::InvalidInput(
+                            "CountIndexedTree direct insertion: provided \
+                                 count_value does not match the existing \
+                                 primary Merk's aggregate count",
+                        ))
+                        .wrap_with_cost(cost);
+                    }
+                    let secondary_merk = cost_return_on_error!(
+                        &mut cost,
+                        self.open_indexed_secondary_at_path(
+                            child_path,
+                            grovedb_element::indexed::IndexAxis::Count,
+                            secondary.clone(),
+                            transaction,
+                            Some(batch),
+                            grove_version,
+                        )
+                    );
+                    let (s_hash, s_root_key, _) = cost_return_on_error!(
+                        &mut cost,
+                        secondary_merk
+                            .root_hash_key_and_aggregate_data()
+                            .map_err(Error::MerkError)
+                    );
+                    if &s_root_key != secondary {
+                        return Err(Error::InvalidInput(
+                            "CountIndexedTree direct insertion: provided \
+                                 secondary_root_key does not match the existing \
+                                 secondary Merk's root key",
+                        ))
+                        .wrap_with_cost(cost);
+                    }
+                    (p_hash, s_hash)
+                };
+                cost_return_on_error_into!(
+                    &mut cost,
+                    element.insert_count_indexed_subtree(
+                        &mut subtree_to_insert_into,
+                        key,
+                        primary_root_hash,
+                        secondary_root_hash,
+                        Some(options.as_merk_options()),
+                        grove_version,
+                    )
+                );
+            }
+            Element::ProvableSumIndexedTree(primary, secondary, sum_value, _) => {
+                let (primary_root_hash, secondary_root_hash) = if primary.is_none()
+                    && secondary.is_none()
+                    && *sum_value == 0
+                {
+                    (NULL_HASH, NULL_HASH)
+                } else {
+                    if primary.is_none() || secondary.is_none() {
+                        return Err(Error::InvalidInput(
+                            "ProvableSumIndexedTree direct insertion: non-empty PSIT must \
+                                 have BOTH primary_root_key and secondary_root_key set to \
+                                 Some(_); partial state is not permitted",
+                        ))
+                        .wrap_with_cost(cost);
+                    }
+                    let child_path_owned = path.derive_owned_with_child(key.to_vec());
+                    let child_path = SubtreePath::from(&child_path_owned);
+                    let primary_merk = cost_return_on_error!(
+                        &mut cost,
+                        self.open_transactional_merk_at_path(
+                            child_path.clone(),
+                            transaction,
+                            Some(batch),
+                            grove_version,
+                        )
+                    );
+                    let (p_hash, p_root_key, p_aggregate) = cost_return_on_error!(
+                        &mut cost,
+                        primary_merk
+                            .root_hash_key_and_aggregate_data()
+                            .map_err(Error::MerkError)
+                    );
+                    if &p_root_key != primary {
+                        return Err(Error::InvalidInput(
+                            "ProvableSumIndexedTree direct insertion: provided \
+                                 primary_root_key does not match the existing primary Merk's \
+                                 root key",
+                        ))
+                        .wrap_with_cost(cost);
+                    }
+                    // Bind the claimed sum_value to the primary's actual
+                    // aggregate so a forged sum cannot be hash-committed
+                    // and propagated into ancestor aggregates.
+                    if p_aggregate.parent_tree_type() != TreeType::ProvableSumTree {
+                        return Err(Error::InvalidInput(
+                            "ProvableSumIndexedTree direct insertion: the \
+                                 existing primary Merk is not a provable-sum \
+                                 tree; the element variant does not match the \
+                                 stored subtree",
+                        ))
+                        .wrap_with_cost(cost);
+                    }
+                    // In-place conversion guard: a DIFFERENT tree element
+                    // already stored at this key can pass every check above
+                    // (a plain ProvableSumTree's subtree is byte-compatible
+                    // with this variant's primary, so the claimed roots and
+                    // aggregates all match), but the per-axis secondaries
+                    // would start EMPTY over a populated primary — the same
+                    // no-reindex hazard as an axes schema change. Refuse
+                    // the conversion.
+                    let stored_is_other_tree = cost_return_on_error!(
+                        &mut cost,
+                        Element::get_optional(&subtree_to_insert_into, key, true, grove_version)
+                            .map_err(Error::MerkError)
+                    )
+                    .is_some_and(|existing| {
+                        let u = existing.into_underlying();
+                        u.is_any_tree() && !matches!(u, Element::ProvableSumIndexedTree(..))
+                    });
+                    if stored_is_other_tree {
+                        return Err(Error::InvalidInput(
+                            "ProvableSumIndexedTree direct insertion: an existing tree of a \
+                                 different type is stored at this key; converting it in place \
+                                 would leave the secondary index empty over a populated \
+                                 primary (no reindex path)",
+                        ))
+                        .wrap_with_cost(cost);
+                    }
+                    if p_aggregate.as_sum_i64() != *sum_value {
+                        return Err(Error::InvalidInput(
+                            "ProvableSumIndexedTree direct insertion: provided \
+                                 sum_value does not match the existing primary Merk's \
+                                 aggregate sum",
+                        ))
+                        .wrap_with_cost(cost);
+                    }
+                    let secondary_merk = cost_return_on_error!(
+                        &mut cost,
+                        self.open_indexed_secondary_at_path(
+                            child_path,
+                            grovedb_element::indexed::IndexAxis::Sum,
+                            secondary.clone(),
+                            transaction,
+                            Some(batch),
+                            grove_version,
+                        )
+                    );
+                    let (s_hash, s_root_key, _) = cost_return_on_error!(
+                        &mut cost,
+                        secondary_merk
+                            .root_hash_key_and_aggregate_data()
+                            .map_err(Error::MerkError)
+                    );
+                    if &s_root_key != secondary {
+                        return Err(Error::InvalidInput(
+                            "ProvableSumIndexedTree direct insertion: provided \
+                                 secondary_root_key does not match the existing secondary \
+                                 Merk's root key",
+                        ))
+                        .wrap_with_cost(cost);
+                    }
+                    (p_hash, s_hash)
+                };
+                cost_return_on_error_into!(
+                    &mut cost,
+                    element.insert_count_indexed_subtree(
+                        &mut subtree_to_insert_into,
+                        key,
+                        primary_root_hash,
+                        secondary_root_hash,
+                        Some(options.as_merk_options()),
+                        grove_version,
+                    )
+                );
+            }
+            Element::ProvableCountProvableSumIndexedTree(
+                primary,
+                count_value,
+                sum_value,
+                axes,
+                _,
+            ) => {
+                // Validate the axes TLV is canonical (sorted by tag, no
+                // duplicates, 1..=3 entries, known tags) for BOTH the
+                // empty and non-empty cases. The `Element` enum is public
+                // and `axes_digest` does not validate, so without this an
+                // empty PCPSIT with invalid/duplicate/unsorted axes could
+                // be persisted (its digest would be computed over the
+                // malformed TLV). Reuses the same check the constructors
+                // run.
+                cost_return_on_error_no_add!(
+                    cost,
+                    Element::validate_pcpsit_axes(axes).map_err(|_| Error::InvalidInput(
+                        "ProvableCountProvableSumIndexedTree direct insertion: axes must be \
+                         canonical (1..=3 entries, sorted ascending by tag, no duplicates, \
+                         tags in 0..=2)"
+                    ))
+                );
+                let axes_all_empty = axes.iter().all(|(_, sk)| sk.is_none());
+                let (primary_root_hash, second_hash) = if primary.is_none()
+                    && axes_all_empty
+                    && *count_value == 0
+                    && *sum_value == 0
+                {
+                    // Every axis slot is NULL_HASH for the empty case.
+                    let zero_axes: Vec<(u8, grovedb_merk::CryptoHash)> =
+                        axes.iter().map(|(t, _)| (*t, NULL_HASH)).collect();
+                    let digest =
+                        grovedb_merk::tree::axes_digest(&zero_axes).unwrap_add_cost(&mut cost);
+                    (NULL_HASH, digest)
+                } else {
+                    if primary.is_none() {
+                        return Err(Error::InvalidInput(
+                            "ProvableCountProvableSumIndexedTree direct insertion: non-empty \
+                             PCPSIT must have primary_root_key = Some(_); partial state is not \
+                             permitted",
+                        ))
+                        .wrap_with_cost(cost);
+                    }
+                    // (Axes canonical form already validated above.)
+                    let child_path_owned = path.derive_owned_with_child(key.to_vec());
+                    let child_path = SubtreePath::from(&child_path_owned);
+                    let primary_merk = cost_return_on_error!(
+                        &mut cost,
+                        self.open_transactional_merk_at_path(
+                            child_path.clone(),
+                            transaction,
+                            Some(batch),
+                            grove_version,
+                        )
+                    );
+                    let (p_hash, p_root_key, p_aggregate) = cost_return_on_error!(
+                        &mut cost,
+                        primary_merk
+                            .root_hash_key_and_aggregate_data()
+                            .map_err(Error::MerkError)
+                    );
+                    if &p_root_key != primary {
+                        return Err(Error::InvalidInput(
+                            "ProvableCountProvableSumIndexedTree direct insertion: provided \
+                             primary_root_key does not match the existing primary Merk's root \
+                             key",
+                        ))
+                        .wrap_with_cost(cost);
+                    }
+                    // Bind BOTH the claimed count_value and sum_value to the
+                    // primary's actual aggregate so forged count/sum cannot be
+                    // hash-committed and propagated into ancestor aggregates.
+                    if p_aggregate.parent_tree_type() != TreeType::ProvableCountProvableSumTree {
+                        return Err(Error::InvalidInput(
+                            "ProvableCountProvableSumIndexedTree direct insertion: the existing \
+                             primary Merk is not a provable-count-provable-sum tree; the element \
+                             variant does not match the stored subtree",
+                        ))
+                        .wrap_with_cost(cost);
+                    }
+                    if p_aggregate.as_count_u64() != *count_value {
+                        return Err(Error::InvalidInput(
+                            "ProvableCountProvableSumIndexedTree direct insertion: provided \
+                             count_value does not match the existing primary Merk's aggregate \
+                             count",
+                        ))
+                        .wrap_with_cost(cost);
+                    }
+                    if p_aggregate.as_sum_i64() != *sum_value {
+                        return Err(Error::InvalidInput(
+                            "ProvableCountProvableSumIndexedTree direct insertion: provided \
+                             sum_value does not match the existing primary Merk's aggregate \
+                             sum",
+                        ))
+                        .wrap_with_cost(cost);
+                    }
+                    // The axes SCHEMA must match what is already stored.
+                    // `axes_digest` is recomputed from the element's own
+                    // claimed axes, so adding an axis to a populated PCPSIT
+                    // was accepted and produced a consistent-looking element
+                    // whose new axis indexes NONE of the existing rows
+                    // (`indexed_avg_top_k` then returns an empty set for a
+                    // populated tree, and `verify_grovedb` reports nothing
+                    // because it re-derives the digest from the same claimed
+                    // axes). Dropping an axis likewise orphans a populated
+                    // secondary Merk. There is no backfill/reindex API, so
+                    // the only safe answer is to refuse the schema change.
+                    let stored_axis_tags: Option<Vec<u8>> = cost_return_on_error!(
+                        &mut cost,
+                        Element::get_optional(&subtree_to_insert_into, key, true, grove_version)
+                            .map_err(Error::MerkError)
+                    )
+                    .and_then(|existing| match existing.into_underlying() {
+                        Element::ProvableCountProvableSumIndexedTree(_, _, _, stored_axes, _) => {
+                            Some(stored_axes.iter().map(|(t, _)| *t).collect::<Vec<u8>>())
+                        }
+                        // In-place conversion guard: a stored tree of a
+                        // DIFFERENT type (e.g. a plain
+                        // ProvableCountProvableSumTree, whose subtree is
+                        // byte-compatible with a PCPSIT primary) would pass the
+                        // aggregate checks above while the axis secondaries
+                        // start EMPTY over a populated primary — the same
+                        // no-reindex hazard as an axes schema change. Mark it
+                        // for rejection below.
+                        other if other.is_any_tree() => Some(vec![u8::MAX]),
+                        _ => None,
+                    });
+                    if let Some(stored_tags) = stored_axis_tags {
+                        if stored_tags == vec![u8::MAX] {
+                            return Err(Error::InvalidInput(
+                                "ProvableCountProvableSumIndexedTree direct insertion: an \
+                                 existing tree of a different type is stored at this key; \
+                                 converting it in place would leave the axis secondaries empty \
+                                 over a populated primary (no reindex path)",
+                            ))
+                            .wrap_with_cost(cost);
+                        }
+                        let incoming_tags: Vec<u8> = axes.iter().map(|(t, _)| *t).collect();
+                        if stored_tags != incoming_tags {
+                            return Err(Error::InvalidInput(
+                                "ProvableCountProvableSumIndexedTree direct insertion: the axes \
+                                 schema does not match the stored element; axes cannot be added \
+                                 or removed on an existing indexed tree (no reindex path exists)",
+                            ))
+                            .wrap_with_cost(cost);
+                        }
+                    }
+                    // For each axis, open + verify and collect its root hash.
+                    let mut axis_hashes: Vec<(u8, grovedb_merk::CryptoHash)> =
+                        Vec::with_capacity(axes.len());
+                    for (tag, sec_root_key) in axes.iter() {
+                        let axis = cost_return_on_error_no_add!(
+                            cost,
+                            grovedb_element::indexed::IndexAxis::try_from_tag(*tag).map_err(|e| {
+                                Error::CorruptedData(format!("invalid axis tag in PCPSIT: {e}"))
+                            })
+                        );
+                        let secondary_merk = cost_return_on_error!(
+                            &mut cost,
+                            self.open_indexed_secondary_at_path(
+                                child_path.clone(),
+                                axis,
+                                sec_root_key.clone(),
+                                transaction,
+                                Some(batch),
+                                grove_version,
+                            )
+                        );
+                        let (s_hash, s_root_key, _) = cost_return_on_error!(
+                            &mut cost,
+                            secondary_merk
+                                .root_hash_key_and_aggregate_data()
+                                .map_err(Error::MerkError)
+                        );
+                        if &s_root_key != sec_root_key {
+                            return Err(Error::InvalidInput(
+                                "ProvableCountProvableSumIndexedTree direct insertion: provided \
+                                 axis secondary_root_key does not match the existing secondary \
+                                 Merk's root key",
+                            ))
+                            .wrap_with_cost(cost);
+                        }
+                        axis_hashes.push((*tag, s_hash));
+                    }
+                    let digest =
+                        grovedb_merk::tree::axes_digest(&axis_hashes).unwrap_add_cost(&mut cost);
+                    (p_hash, digest)
+                };
+                cost_return_on_error_into!(
+                    &mut cost,
+                    element.insert_count_indexed_subtree(
+                        &mut subtree_to_insert_into,
+                        key,
+                        primary_root_hash,
+                        second_hash,
+                        Some(options.as_merk_options()),
+                        grove_version,
+                    )
+                );
+            }
+            // `underlying()` only unwraps one level; nested wrappers are
+            // forbidden by the constructor and (de)serializer, but the public
+            // insert path can still receive a hand-built nested wrapper —
+            // return a typed error rather than panic.
+            Element::NonCounted(_) | Element::NotSummed(_) | Element::NotCountedOrSummed(_) => {
+                return Err(Error::InvalidInput(
+                    "nested element wrappers are not allowed",
+                ))
+                .wrap_with_cost(cost);
+            }
+        }
+
+        Ok(subtree_to_insert_into).wrap_with_cost(cost)
+    }
+}

--- a/grovedb/src/operations/insert/mod.rs
+++ b/grovedb/src/operations/insert/mod.rs
@@ -557,9 +557,17 @@ mod tests {
         exercise_all_add_element_arms(&GROVE_V1);
     }
 
-    /// Coverage for the v1 (layered) snapshot — `GROVE_V3` (latest).
+    /// Coverage for the v1 (layered) snapshot — `GROVE_V3`.
     #[test]
     fn add_element_on_transaction_v1_covers_all_arms() {
+        use grovedb_version::version::v3::GROVE_V3;
+        exercise_all_add_element_arms(&GROVE_V3);
+    }
+
+    /// Coverage for the v2 (stored-terminal reference commitment) snapshot —
+    /// `GROVE_V4` (latest).
+    #[test]
+    fn add_element_on_transaction_v2_covers_all_arms() {
         exercise_all_add_element_arms(GroveVersion::latest());
     }
 
@@ -571,7 +579,7 @@ mod tests {
         bad.grovedb_versions
             .operations
             .insert
-            .add_element_on_transaction = 2;
+            .add_element_on_transaction = 3;
         let db = make_empty_grovedb();
         let err = db
             .insert(EMPTY_PATH, b"x", Element::empty_tree(), None, None, &bad)

--- a/grovedb/src/operations/proof/generate.rs
+++ b/grovedb/src/operations/proof/generate.rs
@@ -2053,9 +2053,13 @@ impl GroveDb {
                     Ok(p) => p,
                     Err(e) => return Err(Error::from(e)).wrap_with_cost(cost),
                 };
+                // Embed the terminal's STORED bytes (wrapper included):
+                // the reference node's hash combines its own value hash
+                // with `H(stored terminal bytes)`, so a looked-through
+                // terminal would not reproduce the committed hash.
                 let referenced_elem = cost_return_on_error!(
                     &mut cost,
-                    self.follow_reference(
+                    self.follow_reference_as_stored(
                         absolute_path.as_slice().into(),
                         true,
                         None,
@@ -2251,6 +2255,14 @@ impl GroveDb {
                             // with `Reference` — both produce a
                             // KVRefValueHash{,Count} node with the
                             // dereferenced target's serialized bytes.
+                            //
+                            // The target is embedded as STORED (wrapper
+                            // included): the node's hash is
+                            // `combine(H(reference), H(stored terminal))`,
+                            // which is what both write paths commit to.
+                            // (The V0 prover in `prove_subqueries` is
+                            // frozen and still embeds the looked-through
+                            // terminal.)
                             Ok(Element::Reference(reference_path, ..))
                             | Ok(Element::ReferenceWithSumItem(reference_path, ..)) => {
                                 let absolute_path = cost_return_on_error_into!(
@@ -2265,7 +2277,7 @@ impl GroveDb {
 
                                 let referenced_elem = cost_return_on_error_into!(
                                     &mut cost,
-                                    self.follow_reference(
+                                    self.follow_reference_as_stored(
                                         absolute_path.as_slice().into(),
                                         true,
                                         None,

--- a/grovedb/src/operations/proof/generate.rs
+++ b/grovedb/src/operations/proof/generate.rs
@@ -2033,7 +2033,9 @@ impl GroveDb {
                     Op::Push(node) | Op::PushInverted(node) => node,
                     _ => continue,
                 };
-                let Node::KVValueHashFeatureType(key, value, _, feature_type) = node else {
+                let Node::KVValueHashFeatureType(key, value, committed_value_hash, feature_type) =
+                    node
+                else {
                     continue;
                 };
                 let elem = match Element::deserialize(value, grove_version) {
@@ -2053,10 +2055,9 @@ impl GroveDb {
                     Ok(p) => p,
                     Err(e) => return Err(Error::from(e)).wrap_with_cost(cost),
                 };
-                // Embed the terminal's STORED bytes (wrapper included):
-                // the reference node's hash combines its own value hash
-                // with `H(stored terminal bytes)`, so a looked-through
-                // terminal would not reproduce the committed hash.
+                // Resolve stored bytes first, then select the representation
+                // bound by this row. Legacy direct writes may coexist with
+                // stored-terminal commitments in the same paginated tree.
                 let referenced_elem = cost_return_on_error!(
                     &mut cost,
                     self.follow_reference_as_stored(
@@ -2064,6 +2065,16 @@ impl GroveDb {
                         true,
                         None,
                         grove_version
+                    )
+                );
+                let reference_element_hash = value_hash(value).unwrap_add_cost(&mut cost);
+                let referenced_elem = cost_return_on_error!(
+                    &mut cost,
+                    Self::reference_terminal_as_committed(
+                        referenced_elem,
+                        &reference_element_hash,
+                        committed_value_hash,
+                        grove_version,
                     )
                 );
                 let serialized_referenced_elem = match referenced_elem.serialize(grove_version) {
@@ -2075,7 +2086,6 @@ impl GroveDb {
                         .wrap_with_cost(cost);
                     }
                 };
-                let reference_element_hash = value_hash(value).unwrap_add_cost(&mut cost);
                 *node = match feature_type {
                     TreeFeatureType::ProvableCountedAndProvableSummedMerkNode(count, sum) => {
                         Node::KVRefValueHashCountSum(
@@ -2235,6 +2245,16 @@ impl GroveDb {
                 _ => None,
             };
 
+            // Merk emits references with their stored combined value hash.
+            // Preserve it before replacing the node with a resolved payload.
+            let committed_value_hash = match op {
+                Op::Push(Node::KVValueHash(_, _, hash))
+                | Op::PushInverted(Node::KVValueHash(_, _, hash))
+                | Op::Push(Node::KVValueHashFeatureType(_, _, hash, _))
+                | Op::PushInverted(Node::KVValueHashFeatureType(_, _, hash, _)) => Some(*hash),
+                _ => None,
+            };
+
             match op {
                 Op::Push(node) | Op::PushInverted(node) => match node {
                     Node::KV(key, value)
@@ -2256,13 +2276,10 @@ impl GroveDb {
                             // KVRefValueHash{,Count} node with the
                             // dereferenced target's serialized bytes.
                             //
-                            // The target is embedded as STORED (wrapper
-                            // included): the node's hash is
-                            // `combine(H(reference), H(stored terminal))`,
-                            // which is what both write paths commit to.
-                            // (The V0 prover in `prove_subqueries` is
-                            // frozen and still embeds the looked-through
-                            // terminal.)
+                            // Select the target bytes by the node's existing
+                            // commitment, not the current GroveVersion: a V4
+                            // reader may encounter V3 direct-written references
+                            // that bind the unwrapped terminal.
                             Ok(Element::Reference(reference_path, ..))
                             | Ok(Element::ReferenceWithSumItem(reference_path, ..)) => {
                                 let absolute_path = cost_return_on_error_into!(
@@ -2285,6 +2302,25 @@ impl GroveDb {
                                     )
                                 );
 
+                                let reference_element_hash =
+                                    value_hash(value).unwrap_add_cost(&mut cost);
+                                let committed_value_hash = cost_return_on_error_no_add!(
+                                    cost,
+                                    committed_value_hash.ok_or_else(|| Error::CorruptedData(
+                                        "reference proof node is missing its committed value hash"
+                                            .to_string()
+                                    ))
+                                );
+                                let referenced_elem = cost_return_on_error!(
+                                    &mut cost,
+                                    Self::reference_terminal_as_committed(
+                                        referenced_elem,
+                                        &reference_element_hash,
+                                        &committed_value_hash,
+                                        grove_version,
+                                    )
+                                );
+
                                 let serialized_referenced_elem =
                                     referenced_elem.serialize(grove_version);
                                 if serialized_referenced_elem.is_err() {
@@ -2303,7 +2339,7 @@ impl GroveDb {
                                     Node::KVRefValueHashCountSum(
                                         key.to_owned(),
                                         serialized_referenced_elem.expect("confirmed ok above"),
-                                        value_hash(value).unwrap_add_cost(&mut cost),
+                                        reference_element_hash,
                                         count,
                                         sum,
                                     )
@@ -2311,21 +2347,21 @@ impl GroveDb {
                                     Node::KVRefValueHashSum(
                                         key.to_owned(),
                                         serialized_referenced_elem.expect("confirmed ok above"),
-                                        value_hash(value).unwrap_add_cost(&mut cost),
+                                        reference_element_hash,
                                         sum,
                                     )
                                 } else if let Some(count) = count_for_ref {
                                     Node::KVRefValueHashCount(
                                         key.to_owned(),
                                         serialized_referenced_elem.expect("confirmed ok above"),
-                                        value_hash(value).unwrap_add_cost(&mut cost),
+                                        reference_element_hash,
                                         count,
                                     )
                                 } else {
                                     Node::KVRefValueHash(
                                         key.to_owned(),
                                         serialized_referenced_elem.expect("confirmed ok above"),
-                                        value_hash(value).unwrap_add_cost(&mut cost),
+                                        reference_element_hash,
                                     )
                                 };
                                 limit_state.charge_row_with_instance(&mut frame_instance);

--- a/grovedb/src/operations/proof/verify.rs
+++ b/grovedb/src/operations/proof/verify.rs
@@ -703,12 +703,20 @@ impl GroveDb {
             // NonCounted-wrapped values are checked **before**
             // unwrapping via `into_underlying`, since the wrapper
             // itself is the rejected shape. The merk-level prover
-            // already refuses to emit NonCounted entries as
-            // value-bearing nodes, so an honest proof can never
-            // surface one here. Reject as `InvalidProof`
-            // (forgery) rather than `NotSupported` to make the
-            // distinction visible.
-            if elem.is_non_counted() {
+            // already refuses to emit NonCounted entries of the proved
+            // tree as value-bearing nodes, so an honest proof can never
+            // surface one of the tree's OWN entries wrapped. Reject as
+            // `InvalidProof` (forgery) rather than `NotSupported` to
+            // make the distinction visible.
+            //
+            // A row resolved through a reference is the exception: a
+            // reference commits to its terminal's stored bytes verbatim
+            // (wrapper included — see `follow_reference_as_stored`), so
+            // a target that lives wrapped in a count-bearing tree
+            // legitimately surfaces here wrapped. The merk verifier
+            // flags those rows, and the wrapper is looked through below
+            // like everywhere else.
+            if elem.is_non_counted() && !item.resolved_from_reference {
                 return Err(Error::InvalidProof(
                     query.clone(),
                     format!(

--- a/grovedb/src/tests/mod.rs
+++ b/grovedb/src/tests/mod.rs
@@ -31,6 +31,7 @@ mod non_merk_integrity_audit_tests;
 mod per_instance_gate_coverage_tests;
 mod per_instance_limit_tests;
 mod private_document_store_tests;
+mod wrapped_terminal_reference_tests;
 // NOTE: the former `count_indexed_tree_tests` (~12.3k LOC) was written
 // against the now-removed non-provable `Element::CountIndexedTree` and was
 // carried here behind a `#[cfg(any())]` gate that made it permanently dead —

--- a/grovedb/src/tests/wrapped_terminal_reference_tests.rs
+++ b/grovedb/src/tests/wrapped_terminal_reference_tests.rs
@@ -1,0 +1,436 @@
+//! Regression tests for issue #858: a reference whose terminal is a
+//! `NonCounted`-wrapped item must commit to the terminal's **stored**
+//! bytes (wrapper included) on every path.
+//!
+//! Before the fix the batch reference resolver hashed the stored bytes
+//! while direct insert, `verify_grovedb` and the V1 prover resolved the
+//! terminal through the presentation-oriented `follow_reference`, which
+//! looks through the wrapper first. The same reference therefore
+//! committed different roots depending on how it was written, and a
+//! batch-written reference failed both the integrity walk and proof
+//! verification.
+//!
+//! `GROVE_V3` is live, so the direct-insert change is gated to
+//! `GROVE_V4` (`add_element_on_transaction: 2`); the read-side paths
+//! (integrity walk, V1 prover) are not versioned and follow the stored
+//! representation unconditionally.
+
+#[cfg(test)]
+mod tests {
+    use grovedb_merk::tree::{combine_hash, value_hash};
+    use grovedb_version::version::{v3::GROVE_V3, GroveVersion};
+
+    use crate::{
+        batch::QualifiedGroveDbOp,
+        reference_path::ReferencePathType,
+        tests::{make_test_grovedb, TempGroveDb, TEST_LEAF},
+        Element, GroveDb, PathQuery, Query, SizedQuery,
+    };
+
+    const COUNT_TREE: &[u8] = b"ct";
+    const TARGET: &[u8] = b"target";
+    const REF: &[u8] = b"ref";
+    const TARGET_VALUE: &[u8] = b"target-value";
+
+    fn wrapped_item() -> Element {
+        Element::new_non_counted(Element::new_item(TARGET_VALUE.to_vec()))
+            .expect("NonCounted(Item) is a valid wrapper")
+    }
+
+    fn reference_to_target() -> Element {
+        Element::new_reference(ReferencePathType::AbsolutePathReference(vec![
+            TEST_LEAF.to_vec(),
+            COUNT_TREE.to_vec(),
+            TARGET.to_vec(),
+        ]))
+    }
+
+    /// `TEST_LEAF/ct` is a `CountTree` holding `NonCounted(Item)` at
+    /// `target`. The wrapper is only admitted under a count-bearing
+    /// parent, which is why the terminal lives in a count tree.
+    fn db_with_wrapped_target(grove_version: &GroveVersion) -> TempGroveDb {
+        let db = make_test_grovedb(grove_version);
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            COUNT_TREE,
+            Element::empty_count_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert count tree");
+        db.insert(
+            [TEST_LEAF, COUNT_TREE].as_ref(),
+            TARGET,
+            wrapped_item(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert NonCounted(Item) target");
+        db
+    }
+
+    fn insert_reference_directly(db: &TempGroveDb, grove_version: &GroveVersion) {
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            REF,
+            reference_to_target(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("direct insert of reference");
+    }
+
+    fn insert_reference_in_batch(db: &TempGroveDb, grove_version: &GroveVersion) {
+        let op = QualifiedGroveDbOp::insert_or_replace_op(
+            vec![TEST_LEAF.to_vec()],
+            REF.to_vec(),
+            reference_to_target(),
+        );
+        db.apply_batch(vec![op], None, None, grove_version)
+            .unwrap()
+            .expect("batch insert of reference");
+    }
+
+    fn root(db: &TempGroveDb, grove_version: &GroveVersion) -> [u8; 32] {
+        db.root_hash(None, grove_version)
+            .unwrap()
+            .expect("root hash")
+    }
+
+    /// Commitment a reference to the wrapped target must carry: the
+    /// reference's own value hash combined with the hash of the
+    /// terminal's STORED bytes (wrapper included).
+    fn expected_reference_value_hash(grove_version: &GroveVersion) -> [u8; 32] {
+        let ref_bytes = reference_to_target()
+            .serialize(grove_version)
+            .expect("serialize reference");
+        let stored_target_bytes = wrapped_item()
+            .serialize(grove_version)
+            .expect("serialize wrapped target");
+        combine_hash(
+            &value_hash(&ref_bytes).unwrap(),
+            &value_hash(&stored_target_bytes).unwrap(),
+        )
+        .unwrap()
+    }
+
+    fn stored_reference_value_hash(db: &TempGroveDb, grove_version: &GroveVersion) -> [u8; 32] {
+        let tx = db.start_transaction();
+        let merk = db
+            .open_transactional_merk_at_path([TEST_LEAF].as_ref().into(), &tx, None, grove_version)
+            .unwrap()
+            .expect("open TEST_LEAF merk");
+        merk.get_value_hash(
+            REF,
+            true,
+            None::<&fn(&[u8], &GroveVersion) -> _>,
+            grove_version,
+        )
+        .unwrap()
+        .expect("read reference value hash")
+        .expect("reference must exist")
+    }
+
+    fn query_for_ref() -> PathQuery {
+        let mut query = Query::new();
+        query.insert_key(REF.to_vec());
+        PathQuery::new(vec![TEST_LEAF.to_vec()], SizedQuery::new(query, None, None))
+    }
+
+    /// Prove the reference and check the proof against the live root.
+    /// Returns the bytes the verifier surfaced for the reference row.
+    fn prove_and_verify_ref(db: &TempGroveDb, grove_version: &GroveVersion) -> Vec<u8> {
+        let path_query = query_for_ref();
+        let proof = db
+            .prove_query(&path_query, None, grove_version)
+            .unwrap()
+            .expect("prove reference");
+        let (proved_root, results) =
+            GroveDb::verify_query_raw(&proof, &path_query, grove_version).expect("verify proof");
+        assert_eq!(
+            proved_root,
+            root(db, grove_version),
+            "proof must bind the live root"
+        );
+        assert_eq!(results.len(), 1, "exactly the reference row");
+        assert_eq!(results[0].key, REF.to_vec());
+        results[0].value.clone()
+    }
+
+    #[test]
+    fn direct_and_batch_reference_to_wrapped_terminal_commit_the_same_root() {
+        let grove_version = GroveVersion::latest();
+
+        let direct = db_with_wrapped_target(grove_version);
+        insert_reference_directly(&direct, grove_version);
+
+        let batched = db_with_wrapped_target(grove_version);
+        insert_reference_in_batch(&batched, grove_version);
+
+        assert_eq!(
+            root(&direct, grove_version),
+            root(&batched, grove_version),
+            "direct and batch writes of the same reference must commit the same root"
+        );
+
+        let expected = expected_reference_value_hash(grove_version);
+        assert_eq!(
+            stored_reference_value_hash(&direct, grove_version),
+            expected,
+            "direct insert must bind the terminal's stored (wrapped) bytes"
+        );
+        assert_eq!(
+            stored_reference_value_hash(&batched, grove_version),
+            expected,
+            "batch insert must bind the terminal's stored (wrapped) bytes"
+        );
+    }
+
+    #[test]
+    fn integrity_walk_accepts_references_to_wrapped_terminals_from_both_paths() {
+        let grove_version = GroveVersion::latest();
+
+        let direct = db_with_wrapped_target(grove_version);
+        insert_reference_directly(&direct, grove_version);
+        let batched = db_with_wrapped_target(grove_version);
+        insert_reference_in_batch(&batched, grove_version);
+
+        for (label, db) in [("direct", &direct), ("batch", &batched)] {
+            let issues = db
+                .verify_grovedb(None, true, true, grove_version)
+                .expect("verify_grovedb runs");
+            assert!(
+                issues.is_empty(),
+                "{label}-written reference to a wrapped terminal must pass verify_grovedb, got \
+                 {issues:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn v1_proof_round_trips_a_reference_to_a_wrapped_terminal_from_both_paths() {
+        let grove_version = GroveVersion::latest();
+
+        let direct = db_with_wrapped_target(grove_version);
+        insert_reference_directly(&direct, grove_version);
+        let batched = db_with_wrapped_target(grove_version);
+        insert_reference_in_batch(&batched, grove_version);
+
+        for (label, db) in [("direct", &direct), ("batch", &batched)] {
+            let surfaced = prove_and_verify_ref(db, grove_version);
+            // The proof embeds the terminal exactly as stored (that is
+            // what the reference node's hash binds); consumers look
+            // through the wrapper the same way the trusted read does.
+            let element =
+                Element::deserialize(&surfaced, grove_version).expect("surfaced bytes decode");
+            assert_eq!(
+                element,
+                wrapped_item(),
+                "{label}: proof must surface the terminal's stored bytes"
+            );
+            assert_eq!(
+                element.into_underlying(),
+                Element::new_item(TARGET_VALUE.to_vec()),
+                "{label}: looked-through terminal is the item"
+            );
+        }
+
+        // The trusted read still presents the looked-through value.
+        let got = direct
+            .get([TEST_LEAF].as_ref(), REF, None, grove_version)
+            .unwrap()
+            .expect("get through reference");
+        assert_eq!(got, Element::new_item(TARGET_VALUE.to_vec()));
+    }
+
+    /// A chain that hops through a `NonCounted(Reference)` and lands on
+    /// a `NonCounted(Item)`: the wrapper on the intermediate hop is
+    /// looked through for chain-following, the wrapper on the terminal
+    /// is part of the commitment.
+    #[test]
+    fn chain_through_wrapped_hop_to_wrapped_terminal_agrees_across_paths() {
+        let grove_version = GroveVersion::latest();
+
+        let setup = |db: &TempGroveDb| {
+            let hop = Element::new_non_counted(reference_to_target()).expect("wrap reference");
+            db.insert(
+                [TEST_LEAF, COUNT_TREE].as_ref(),
+                b"hop",
+                hop,
+                None,
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("insert wrapped hop");
+        };
+        let ref_to_hop = || {
+            Element::new_reference(ReferencePathType::AbsolutePathReference(vec![
+                TEST_LEAF.to_vec(),
+                COUNT_TREE.to_vec(),
+                b"hop".to_vec(),
+            ]))
+        };
+
+        let direct = db_with_wrapped_target(grove_version);
+        setup(&direct);
+        direct
+            .insert(
+                [TEST_LEAF].as_ref(),
+                REF,
+                ref_to_hop(),
+                None,
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("direct insert of chained reference");
+
+        let batched = db_with_wrapped_target(grove_version);
+        setup(&batched);
+        batched
+            .apply_batch(
+                vec![QualifiedGroveDbOp::insert_or_replace_op(
+                    vec![TEST_LEAF.to_vec()],
+                    REF.to_vec(),
+                    ref_to_hop(),
+                )],
+                None,
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("batch insert of chained reference");
+
+        assert_eq!(root(&direct, grove_version), root(&batched, grove_version));
+        for (label, db) in [("direct", &direct), ("batch", &batched)] {
+            let issues = db
+                .verify_grovedb(None, true, true, grove_version)
+                .expect("verify_grovedb runs");
+            assert!(issues.is_empty(), "{label}: {issues:?}");
+            let surfaced = prove_and_verify_ref(db, grove_version);
+            assert_eq!(
+                Element::deserialize(&surfaced, grove_version)
+                    .expect("decode")
+                    .into_underlying(),
+                Element::new_item(TARGET_VALUE.to_vec()),
+                "{label}: chain resolves to the item"
+            );
+        }
+    }
+
+    /// Offset-paginated proofs over a `ProvableCountTree` of references
+    /// whose terminals are wrapped: the rows surface the stored
+    /// (wrapped) target bytes and the verifier accepts them because they
+    /// were resolved through a reference.
+    #[test]
+    fn count_offset_proof_round_trips_references_to_wrapped_terminals() {
+        let grove_version = GroveVersion::latest();
+        let db = db_with_wrapped_target(grove_version);
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"refs",
+            Element::empty_provable_count_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert provable count tree");
+        // Batch-written rows: before the fix these carried the stored
+        // (wrapped) commitment while the prover embedded the
+        // looked-through terminal, so the proof failed to verify.
+        let ops = [b"a", b"b", b"c", b"d"]
+            .into_iter()
+            .map(|key| {
+                QualifiedGroveDbOp::insert_or_replace_op(
+                    vec![TEST_LEAF.to_vec(), b"refs".to_vec()],
+                    key.to_vec(),
+                    reference_to_target(),
+                )
+            })
+            .collect();
+        db.apply_batch(ops, None, None, grove_version)
+            .unwrap()
+            .expect("batch insert reference rows");
+
+        let mut query = Query::new();
+        query.insert_range_inclusive(b"a".to_vec()..=b"d".to_vec());
+        let path_query = PathQuery::new(
+            vec![TEST_LEAF.to_vec(), b"refs".to_vec()],
+            SizedQuery::new(query, Some(2), Some(1)),
+        );
+        let proof = db
+            .prove_query(&path_query, None, grove_version)
+            .unwrap()
+            .expect("prove offset-paginated reference rows");
+        let (proved_root, results) =
+            GroveDb::verify_query_raw(&proof, &path_query, grove_version).expect("verify");
+        assert_eq!(proved_root, root(&db, grove_version));
+        let keys: Vec<Vec<u8>> = results.iter().map(|r| r.key.clone()).collect();
+        assert_eq!(keys, vec![b"b".to_vec(), b"c".to_vec()]);
+        for row in results {
+            assert_eq!(
+                Element::deserialize(&row.value, grove_version)
+                    .expect("decode")
+                    .into_underlying(),
+                Element::new_item(TARGET_VALUE.to_vec())
+            );
+        }
+    }
+
+    /// Consensus pin: `GROVE_V3` is live, so its direct insert keeps the
+    /// legacy commitment (hash of the looked-through terminal) and still
+    /// disagrees with the batch path. The read side is not versioned, so
+    /// the integrity walk now reports that legacy node — which is the
+    /// honest answer, since no proof can bind it either.
+    #[test]
+    fn grove_v3_direct_insert_keeps_the_legacy_unwrapped_commitment() {
+        let grove_version = &GROVE_V3;
+
+        let direct = db_with_wrapped_target(grove_version);
+        insert_reference_directly(&direct, grove_version);
+        let batched = db_with_wrapped_target(grove_version);
+        insert_reference_in_batch(&batched, grove_version);
+
+        let ref_bytes = reference_to_target()
+            .serialize(grove_version)
+            .expect("serialize reference");
+        let unwrapped_target_bytes = Element::new_item(TARGET_VALUE.to_vec())
+            .serialize(grove_version)
+            .expect("serialize inner item");
+        let legacy = combine_hash(
+            &value_hash(&ref_bytes).unwrap(),
+            &value_hash(&unwrapped_target_bytes).unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            stored_reference_value_hash(&direct, grove_version),
+            legacy,
+            "GROVE_V3 direct insert must keep hashing the looked-through terminal"
+        );
+        assert_eq!(
+            stored_reference_value_hash(&batched, grove_version),
+            expected_reference_value_hash(grove_version),
+            "the batch path has always committed to the stored bytes"
+        );
+        assert_ne!(root(&direct, grove_version), root(&batched, grove_version));
+
+        let issues = direct
+            .verify_grovedb(None, true, true, grove_version)
+            .expect("verify_grovedb runs");
+        assert_eq!(issues.len(), 1, "the legacy node is reported: {issues:?}");
+        assert!(issues.contains_key(&vec![TEST_LEAF.to_vec(), REF.to_vec()]));
+        assert!(batched
+            .verify_grovedb(None, true, true, grove_version)
+            .expect("verify_grovedb runs")
+            .is_empty());
+    }
+}

--- a/grovedb/src/tests/wrapped_terminal_reference_tests.rs
+++ b/grovedb/src/tests/wrapped_terminal_reference_tests.rs
@@ -12,8 +12,8 @@
 //!
 //! `GROVE_V3` is live, so the direct-insert change is gated to
 //! `GROVE_V4` (`add_element_on_transaction: 2`); the read-side paths
-//! (integrity walk, V1 prover) are not versioned and follow the stored
-//! representation unconditionally.
+//! (integrity walk, V1 prover) select the representation matching each
+//! reference's stored commitment, including when reading V3 data under V4.
 
 #[cfg(test)]
 mod tests {
@@ -387,9 +387,8 @@ mod tests {
 
     /// Consensus pin: `GROVE_V3` is live, so its direct insert keeps the
     /// legacy commitment (hash of the looked-through terminal) and still
-    /// disagrees with the batch path. The read side is not versioned, so
-    /// the integrity walk now reports that legacy node — which is the
-    /// honest answer, since no proof can bind it either.
+    /// disagrees with the batch path. Both commitments must remain readable
+    /// and provable, including after upgrading to GROVE_V4.
     #[test]
     fn grove_v3_direct_insert_keeps_the_legacy_unwrapped_commitment() {
         let grove_version = &GROVE_V3;
@@ -423,14 +422,187 @@ mod tests {
         );
         assert_ne!(root(&direct, grove_version), root(&batched, grove_version));
 
-        let issues = direct
-            .verify_grovedb(None, true, true, grove_version)
-            .expect("verify_grovedb runs");
-        assert_eq!(issues.len(), 1, "the legacy node is reported: {issues:?}");
-        assert!(issues.contains_key(&vec![TEST_LEAF.to_vec(), REF.to_vec()]));
-        assert!(batched
-            .verify_grovedb(None, true, true, grove_version)
-            .expect("verify_grovedb runs")
-            .is_empty());
+        for reader_version in [&GROVE_V3, GroveVersion::latest()] {
+            for (db, expected) in [
+                (&direct, wrapped_item().into_underlying()),
+                (&batched, wrapped_item()),
+            ] {
+                let before = root(db, reader_version);
+                let surfaced = prove_and_verify_ref(db, reader_version);
+                assert_eq!(
+                    Element::deserialize(&surfaced, reader_version).unwrap(),
+                    expected
+                );
+                assert!(db
+                    .verify_grovedb(None, true, true, reader_version)
+                    .expect("verify_grovedb runs")
+                    .is_empty());
+                assert_eq!(
+                    root(db, reader_version),
+                    before,
+                    "reads must not rewrite commitments"
+                );
+            }
+        }
+    }
+
+    /// A single tree can contain both commitment formats. The reader's
+    /// current version cannot identify how any individual row was written.
+    #[test]
+    fn mixed_commitments_round_trip_in_regular_and_paginated_reference_proofs() {
+        let latest = GroveVersion::latest();
+        for host in [
+            Element::empty_provable_count_tree(),
+            Element::empty_provable_count_sum_tree(),
+            Element::empty_provable_count_provable_sum_tree(),
+        ] {
+            for with_sum in [false, true] {
+                let db = db_with_wrapped_target(&GROVE_V3);
+                // Include a wrapped intermediate reference, itself written
+                // under V3, so the integrity walk also checks a legacy hop.
+                db.insert(
+                    [TEST_LEAF, COUNT_TREE].as_ref(),
+                    b"hop",
+                    Element::new_non_counted(reference_to_target()).unwrap(),
+                    None,
+                    None,
+                    &GROVE_V3,
+                )
+                .unwrap()
+                .unwrap();
+                db.insert(
+                    [TEST_LEAF].as_ref(),
+                    b"refs",
+                    host.clone(),
+                    None,
+                    None,
+                    latest,
+                )
+                .unwrap()
+                .unwrap();
+                let path = vec![TEST_LEAF.to_vec(), b"refs".to_vec()];
+                let reference_path = ReferencePathType::AbsolutePathReference(vec![
+                    TEST_LEAF.to_vec(),
+                    COUNT_TREE.to_vec(),
+                    b"hop".to_vec(),
+                ]);
+                let reference = if with_sum {
+                    Element::new_reference_with_sum_item(reference_path, 7)
+                } else {
+                    Element::new_reference(reference_path)
+                };
+                for (key, version, batch) in [
+                    (b"a", &GROVE_V3, true),
+                    (b"b", &GROVE_V3, false),
+                    (b"c", latest, false),
+                    (b"d", latest, true),
+                ] {
+                    if batch {
+                        db.apply_batch(
+                            vec![QualifiedGroveDbOp::insert_or_replace_op(
+                                path.clone(),
+                                key.to_vec(),
+                                reference.clone(),
+                            )],
+                            None,
+                            None,
+                            version,
+                        )
+                        .unwrap()
+                        .unwrap();
+                    } else {
+                        db.insert(path.as_slice(), key, reference.clone(), None, None, version)
+                            .unwrap()
+                            .unwrap();
+                    }
+                }
+                let before = root(&db, latest);
+                for reader_version in [&GROVE_V3, latest] {
+                    for ascending in [false, true] {
+                        for offset in [None, Some(1)] {
+                            let mut query = Query::new();
+                            query.left_to_right = ascending;
+                            query.insert_range_inclusive(b"a".to_vec()..=b"d".to_vec());
+                            let query = PathQuery::new(
+                                path.clone(),
+                                SizedQuery::new(query, offset.map(|_| 2), offset),
+                            );
+                            let proof = db
+                                .prove_query(&query, None, reader_version)
+                                .unwrap()
+                                .unwrap();
+                            let (proved_root, rows) =
+                                GroveDb::verify_query_raw(&proof, &query, reader_version)
+                                    .expect("mixed reference commitments must verify");
+                            assert_eq!(proved_root, before);
+                            let mut expected_keys = if offset.is_some() {
+                                vec![b"b".to_vec(), b"c".to_vec()]
+                            } else {
+                                vec![b"a".to_vec(), b"b".to_vec(), b"c".to_vec(), b"d".to_vec()]
+                            };
+                            if !ascending {
+                                expected_keys.reverse();
+                            }
+                            assert_eq!(
+                                rows.iter().map(|r| r.key.clone()).collect::<Vec<_>>(),
+                                expected_keys
+                            );
+                            for row in rows {
+                                let expected = if row.key == b"b" {
+                                    wrapped_item().into_underlying()
+                                } else {
+                                    wrapped_item()
+                                };
+                                assert_eq!(
+                                    Element::deserialize(&row.value, reader_version).unwrap(),
+                                    expected
+                                );
+                            }
+                        }
+                    }
+                    assert!(db
+                        .verify_grovedb(None, true, true, reader_version)
+                        .unwrap()
+                        .is_empty());
+                    assert_eq!(root(&db, reader_version), before);
+                }
+            }
+        }
+    }
+
+    /// Compatibility may select an older representation, but never an
+    /// unrelated terminal whose bytes match neither committed format.
+    #[test]
+    fn stale_wrapped_reference_commitments_are_still_detected() {
+        for batch in [false, true] {
+            let db = db_with_wrapped_target(&GROVE_V3);
+            if batch {
+                insert_reference_in_batch(&db, &GROVE_V3);
+            } else {
+                insert_reference_directly(&db, &GROVE_V3);
+            }
+            db.insert(
+                [TEST_LEAF, COUNT_TREE].as_ref(),
+                TARGET,
+                Element::new_non_counted(Element::new_item(b"changed".to_vec())).unwrap(),
+                None,
+                None,
+                GroveVersion::latest(),
+            )
+            .unwrap()
+            .unwrap();
+            for reader_version in [&GROVE_V3, GroveVersion::latest()] {
+                let issues = db.verify_grovedb(None, true, true, reader_version).unwrap();
+                assert_eq!(issues.len(), 1);
+                assert!(issues.contains_key(&vec![TEST_LEAF.to_vec(), REF.to_vec()]));
+                let query = query_for_ref();
+                let proof = db
+                    .prove_query(&query, None, reader_version)
+                    .unwrap()
+                    .unwrap();
+                let result = GroveDb::verify_query_raw(&proof, &query, reader_version);
+                assert!(result.is_err() || result.unwrap().0 != root(&db, reader_version));
+            }
+        }
     }
 }

--- a/merk/src/proofs/query/count_offset/tests.rs
+++ b/merk/src/proofs/query/count_offset/tests.rs
@@ -185,6 +185,7 @@ fn returned_items_carry_full_committed_payload() {
         value: vec![5u8],
         value_hash: crate::tree::value_hash(&[5u8]).unwrap(),
         child_hash_verified: false,
+        resolved_from_reference: false,
     };
     assert_eq!(
         verified.returned_items[0], expected_f,

--- a/merk/src/proofs/query/count_offset/verify.rs
+++ b/merk/src/proofs/query/count_offset/verify.rs
@@ -106,6 +106,18 @@ pub struct CountOffsetReturnedItem {
     /// `child_hash_verified = true` for non-empty trees); callers must
     /// not silently treat a `false` here as `true`.
     pub child_hash_verified: bool,
+    /// Whether this row was surfaced through a `KVRefValueHash*` node,
+    /// i.e. `value` holds the RESOLVED reference target's stored bytes
+    /// rather than the proved tree's own entry bytes.
+    ///
+    /// The caller needs this to tell an honest dereferenced target apart
+    /// from a forged own-entry: a reference commits to its terminal's
+    /// stored bytes verbatim, wrapper included, so a target that lives
+    /// wrapped in `NonCounted` legitimately surfaces here wrapped. The
+    /// proved tree's own entries can never surface wrapped (the prover
+    /// rejects them), so a wrapped value with this flag `false` is a
+    /// forgery.
+    pub resolved_from_reference: bool,
 }
 
 /// The verifier's reconstructed view of an offset-paginated count-tree
@@ -595,6 +607,7 @@ fn classify_self<'a>(
             }
             let vh = compute_value_hash(value.as_slice()).unwrap();
             Ok(BoundaryKind::ValueReturned {
+                resolved_from_reference: false,
                 key: key.as_slice(),
                 value: value.as_slice(),
                 value_hash: vh,
@@ -620,6 +633,7 @@ fn classify_self<'a>(
             }
             let vh = compute_value_hash(value.as_slice()).unwrap();
             Ok(BoundaryKind::ValueReturned {
+                resolved_from_reference: false,
                 key: key.as_slice(),
                 value: value.as_slice(),
                 value_hash: vh,
@@ -693,6 +707,7 @@ fn classify_self<'a>(
                 ));
             }
             Ok(BoundaryKind::ValueReturned {
+                resolved_from_reference: false,
                 key: key.as_slice(),
                 value: value.as_slice(),
                 value_hash: *vh,
@@ -728,6 +743,7 @@ fn classify_self<'a>(
                 )));
             }
             Ok(BoundaryKind::ValueReturned {
+                resolved_from_reference: true,
                 key: key.as_slice(),
                 value: value.as_slice(),
                 // The committed value hash for a combined reference is
@@ -755,6 +771,7 @@ fn classify_self<'a>(
                 )));
             }
             Ok(BoundaryKind::ValueReturned {
+                resolved_from_reference: true,
                 key: key.as_slice(),
                 value: value.as_slice(),
                 value_hash: crate::tree::combine_hash(
@@ -823,6 +840,10 @@ enum BoundaryKind<'a> {
         /// proof-carried value_hash (tree-flavored entries store
         /// `combine_hash(H(value), child_root)`).
         value_hash: CryptoHash,
+        /// `true` for the `KVRefValueHash*` family — `value` is the
+        /// dereferenced target's stored bytes. See
+        /// [`CountOffsetReturnedItem::resolved_from_reference`].
+        resolved_from_reference: bool,
     },
 }
 
@@ -864,6 +885,7 @@ fn apply_self_state(disposition: &BoundaryKind<'_>, state: &mut VerifyState) -> 
             key,
             value,
             value_hash,
+            resolved_from_reference,
         } => {
             if state.offset_remaining > 0 {
                 return Err(Error::InvalidProofError(
@@ -886,6 +908,7 @@ fn apply_self_state(disposition: &BoundaryKind<'_>, state: &mut VerifyState) -> 
                 key: key.to_vec(),
                 value: value.to_vec(),
                 value_hash: *value_hash,
+                resolved_from_reference: *resolved_from_reference,
                 // The current count-offset prover never emits
                 // `KVValueHashFeatureTypeWithChildHash` (it has no need
                 // to — Items in count trees don't have child merks to


### PR DESCRIPTION
Fixes #858.

References to `NonCounted`-wrapped items previously committed different hashes depending on whether they were written directly or in a batch. Batch-written references then failed integrity checks and V1 proof verification because those readers stripped the terminal's wrapper.

## Changes

- Add `follow_reference_as_stored`, which preserves the terminal's wrapper while still following wrapped intermediate references. Presentation reads through `follow_reference` retain their existing behavior.
- Select `add_element_on_transaction` v2 on `GROVE_V4`: new direct writes hash the stored terminal bytes, matching the existing batch and refresh paths. Earlier versions retain their original write commitments.
- Preserve existing data in both V1 proof-generation paths and `verify_grovedb`. Readers select the unwrapped terminal only when its combined hash matches the reference node's actual stored commitment; otherwise they use the stored terminal. This supports mixed direct/batch write histories, including GROVE_V3 data read after a GROVE_V4 upgrade, without rewriting rows or changing roots. Stale targets that match neither representation still fail verification. The prover reuses the hash already carried by the Merk node, and additional hashing costs are accumulated.
- Mark resolved reference rows in the count-offset verifier so a wrapped target is accepted while a forged wrapped own-entry remains rejected.

The V0 proof implementation, batch/refresh commitments, and pre-GROVE_V4 write behavior are unchanged.

## Validation

- Added regression cases failed before the compatibility fix and pass afterward.
- Coverage includes direct/batch root equality, exact stored hashes, legacy commitments under GROVE_V3 and GROVE_V4 readers, mixed write histories, wrapped chains, plain and sum-carrying references, regular and paginated proofs in both directions across all three supported count hosts, and stale-target rejection.
- Full GroveDB library test suite passes with `proof_debug,serde,unsafe-dump-load,verify,zk_client` plus default features.
- Verification-only build, Clippy for the GroveDB library, formatting, and pre-commit checks pass. The verification-only build emits existing warnings in unchanged code.
