### PR TITLE
fix: bind every sum-budget window row before it is folded or skipped (#870)

### DIFF
--- a/docs/book/src/unified-path-query.md
+++ b/docs/book/src/unified-path-query.md
@@ -296,6 +296,20 @@ unified trusted read uses the same semantics, so read and verified
 results agree over any state. The legacy `AggregateSumPathQuery`
 surface keeps its configurable options, including reference following.
 
+Every fold-or-skip decision rests on **bound element bytes**. An item row
+is bound because the Merk node hashes its value (`H(value) ==
+value_hash`). A composite row — a subtree or a reference — is carried on
+a `KVValueHashFeatureTypeWithChildHash` node whose child hash the Merk
+verifier closes with `combine_hash(H(value), child_hash) == value_hash`:
+the child Merk root (or `NULL_HASH`) for a subtree, the referenced
+element's value hash for a reference, and the tree's own state root for
+a non-Merk tree. A bare `KVValueHash` row would leave its bytes free to
+rewrite under a genuine root — enough to disguise a sum item as a tree
+and drop its contribution — so the verifier rejects any present row that
+is neither hashed as an item nor closed through a child hash. Indexed
+trees commit a three-input hash no proof node carries; a window that
+scans one is refused by the prover.
+
 ## Version gating
 
 Everything new activates at **GROVE_V4** and fails closed below it, on

--- a/docs/book/src/unified-path-query.md
+++ b/docs/book/src/unified-path-query.md
@@ -310,6 +310,13 @@ is neither hashed as an item nor closed through a child hash. Indexed
 trees commit a three-input hash no proof node carries; a window that
 scans one is refused by the prover.
 
+Reference witnesses preserve the representation committed by each row.
+The prover resolves the stored terminal, including `NonCounted` wrappers,
+then selects its unwrapped form only when that form matches the reference's
+persisted commitment. This supports legacy direct writes alongside batch
+and GROVE_V4 direct writes without rewriting state. A changed target whose
+hash no longer matches the reference still produces an invalid proof.
+
 ## Version gating
 
 Everything new activates at **GROVE_V4** and fails closed below it, on

--- a/grovedb/src/operations/proof/generate.rs
+++ b/grovedb/src/operations/proof/generate.rs
@@ -602,11 +602,7 @@ impl GroveDb {
                     );
                     let referenced_bytes = cost_return_on_error_no_add!(
                         cost,
-                        referenced.serialize(grove_version).map_err(|e| {
-                            Error::CorruptedData(format!(
-                                "sum-budget window: unable to serialize the referenced element: {e}"
-                            ))
-                        })
+                        referenced.serialize(grove_version).map_err(Error::from)
                     );
                     let referenced_hash = value_hash(&referenced_bytes).unwrap_add_cost(&mut cost);
                     *node = Node::KVValueHashFeatureTypeWithChildHash(

--- a/grovedb/src/operations/proof/generate.rs
+++ b/grovedb/src/operations/proof/generate.rs
@@ -1,6 +1,6 @@
 //! Generate proof operations
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, LinkedList};
 
 use grovedb_bulk_append_tree::BulkAppendTreeProof;
 use grovedb_commitment_tree::COMMITMENT_TREE_DATA_KEY;
@@ -11,7 +11,7 @@ use grovedb_costs::{
 use grovedb_dense_fixed_sized_merkle_tree::DenseTreeProof;
 use grovedb_merk::{
     proofs::{encode_into, query::QueryItem, Node, Op},
-    tree::{combine_hash, value_hash},
+    tree::{combine_hash, value_hash, NULL_HASH},
     Merk, ProofWithoutEncodingResult, TreeFeatureType,
 };
 use grovedb_merkle_mountain_range::MmrTreeProof;
@@ -476,28 +476,193 @@ impl GroveDb {
                 grove_version
             )
         );
-        let mut window_query = grovedb_merk::proofs::Query::new_with_direction(node.left_to_right);
-        window_query.items = node.items.clone();
         let window_limit = if exhausted {
             None
         } else {
             Some(walk.elements_scanned)
         };
-        let proof_result = cost_return_on_error!(
+        let mut window_proof = cost_return_on_error!(
             &mut cost,
-            target_merk
-                .prove(window_query, window_limit, grove_version)
-                .map_err(|e| Error::CorruptedData(format!(
-                    "sum-budget window: merk proof over the scanned window: {e}"
-                )))
+            self.generate_merk_proof(
+                &target_merk,
+                &node.items,
+                node.left_to_right,
+                window_limit,
+                grove_version,
+            )
         );
+
+        // 4. Bind every composite row so the verifier can authenticate
+        // the bytes it classifies (#870).
+        cost_return_on_error!(
+            &mut cost,
+            self.bind_sum_budget_window_rows(
+                &mut window_proof.proof,
+                target_path,
+                transaction,
+                grove_version,
+            )
+        );
+
+        let mut merk_proof = Vec::with_capacity(1024);
+        encode_into(window_proof.proof.iter(), &mut merk_proof);
 
         Ok(crate::operations::proof::SumBudgetWindowProof {
             exhausted,
             window_len: walk.elements_scanned,
-            merk_proof: proof_result.proof,
+            merk_proof,
         })
         .wrap_with_cost(cost)
+    }
+
+    /// Bind every value-bearing row of a sum-budget window proof to the
+    /// element bytes the verifier classifies (#870).
+    ///
+    /// A raw merk proof binds an item row through `KV` (the verifier hashes
+    /// the value bytes itself) but a tree or reference row through
+    /// `KVValueHash`, whose bytes the merk root does not cover. The window
+    /// verifier decides "fold or skip" from those bytes, so an unbound
+    /// composite row let a prover disguise a genuine sum item as a tree and
+    /// drop its contribution under a genuine root hash. Every composite row
+    /// is rewritten to a node the merk verifier checks end to end:
+    ///
+    /// - Merk trees: `KVValueHashFeatureTypeWithChildHash` carrying the
+    ///   child root (`NULL_HASH` for an empty tree), verified as
+    ///   `combine_hash(H(value), child_root) == value_hash` — the
+    ///   composition `insert` commits.
+    /// - References: the same node carrying the referenced element's value
+    ///   hash, which is the reference's committed composition.
+    /// - Non-Merk trees: [`Self::bind_terminal_non_merk_tree`] (their own
+    ///   state root).
+    /// - Indexed trees commit a three-input hash no proof node carries, so
+    ///   the window refuses them rather than emit an unbound row.
+    ///
+    /// Item rows are left as the merk prover emitted them.
+    fn bind_sum_budget_window_rows(
+        &self,
+        ops: &mut LinkedList<Op>,
+        target_path: &[&[u8]],
+        transaction: &Transaction,
+        grove_version: &GroveVersion,
+    ) -> CostResult<(), Error> {
+        let mut cost = OperationCost::default();
+
+        for op in ops.iter_mut() {
+            let node = match op {
+                Op::Push(node) | Op::PushInverted(node) => node,
+                _ => continue,
+            };
+            let (key, value, node_value_hash, feature_type) = match &*node {
+                Node::KVValueHash(key, value, value_hash) => (
+                    key.clone(),
+                    value.clone(),
+                    *value_hash,
+                    TreeFeatureType::BasicMerkNode,
+                ),
+                Node::KVValueHashFeatureType(key, value, value_hash, feature_type) => {
+                    (key.clone(), value.clone(), *value_hash, *feature_type)
+                }
+                // Items are pushed as KV / KVCount / KVSum / KVCountSum,
+                // whose value bytes the merk verifier hashes itself.
+                _ => continue,
+            };
+            let element = cost_return_on_error_no_add!(
+                cost,
+                Element::deserialize(&value, grove_version).map_err(Error::from)
+            )
+            .into_underlying();
+            if element.is_indexed_tree() {
+                return Err(Error::NotSupported(format!(
+                    "sum-budget window: the scanned row {} is an indexed tree, whose \
+                     three-input binding no proof node can carry",
+                    hex_to_ascii(&key)
+                )))
+                .wrap_with_cost(cost);
+            }
+            match element {
+                Element::Reference(reference_path, ..)
+                | Element::ReferenceWithSumItem(reference_path, ..) => {
+                    let absolute_path = cost_return_on_error_into!(
+                        &mut cost,
+                        path_from_reference_path_type(
+                            reference_path,
+                            target_path,
+                            Some(key.as_slice())
+                        )
+                        .wrap_with_cost(OperationCost::default())
+                    );
+                    let referenced = cost_return_on_error_into!(
+                        &mut cost,
+                        self.follow_reference(
+                            absolute_path.as_slice().into(),
+                            true,
+                            Some(transaction),
+                            grove_version
+                        )
+                    );
+                    let referenced_bytes = cost_return_on_error_no_add!(
+                        cost,
+                        referenced.serialize(grove_version).map_err(|e| {
+                            Error::CorruptedData(format!(
+                                "sum-budget window: unable to serialize the referenced element: {e}"
+                            ))
+                        })
+                    );
+                    let referenced_hash = value_hash(&referenced_bytes).unwrap_add_cost(&mut cost);
+                    *node = Node::KVValueHashFeatureTypeWithChildHash(
+                        key,
+                        value,
+                        node_value_hash,
+                        feature_type,
+                        referenced_hash,
+                    );
+                }
+                non_merk @ (Element::MmrTree(..)
+                | Element::BulkAppendTree(..)
+                | Element::DenseAppendOnlyFixedSizeTree(..)
+                | Element::CommitmentTree(..)
+                | Element::PrivateDocumentStore(..)) => {
+                    cost_return_on_error!(
+                        &mut cost,
+                        self.bind_terminal_non_merk_tree(
+                            node,
+                            &non_merk,
+                            target_path,
+                            transaction,
+                            grove_version,
+                        )
+                    );
+                }
+                tree if tree.is_any_tree() => {
+                    let child_root = if tree.is_non_empty_merk_tree() {
+                        let mut child_path = target_path.to_vec();
+                        child_path.push(key.as_slice());
+                        let child_merk = cost_return_on_error!(
+                            &mut cost,
+                            self.open_transactional_merk_at_path(
+                                child_path.as_slice().into(),
+                                transaction,
+                                None,
+                                grove_version
+                            )
+                        );
+                        child_merk.root_hash().unwrap_add_cost(&mut cost)
+                    } else {
+                        NULL_HASH
+                    };
+                    *node = Node::KVValueHashFeatureTypeWithChildHash(
+                        key,
+                        value,
+                        node_value_hash,
+                        feature_type,
+                        child_root,
+                    );
+                }
+                _ => continue,
+            }
+        }
+
+        Ok(()).wrap_with_cost(cost)
     }
 
     fn check_count_offset_target_tree_type(

--- a/grovedb/src/operations/proof/generate.rs
+++ b/grovedb/src/operations/proof/generate.rs
@@ -593,13 +593,30 @@ impl GroveDb {
                     );
                     let referenced = cost_return_on_error_into!(
                         &mut cost,
-                        self.follow_reference(
+                        self.follow_reference_as_stored(
                             absolute_path.as_slice().into(),
                             true,
                             Some(transaction),
                             grove_version
                         )
                     );
+                    // Legacy direct writes and stored-terminal commitments
+                    // can coexist. Select the bytes using this row's actual
+                    // commitment, independently of the version serving it.
+                    let referenced = if referenced.is_wrapped() {
+                        let reference_element_hash = value_hash(&value).unwrap_add_cost(&mut cost);
+                        cost_return_on_error!(
+                            &mut cost,
+                            Self::reference_terminal_as_committed(
+                                referenced,
+                                &reference_element_hash,
+                                &node_value_hash,
+                                grove_version,
+                            )
+                        )
+                    } else {
+                        referenced
+                    };
                     let referenced_bytes = cost_return_on_error_no_add!(
                         cost,
                         referenced.serialize(grove_version).map_err(Error::from)

--- a/grovedb/src/operations/proof/verify.rs
+++ b/grovedb/src/operations/proof/verify.rs
@@ -1329,19 +1329,14 @@ impl GroveDb {
             if element.is_reference() || !element.is_sum_item() {
                 continue;
             }
-            // A sum item commits the plain hash of its bytes; the merk
-            // verifier already refuses item elements on child-hash
-            // nodes, so this cannot fire on a proof it accepted.
-            if !simply_bound {
-                return Err(Error::InvalidProof(
-                    query.clone(),
-                    format!(
-                        "sum-budget window row {} folds as a sum item but is not bound by its \
-                         own value hash",
-                        hex::encode(key)
-                    ),
-                ));
-            }
+            // A sum item commits the plain hash of its bytes, and the
+            // merk verifier refuses item elements on child-hash nodes at
+            // proof version 1, so a row that reaches the fold is always
+            // simply bound on a proof it accepted.
+            debug_assert!(
+                simply_bound,
+                "a folded sum item row must be bound by its own hash"
+            );
             let value = match element.into_underlying() {
                 Element::SumItem(value, _) => value,
                 Element::ItemWithSumItem(_, value, _) => value,

--- a/grovedb/src/operations/proof/verify.rs
+++ b/grovedb/src/operations/proof/verify.rs
@@ -1248,12 +1248,18 @@ impl GroveDb {
                 )
             })?;
 
-        // Present rows only, in walk order; absent keys (value None)
-        // are covered by the proof but never scanned by the engine.
-        let window: Vec<(&Vec<u8>, &Vec<u8>)> = window_result
+        // Present rows only, in walk order, each kept WITH its binding
+        // evidence (the merk-surfaced value hash and whether a child hash
+        // was verified); absent keys (value None) are covered by the
+        // proof but never scanned by the engine.
+        let window: Vec<(&Vec<u8>, &Vec<u8>, &CryptoHash, bool)> = window_result
             .result_set
             .iter()
-            .filter_map(|row| row.value.as_ref().map(|value| (&row.key, value)))
+            .filter_map(|row| {
+                row.value
+                    .as_ref()
+                    .map(|value| (&row.key, value, &row.proof, row.child_hash_verified))
+            })
             .collect();
         if window.len() != payload.window_len as usize {
             return Err(Error::InvalidProof(
@@ -1278,7 +1284,7 @@ impl GroveDb {
         let mut matches: Vec<(Vec<u8>, i64)> = Vec::new();
         let mut hard_cap_tripped = false;
 
-        for (key, value_bytes) in &window {
+        for (key, value_bytes, row_value_hash, child_hash_verified) in &window {
             // Pre-element conditions (the engine's loop guards): a
             // window that continues past a fired stop hides where the
             // walk really ended.
@@ -1286,6 +1292,27 @@ impl GroveDb {
                 return Err(Error::InvalidProof(
                     query.clone(),
                     "sum-budget window continues past its stop condition".to_string(),
+                ));
+            }
+            // Binding evidence (#870): the fold/skip decision below reads
+            // the element bytes, so they must be the bytes the root
+            // commits. An item row is bound when the merk verifier hashed
+            // its value itself (`H(value) == value_hash`); a composite row
+            // (tree, reference) is bound only when the merk verifier
+            // checked `combine_hash(H(value), child_hash) == value_hash`
+            // on a node carrying the child hash. A bare `KVValueHash` row
+            // satisfies neither: its bytes are free for a prover to
+            // rewrite under a genuine root, which is exactly how a sum
+            // item could be disguised as a tree and dropped.
+            let simply_bound = value_hash(value_bytes).value() == *row_value_hash;
+            if !simply_bound && !*child_hash_verified {
+                return Err(Error::InvalidProof(
+                    query.clone(),
+                    format!(
+                        "sum-budget window row {} presents element bytes the proof does not \
+                         bind: a composite row must carry its child hash",
+                        hex::encode(key)
+                    ),
                 ));
             }
             scanned = scanned.saturating_add(1);
@@ -1298,8 +1325,22 @@ impl GroveDb {
             let element = Element::deserialize(value_bytes, grove_version)?;
             // Provable fold semantics: references and non-sum elements
             // are skipped (they cannot be replayed / do not contribute).
+            // Their bytes are authenticated above, so the skip is too.
             if element.is_reference() || !element.is_sum_item() {
                 continue;
+            }
+            // A sum item commits the plain hash of its bytes; the merk
+            // verifier already refuses item elements on child-hash
+            // nodes, so this cannot fire on a proof it accepted.
+            if !simply_bound {
+                return Err(Error::InvalidProof(
+                    query.clone(),
+                    format!(
+                        "sum-budget window row {} folds as a sum item but is not bound by its \
+                         own value hash",
+                        hex::encode(key)
+                    ),
+                ));
             }
             let value = match element.into_underlying() {
                 Element::SumItem(value, _) => value,

--- a/grovedb/src/tests/sum_budget_proof_tests.rs
+++ b/grovedb/src/tests/sum_budget_proof_tests.rs
@@ -5,7 +5,10 @@
 
 #[cfg(test)]
 mod tests {
-    use grovedb_merk::proofs::query::query_item::QueryItem;
+    use grovedb_merk::{
+        proofs::{encode_into, query::query_item::QueryItem, Decoder, Node, Op},
+        tree::value_hash,
+    };
     use grovedb_version::version::{GroveVersion, GROVE_VERSIONS};
 
     use crate::{
@@ -352,5 +355,293 @@ mod tests {
             Err(Error::NotSupported(_)) => {}
             other => panic!("V3 verifier must reject sum-budget shapes, got {other:?}"),
         }
+    }
+
+    // -----------------------------------------------------------------
+    // Row binding (#870): every row's classification must rest on
+    // authenticated element bytes
+    // -----------------------------------------------------------------
+
+    /// Rewrites the merk ops inside the sum-budget window payload.
+    fn tamper_window_ops(proof: &[u8], mutate: impl FnOnce(&mut Vec<Op>)) -> Vec<u8> {
+        tamper_window(proof, |payload| {
+            let mut ops: Vec<Op> = Decoder::new(&payload.merk_proof)
+                .map(|op| op.expect("decode window op"))
+                .collect();
+            mutate(&mut ops);
+            let mut bytes = Vec::new();
+            encode_into(ops.iter(), &mut bytes);
+            payload.merk_proof = bytes;
+        })
+    }
+
+    #[test]
+    fn a_sum_item_row_disguised_as_a_composite_element_is_rejected() {
+        // Re-present the genuine KV node of `b` (5) as a KVValueHash node
+        // carrying an empty-tree element while keeping the genuine value
+        // hash. The merk root still verifies — KVValueHash hashes only
+        // (key, value_hash) — so a verifier that classified rows from the
+        // presented bytes would skip `b` and report a total short by 5.
+        let grove_version = GroveVersion::latest();
+        let db = make_test_sum_tree_grovedb(grove_version);
+        build_sum_tree(&db, grove_version);
+        let pq = budget_query(1_000, None);
+        let proof = prove(&db, &pq, grove_version);
+        let (_, matches, honest_total, stop) = verify_budget(&proof, &pq, grove_version);
+        assert_eq!(stop, SumBudgetStop::Exhausted);
+        assert_eq!(matches.len(), SUM_ENTRIES.len());
+        assert_eq!(honest_total, 62);
+
+        let disguise = Element::empty_tree()
+            .serialize(grove_version)
+            .expect("serialize disguise");
+        let tampered = tamper_window_ops(&proof, |ops| {
+            let mut hit = false;
+            for op in ops.iter_mut() {
+                let replacement = match &*op {
+                    Op::Push(Node::KV(key, value)) if key.as_slice() == b"b" => {
+                        Some(Op::Push(Node::KVValueHash(
+                            key.clone(),
+                            disguise.clone(),
+                            *value_hash(value).value(),
+                        )))
+                    }
+                    Op::PushInverted(Node::KV(key, value)) if key.as_slice() == b"b" => {
+                        Some(Op::PushInverted(Node::KVValueHash(
+                            key.clone(),
+                            disguise.clone(),
+                            *value_hash(value).value(),
+                        )))
+                    }
+                    _ => None,
+                };
+                if let Some(replacement) = replacement {
+                    *op = replacement;
+                    hit = true;
+                }
+            }
+            assert!(hit, "the window carries `b` as a KV node");
+        });
+        let err = GroveDb::verify_path_query(&tampered, &pq, grove_version)
+            .expect_err("a sum item disguised as a composite element must be rejected");
+        assert!(matches!(err, Error::InvalidProof(..)), "{err:?}");
+    }
+
+    /// TEST_LEAF: a(7), then composite rows the fold skips — a reference
+    /// to `a`, an empty subtree, a populated subtree, a bulk-append
+    /// tree — then b(5).
+    const COMPOSITE_KEYS: &[&[u8]] = &[b"ab_ref", b"ac_empty", b"ad_full", b"ae_bulk"];
+
+    fn build_sum_tree_with_composite_rows(db: &GroveDb, grove_version: &GroveVersion) {
+        use crate::reference_path::ReferencePathType;
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"a",
+            Element::new_sum_item(7),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert a");
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"ab_ref",
+            Element::new_reference(ReferencePathType::AbsolutePathReference(vec![
+                TEST_LEAF.to_vec(),
+                b"a".to_vec(),
+            ])),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert reference");
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"ac_empty",
+            Element::empty_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert empty subtree");
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"ad_full",
+            Element::empty_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert subtree");
+        db.insert(
+            [TEST_LEAF, b"ad_full".as_slice()].as_ref(),
+            b"child",
+            Element::new_item(b"child".to_vec()),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert subtree child");
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"ae_bulk",
+            Element::empty_bulk_append_tree(2).expect("chunk power"),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert bulk tree");
+        db.bulk_append(
+            [TEST_LEAF].as_ref(),
+            b"ae_bulk",
+            b"entry".to_vec(),
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("bulk append");
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"b",
+            Element::new_sum_item(5),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert b");
+    }
+
+    fn trusted_matches(
+        db: &GroveDb,
+        pq: &PathQuery,
+        grove_version: &GroveVersion,
+    ) -> Vec<(Vec<u8>, i64)> {
+        let run = db
+            .run_path_query(
+                pq,
+                true,
+                true,
+                true,
+                crate::query_result_type::QueryResultType::QueryKeyElementPairResultType,
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("trusted read");
+        let crate::operations::get::PathQueryRun::SumBudget(read) = run else {
+            panic!("expected SumBudget run");
+        };
+        read.results
+    }
+
+    #[test]
+    fn composite_rows_are_bound_before_they_are_skipped() {
+        // Honest windows containing every composite row kind verify and
+        // agree with the trusted read; each composite row is carried on a
+        // child-hash node the merk verifier closes, and downgrading any of
+        // them to a bare KVValueHash (which keeps the root intact) is
+        // rejected as an unbound classification.
+        let grove_version = GroveVersion::latest();
+        let db = make_test_sum_tree_grovedb(grove_version);
+        build_sum_tree_with_composite_rows(&db, grove_version);
+
+        for (sum_limit, match_limit) in [(1_000u64, None), (10, None), (1_000, Some(1u16))] {
+            let pq = budget_query(sum_limit, match_limit);
+            let proof = prove(&db, &pq, grove_version);
+            let (_, matches, total, _) = verify_budget(&proof, &pq, grove_version);
+            assert_eq!(
+                matches,
+                trusted_matches(&db, &pq, grove_version),
+                "sum_limit={sum_limit} match_limit={match_limit:?}: verified matches must be \
+                 the trusted read's"
+            );
+            assert_eq!(total, matches.iter().map(|(_, v)| v).sum::<i64>());
+        }
+
+        // The exhausted window scans every row: a, four composites, b.
+        let pq = budget_query(1_000, None);
+        let proof = prove(&db, &pq, grove_version);
+        let (_, matches, total, stop) = verify_budget(&proof, &pq, grove_version);
+        assert_eq!(stop, SumBudgetStop::Exhausted);
+        assert_eq!(matches, vec![(b"a".to_vec(), 7), (b"b".to_vec(), 5)]);
+        assert_eq!(total, 12);
+
+        for composite in COMPOSITE_KEYS {
+            let downgraded = tamper_window_ops(&proof, |ops| {
+                let mut hit = false;
+                for op in ops.iter_mut() {
+                    let replacement =
+                        match &*op {
+                            Op::Push(Node::KVValueHashFeatureTypeWithChildHash(
+                                key,
+                                value,
+                                value_hash,
+                                ..,
+                            )) if key.as_slice() == *composite => Some(Op::Push(
+                                Node::KVValueHash(key.clone(), value.clone(), *value_hash),
+                            )),
+                            Op::PushInverted(Node::KVValueHashFeatureTypeWithChildHash(
+                                key,
+                                value,
+                                value_hash,
+                                ..,
+                            )) if key.as_slice() == *composite => Some(Op::PushInverted(
+                                Node::KVValueHash(key.clone(), value.clone(), *value_hash),
+                            )),
+                            _ => None,
+                        };
+                    if let Some(replacement) = replacement {
+                        *op = replacement;
+                        hit = true;
+                    }
+                }
+                assert!(
+                    hit,
+                    "{}: the honest window carries the row on a child-hash node",
+                    String::from_utf8_lossy(composite)
+                );
+            });
+            let err = GroveDb::verify_path_query(&downgraded, &pq, grove_version).expect_err(
+                "a composite row stripped of its child hash must be rejected as unbound",
+            );
+            assert!(
+                matches!(err, Error::InvalidProof(..)),
+                "{}: {err:?}",
+                String::from_utf8_lossy(composite)
+            );
+        }
+    }
+
+    #[test]
+    fn indexed_tree_rows_are_refused_rather_than_left_unbound() {
+        // An indexed tree commits a three-input hash no proof node can
+        // carry; a window scanning one is refused by the prover instead
+        // of shipping an unbound row the verifier would reject anyway.
+        let grove_version = GroveVersion::latest();
+        let db = make_test_sum_tree_grovedb(grove_version);
+        build_sum_tree(&db, grove_version);
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"ba_indexed",
+            Element::empty_provable_sum_indexed_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert indexed tree");
+        let pq = budget_query(1_000, None);
+        let err = db
+            .prove_query(&pq, None, grove_version)
+            .unwrap()
+            .expect_err("a window over an indexed tree row must be refused");
+        assert!(matches!(err, Error::NotSupported(_)), "{err:?}");
     }
 }

--- a/grovedb/src/tests/sum_budget_proof_tests.rs
+++ b/grovedb/src/tests/sum_budget_proof_tests.rs
@@ -785,4 +785,230 @@ mod tests {
             .expect_err("a feature-typed row stripped of its child hash must be rejected");
         assert!(matches!(err, Error::InvalidProof(..)), "{err:?}");
     }
+
+    /// The window may mix legacy direct-written references and stored-terminal
+    /// commitments, including references carrying sums and wrapped chain hops.
+    #[test]
+    fn wrapped_reference_rows_preserve_mixed_commitments() {
+        use crate::{
+            batch::QualifiedGroveDbOp, reference_path::ReferencePathType, tests::common::EMPTY_PATH,
+        };
+        use grovedb_version::version::v3::GROVE_V3;
+
+        let v = GroveVersion::latest();
+        for host in [
+            Element::empty_sum_tree(),
+            Element::empty_provable_sum_tree(),
+            Element::empty_provable_count_sum_tree(),
+            Element::empty_provable_count_provable_sum_tree(),
+        ] {
+            for inner in [
+                Element::new_item(b"payload".to_vec()),
+                Element::new_sum_item(17),
+                Element::new_item_with_sum_item(b"payload".to_vec(), 17),
+            ] {
+                let db = make_test_sum_tree_grovedb(v);
+                db.insert(EMPTY_PATH, b"window", host.clone(), None, None, v)
+                    .unwrap()
+                    .unwrap();
+                db.insert(
+                    EMPTY_PATH,
+                    b"targets",
+                    Element::empty_count_sum_tree(),
+                    None,
+                    None,
+                    v,
+                )
+                .unwrap()
+                .unwrap();
+                let wrapped = Element::new_non_counted(inner.clone()).unwrap();
+                db.insert(
+                    [b"targets".as_slice()].as_ref(),
+                    b"target",
+                    wrapped.clone(),
+                    None,
+                    None,
+                    v,
+                )
+                .unwrap()
+                .unwrap();
+                let to_target = ReferencePathType::AbsolutePathReference(vec![
+                    b"targets".to_vec(),
+                    b"target".to_vec(),
+                ]);
+                db.insert(
+                    [b"targets".as_slice()].as_ref(),
+                    b"hop",
+                    Element::new_non_counted(Element::new_reference(to_target.clone())).unwrap(),
+                    None,
+                    None,
+                    v,
+                )
+                .unwrap()
+                .unwrap();
+                for (key, sum) in [(b"a", 7), (b"b", 5)] {
+                    db.insert(
+                        [b"window".as_slice()].as_ref(),
+                        key,
+                        Element::new_sum_item(sum),
+                        None,
+                        None,
+                        v,
+                    )
+                    .unwrap()
+                    .unwrap();
+                }
+                let to_hop = ReferencePathType::AbsolutePathReference(vec![
+                    b"targets".to_vec(),
+                    b"hop".to_vec(),
+                ]);
+                for (key, version, batch, reference) in [
+                    (
+                        b"ab_legacy".as_slice(),
+                        &GROVE_V3,
+                        false,
+                        Element::new_reference(to_target.clone()),
+                    ),
+                    (
+                        b"ac_batch".as_slice(),
+                        &GROVE_V3,
+                        true,
+                        Element::new_reference(to_target.clone()),
+                    ),
+                    (
+                        b"ad_direct".as_slice(),
+                        v,
+                        false,
+                        Element::new_reference_with_sum_item(to_target.clone(), 1000),
+                    ),
+                    (
+                        b"ae_chain".as_slice(),
+                        v,
+                        true,
+                        Element::new_reference_with_sum_item(to_hop, 1000),
+                    ),
+                ] {
+                    if batch {
+                        db.apply_batch(
+                            vec![QualifiedGroveDbOp::insert_or_replace_op(
+                                vec![b"window".to_vec()],
+                                key.to_vec(),
+                                reference,
+                            )],
+                            None,
+                            None,
+                            version,
+                        )
+                        .unwrap()
+                        .unwrap();
+                    } else {
+                        db.insert(
+                            [b"window".as_slice()].as_ref(),
+                            key,
+                            reference,
+                            None,
+                            None,
+                            version,
+                        )
+                        .unwrap()
+                        .unwrap();
+                    }
+                }
+
+                let root = root_hash(&db, v);
+                for ascending in [false, true] {
+                    for (budget, limit, expected_stop) in [
+                        (10, None, SumBudgetStop::BudgetReached),
+                        (1000, None, SumBudgetStop::Exhausted),
+                        (1000, Some(2), SumBudgetStop::MatchLimitReached),
+                    ] {
+                        let pq = PathQuery::new_sum_budget(
+                            vec![b"window".to_vec()],
+                            vec![QueryItem::RangeFull(..)],
+                            ascending,
+                            budget,
+                            limit,
+                        );
+                        let proof = prove(&db, &pq, v);
+                        let (verified_root, matches, total, stop) = verify_budget(&proof, &pq, v);
+                        assert_eq!(verified_root, root);
+                        assert_eq!(matches, trusted_matches(&db, &pq, v));
+                        assert_eq!(total, 12, "reference sums and target sums are skipped");
+                        assert_eq!(stop, expected_stop);
+                    }
+                }
+                assert_eq!(
+                    root_hash(&db, v),
+                    root,
+                    "proof serving must not rewrite commitments"
+                );
+
+                let pq = PathQuery::new_sum_budget(
+                    vec![b"window".to_vec()],
+                    vec![QueryItem::RangeFull(..)],
+                    true,
+                    1000,
+                    None,
+                );
+                let proof = prove(&db, &pq, v);
+                // Flipping a row's witness to the other representation must
+                // fail: supporting both formats cannot weaken hash binding.
+                for key in [
+                    b"ab_legacy".as_slice(),
+                    b"ac_batch",
+                    b"ad_direct",
+                    b"ae_chain",
+                ] {
+                    let wrong_terminal = if key == b"ab_legacy" {
+                        &wrapped
+                    } else {
+                        &inner
+                    };
+                    let wrong_hash = value_hash(&wrong_terminal.serialize(v).unwrap()).unwrap();
+                    let tampered = tamper_window_ops(&proof, |ops| {
+                        let mut hit = false;
+                        for op in ops {
+                            if let Op::Push(Node::KVValueHashFeatureTypeWithChildHash(
+                                row_key,
+                                _,
+                                _,
+                                _,
+                                child_hash,
+                            )) = op
+                            {
+                                if row_key == key {
+                                    assert_ne!(*child_hash, wrong_hash);
+                                    *child_hash = wrong_hash;
+                                    hit = true;
+                                }
+                            }
+                        }
+                        assert!(hit, "the reference row must carry a bound witness");
+                    });
+                    assert!(matches!(
+                        GroveDb::verify_path_query(&tampered, &pq, v),
+                        Err(Error::InvalidProof(..))
+                    ));
+                }
+
+                // Neither representation of a changed target can satisfy the
+                // old commitment. Compatibility must not conceal stale refs.
+                db.insert(
+                    [b"targets".as_slice()].as_ref(),
+                    b"target",
+                    Element::new_non_counted(Element::new_item(b"changed".to_vec())).unwrap(),
+                    None,
+                    None,
+                    v,
+                )
+                .unwrap()
+                .unwrap();
+                let stale_proof = prove(&db, &pq, v);
+                assert!(matches!(
+                    GroveDb::verify_path_query(&stale_proof, &pq, v),
+                    Err(Error::InvalidProof(..))
+                ));
+            }
+        }
+    }
 }

--- a/grovedb/src/tests/sum_budget_proof_tests.rs
+++ b/grovedb/src/tests/sum_budget_proof_tests.rs
@@ -428,9 +428,15 @@ mod tests {
     }
 
     /// TEST_LEAF: a(7), then composite rows the fold skips — a reference
-    /// to `a`, an empty subtree, a populated subtree, a bulk-append
-    /// tree — then b(5).
-    const COMPOSITE_KEYS: &[&[u8]] = &[b"ab_ref", b"ac_empty", b"ad_full", b"ae_bulk"];
+    /// to `a`, a reference carrying a sum, an empty subtree, a populated
+    /// subtree, a bulk-append tree — then b(5).
+    const COMPOSITE_KEYS: &[&[u8]] = &[
+        b"ab_ref",
+        b"ab_ref_sum",
+        b"ac_empty",
+        b"ad_full",
+        b"ae_bulk",
+    ];
 
     fn build_sum_tree_with_composite_rows(db: &GroveDb, grove_version: &GroveVersion) {
         use crate::reference_path::ReferencePathType;
@@ -457,6 +463,21 @@ mod tests {
         )
         .unwrap()
         .expect("insert reference");
+        // A reference that carries its own sum contribution is still a
+        // reference to the fold: skipped, never folded.
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"ab_ref_sum",
+            Element::new_reference_with_sum_item(
+                ReferencePathType::AbsolutePathReference(vec![TEST_LEAF.to_vec(), b"a".to_vec()]),
+                1_000,
+            ),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert reference with sum item");
         db.insert(
             [TEST_LEAF].as_ref(),
             b"ac_empty",
@@ -643,5 +664,125 @@ mod tests {
             .unwrap()
             .expect_err("a window over an indexed tree row must be refused");
         assert!(matches!(err, Error::NotSupported(_)), "{err:?}");
+    }
+
+    #[test]
+    fn composite_rows_in_a_provable_sum_tree_target_are_bound_too() {
+        // A provable sum tree emits its composite rows on feature-typed
+        // nodes; the window binder must carry that feature type through
+        // to the child-hash node, and stripping the child hash is still
+        // rejected.
+        use crate::tests::common::EMPTY_PATH;
+        let grove_version = GroveVersion::latest();
+        let db = make_test_sum_tree_grovedb(grove_version);
+        db.insert(
+            EMPTY_PATH,
+            b"psum",
+            Element::empty_provable_sum_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert provable sum tree");
+        db.insert(
+            [b"psum".as_slice()].as_ref(),
+            b"a",
+            Element::new_sum_item(7),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert a");
+        db.insert(
+            [b"psum".as_slice()].as_ref(),
+            b"ab_tree",
+            Element::empty_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert subtree");
+        db.insert(
+            [b"psum".as_slice(), b"ab_tree".as_slice()].as_ref(),
+            b"child",
+            Element::new_item(b"child".to_vec()),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert subtree child");
+        db.insert(
+            [b"psum".as_slice()].as_ref(),
+            b"b",
+            Element::new_sum_item(5),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert b");
+
+        let pq = PathQuery::new_sum_budget(
+            vec![b"psum".to_vec()],
+            vec![QueryItem::RangeFull(..)],
+            true,
+            1_000,
+            None,
+        );
+        let proof = prove(&db, &pq, grove_version);
+        let (_, matches, total, stop) = verify_budget(&proof, &pq, grove_version);
+        assert_eq!(stop, SumBudgetStop::Exhausted);
+        assert_eq!(matches, trusted_matches(&db, &pq, grove_version));
+        assert_eq!(matches, vec![(b"a".to_vec(), 7), (b"b".to_vec(), 5)]);
+        assert_eq!(total, 12);
+
+        let downgraded = tamper_window_ops(&proof, |ops| {
+            let mut hit = false;
+            for op in ops.iter_mut() {
+                let replacement = match &*op {
+                    Op::Push(Node::KVValueHashFeatureTypeWithChildHash(
+                        key,
+                        value,
+                        value_hash,
+                        feature_type,
+                        _,
+                    )) if key.as_slice() == b"ab_tree" => {
+                        Some(Op::Push(Node::KVValueHashFeatureType(
+                            key.clone(),
+                            value.clone(),
+                            *value_hash,
+                            *feature_type,
+                        )))
+                    }
+                    Op::PushInverted(Node::KVValueHashFeatureTypeWithChildHash(
+                        key,
+                        value,
+                        value_hash,
+                        feature_type,
+                        _,
+                    )) if key.as_slice() == b"ab_tree" => {
+                        Some(Op::PushInverted(Node::KVValueHashFeatureType(
+                            key.clone(),
+                            value.clone(),
+                            *value_hash,
+                            *feature_type,
+                        )))
+                    }
+                    _ => None,
+                };
+                if let Some(replacement) = replacement {
+                    *op = replacement;
+                    hit = true;
+                }
+            }
+            assert!(hit, "the subtree row rides on a child-hash node");
+        });
+        let err = GroveDb::verify_path_query(&downgraded, &pq, grove_version)
+            .expect_err("a feature-typed row stripped of its child hash must be rejected");
+        assert!(matches!(err, Error::InvalidProof(..)), "{err:?}");
     }
 }


### PR DESCRIPTION
Closes #870.

A sum-budget window could present a genuine sum item as an unbound composite row and make the verifier skip its contribution while retaining the genuine root hash. The prover now binds every scanned composite row, and the verifier checks those bindings before deciding whether to fold or skip the row.

## Changes

- Bind subtree rows to their child Merk root and non-Merk trees to their state root. Refuse indexed-tree rows whose three-input commitment cannot be carried by the available proof nodes.
- Bind reference rows to the terminal representation matching their persisted commitment. Reuse the shared resolver from #874 so V3 direct writes, batch writes, V4 direct writes, and wrapped reference chains can coexist without changing stored commitments.
- Reject present rows whose value bytes are neither directly hashed nor authenticated through a verified child hash. Tampered witnesses and stale reference targets remain invalid.
- Document the sum-budget binding contract. The existing GROVE_V4 gate and V1 envelope apply.

## Validation

- Reproduced the wrapped-terminal regression before the fix: proof verification failed with a value/child hash mismatch.
- All 15 sum-budget tests pass. Coverage includes forged row classifications, mixed reference commitments, three wrapped terminal types, four sum-tree types, both scan directions, stop reasons, trusted-read agreement, and witness tampering.
- `cargo test -p grovedb --offline --all-features --lib`: 3,030 passed, 0 failed, 2 ignored.
- `cargo clippy -p grovedb --offline --all-features --lib`: passed without warnings.
- `cargo check -p grovedb --offline --no-default-features --features verify`: passed, with existing unused-code warnings outside the changed files.
- Formatting, diff checks, and all commit hooks passed.
