### PR TITLE
fix(proof): bind a tree's claimed emptiness before skipping its descent or dropping it (#869)

### DIFF
--- a/grovedb/src/operations/proof/verify.rs
+++ b/grovedb/src/operations/proof/verify.rs
@@ -2273,87 +2273,10 @@ impl GroveDb {
                                 || !matches!(element, Element::Tree(None, _)))
                     {
                         // For empty trees in the result set (no lower layer
-                        // proof), verify that the value_hash matches
-                        // combine_hash(H(value), NULL_HASH). Without this
-                        // check, an attacker could swap tree types (e.g.
-                        // SumTree→Tree) in KVValueHash nodes without breaking
-                        // the merk proof, since the value bytes are not part of
-                        // the KVValueHash tree hash computation.
-                        //
-                        // Indexed-tree elements (PCIT / PSIT / PCPSIT) have TWO
-                        // (or more) child Merks — a primary and one-or-more
-                        // secondaries — so their empty terminal proofs commit
-                        // `combine_hash_three(H(value), NULL_HASH, second)`
-                        // rather than the two-input `combine_hash`.
-                        //   - Empty PCIT / PSIT: `second = NULL_HASH` (the lone
-                        //     secondary's root hash while empty).
-                        //   - Empty PCPSIT: `second = axes_digest(zero_axes)`,
-                        //     the digest over the element's own axes list with
-                        //     every axis's secondary root hash = NULL_HASH.
-                        // These mirror the insert commit path in
-                        // add_element_on_transaction/v1.rs. Without the
-                        // indexed-specific arms, honest empty-indexed terminal
-                        // proofs fail verification.
-                        let empty_indexed_expected: Option<CryptoHash> = match &element {
-                            Element::ProvableCountIndexedTree(None, None, 0, _)
-                            | Element::ProvableSumIndexedTree(None, None, 0, _) => Some(
-                                combine_hash_three(
-                                    value_hash(value_bytes).value(),
-                                    &NULL_HASH,
-                                    &NULL_HASH,
-                                )
-                                .value()
-                                .to_owned(),
-                            ),
-                            Element::ProvableCountProvableSumIndexedTree(None, 0, 0, axes, _)
-                                if axes.iter().all(|(_, sk)| sk.is_none()) =>
-                            {
-                                let zero_axes: Vec<(u8, CryptoHash)> =
-                                    axes.iter().map(|(t, _)| (*t, NULL_HASH)).collect();
-                                let digest = axes_digest(&zero_axes).value().to_owned();
-                                Some(
-                                    combine_hash_three(
-                                        value_hash(value_bytes).value(),
-                                        &NULL_HASH,
-                                        &digest,
-                                    )
-                                    .value()
-                                    .to_owned(),
-                                )
-                            }
-                            _ => None,
-                        };
-                        if let Some(expected_value_hash) = empty_indexed_expected {
-                            if hash != &expected_value_hash {
-                                return Err(Error::InvalidProof(
-                                    query.clone(),
-                                    format!(
-                                        "V1 empty indexed-tree value hash mismatch at key {}: \
-                                         expected {}, got {}",
-                                        hex::encode(key),
-                                        hex::encode(hash),
-                                        hex::encode(expected_value_hash)
-                                    ),
-                                ));
-                            }
-                        } else if element.is_any_tree() && !element.is_non_empty_tree() {
-                            let expected_value_hash =
-                                combine_hash(value_hash(value_bytes).value(), &NULL_HASH)
-                                    .value()
-                                    .to_owned();
-                            if hash != &expected_value_hash {
-                                return Err(Error::InvalidProof(
-                                    query.clone(),
-                                    format!(
-                                        "V1 empty tree value hash mismatch at key {}: \
-                                         expected {}, got {}",
-                                        hex::encode(key),
-                                        hex::encode(hash),
-                                        hex::encode(expected_value_hash)
-                                    ),
-                                ));
-                            }
-                        }
+                        // proof), bind the element bytes to the proof's
+                        // value_hash before trusting anything decoded from
+                        // them (see `verify_empty_tree_binding`).
+                        Self::verify_empty_tree_binding(query, key, &element, value_bytes, hash)?;
 
                         // For trees reported without a subquery (no lower layer
                         // proof), the prover must use
@@ -2420,13 +2343,22 @@ impl GroveDb {
                         && internal_query.has_subquery_or_matching_in_path_on_key(key)
                     {
                         // An EMPTY tree a subquery matches: an empty
-                        // child, not a result row. When the governing
-                        // query asks for parent-tree inclusion, the
-                        // matched parent is still reported — empty and
-                        // non-empty parents must behave alike — and,
-                        // like every parent-tree row, it does not
-                        // consume a budget slot (the documented
-                        // known limitation on the flag).
+                        // child, not a result row. "Empty" is so far
+                        // only what the element bytes CLAIM, and a
+                        // `KVValueHash*` node does not hash those bytes
+                        // — a prover can rewrite a populated tree into
+                        // its empty form, omit the lower layer, and the
+                        // root still verifies. Bind the claim to the
+                        // proof's value_hash before acting on it; the
+                        // real tree's child hash is NULL_HASH only if it
+                        // really is empty (issue #869).
+                        Self::verify_empty_tree_binding(query, key, &element, value_bytes, hash)?;
+                        // When the governing query asks for parent-tree
+                        // inclusion, the matched parent is still
+                        // reported — empty and non-empty parents must
+                        // behave alike — and, like every parent-tree
+                        // row, it does not consume a budget slot (the
+                        // documented known limitation on the flag).
                         if query.should_add_parent_tree_at_path(current_path, grove_version)? {
                             let path_key_optional_value =
                                 ProvedPathKeyOptionalValue::from_proved_key_value(
@@ -2453,6 +2385,32 @@ impl GroveDb {
                                 hex::encode(key),
                             ),
                         ));
+                    } else if element.is_any_tree() && !element.is_non_empty_tree() {
+                        // A claimed-empty plain `Tree` at a terminal
+                        // position while the caller excludes empty trees
+                        // from results (`include_empty_trees_in_result`
+                        // is false). It is not reported, but the claim
+                        // still decides that a key the trusted read
+                        // returns is absent from the result set — so it
+                        // must be bound exactly like a reported empty
+                        // tree (issue #869).
+                        Self::verify_empty_tree_binding(query, key, &element, value_bytes, hash)?;
+                    } else {
+                        // Every classification the verifier can act on
+                        // is either descended into (bound through its
+                        // lower layer), reported (bound above), or a
+                        // bound empty tree. Nothing else may be
+                        // silently skipped: the element bytes of a
+                        // `KVValueHash*` node are unauthenticated until
+                        // one of those paths binds them.
+                        return Err(Error::InvalidProof(
+                            query.clone(),
+                            format!(
+                                "V1 proof reports an element at key {} that is neither \
+                                 descended into nor bound to the proof",
+                                hex::encode(key),
+                            ),
+                        ));
                     }
                 }
             }
@@ -2475,6 +2433,94 @@ impl GroveDb {
         }
 
         Ok(root_hash)
+    }
+
+    /// Bind a claimed-empty tree's element bytes to the proof's
+    /// authenticated `value_hash`.
+    ///
+    /// A merk `KVValueHash*` node hashes `(key, value_hash)`; the element
+    /// bytes it carries are NOT part of the merk root, so everything the
+    /// verifier decodes from them — tree type, emptiness — is a claim
+    /// until it is tied to `value_hash`. A non-empty tree is tied through
+    /// the lower layer it descends into (`combine_hash(H(value), lower
+    /// root)`) or the child hash it must carry when reported terminally.
+    /// An empty tree has no lower layer, so the tie is that its committed
+    /// child hash is NULL_HASH: `value_hash == combine_hash(H(value),
+    /// NULL_HASH)`. Without this a prover could swap tree types
+    /// (SumTree→Tree) or rewrite a populated tree into its empty form —
+    /// omitting the descent — without breaking the merk proof.
+    ///
+    /// Indexed-tree elements (PCIT / PSIT / PCPSIT) have TWO (or more)
+    /// child Merks — a primary and one-or-more secondaries — so their
+    /// empty form commits `combine_hash_three(H(value), NULL_HASH,
+    /// second)` rather than the two-input `combine_hash`:
+    ///   - Empty PCIT / PSIT: `second = NULL_HASH` (the lone secondary's
+    ///     root hash while empty).
+    ///   - Empty PCPSIT: `second = axes_digest(zero_axes)`, the digest
+    ///     over the element's own axes list with every axis's secondary
+    ///     root hash = NULL_HASH.
+    /// These mirror the insert commit path in
+    /// add_element_on_transaction/v1.rs.
+    ///
+    /// Non-tree elements and non-empty trees pass through untouched:
+    /// their binding is the caller's responsibility.
+    fn verify_empty_tree_binding(
+        query: &PathQuery,
+        key: &[u8],
+        element: &Element,
+        value_bytes: &[u8],
+        hash: &CryptoHash,
+    ) -> Result<(), Error> {
+        let empty_indexed_expected: Option<CryptoHash> = match element {
+            Element::ProvableCountIndexedTree(None, None, 0, _)
+            | Element::ProvableSumIndexedTree(None, None, 0, _) => Some(
+                combine_hash_three(value_hash(value_bytes).value(), &NULL_HASH, &NULL_HASH)
+                    .value()
+                    .to_owned(),
+            ),
+            Element::ProvableCountProvableSumIndexedTree(None, 0, 0, axes, _)
+                if axes.iter().all(|(_, sk)| sk.is_none()) =>
+            {
+                let zero_axes: Vec<(u8, CryptoHash)> =
+                    axes.iter().map(|(t, _)| (*t, NULL_HASH)).collect();
+                let digest = axes_digest(&zero_axes).value().to_owned();
+                Some(
+                    combine_hash_three(value_hash(value_bytes).value(), &NULL_HASH, &digest)
+                        .value()
+                        .to_owned(),
+                )
+            }
+            _ => None,
+        };
+        if let Some(expected_value_hash) = empty_indexed_expected {
+            if hash != &expected_value_hash {
+                return Err(Error::InvalidProof(
+                    query.clone(),
+                    format!(
+                        "V1 empty indexed-tree value hash mismatch at key {}: expected {}, got {}",
+                        hex::encode(key),
+                        hex::encode(hash),
+                        hex::encode(expected_value_hash)
+                    ),
+                ));
+            }
+        } else if element.is_any_tree() && !element.is_non_empty_tree() {
+            let expected_value_hash = combine_hash(value_hash(value_bytes).value(), &NULL_HASH)
+                .value()
+                .to_owned();
+            if hash != &expected_value_hash {
+                return Err(Error::InvalidProof(
+                    query.clone(),
+                    format!(
+                        "V1 empty tree value hash mismatch at key {}: expected {}, got {}",
+                        hex::encode(key),
+                        hex::encode(hash),
+                        hex::encode(expected_value_hash)
+                    ),
+                ));
+            }
+        }
+        Ok(())
     }
 
     /// Verify an MMR lower layer proof and add results.

--- a/grovedb/src/operations/proof/verify.rs
+++ b/grovedb/src/operations/proof/verify.rs
@@ -2459,6 +2459,7 @@ impl GroveDb {
     ///   - Empty PCPSIT: `second = axes_digest(zero_axes)`, the digest
     ///     over the element's own axes list with every axis's secondary
     ///     root hash = NULL_HASH.
+    ///
     /// These mirror the insert commit path in
     /// add_element_on_transaction/v1.rs.
     ///

--- a/grovedb/src/operations/proof/verify.rs
+++ b/grovedb/src/operations/proof/verify.rs
@@ -2472,6 +2472,12 @@ impl GroveDb {
     /// These mirror the insert commit path in
     /// add_element_on_transaction/v1.rs.
     ///
+    /// GROVE_V1/V2 direct inserts committed empty `CountSumTree`,
+    /// `ProvableCountTree`, and `ProvableCountSumTree` as `H(value)`.
+    /// Those rows can coexist with layered commitments after an upgrade,
+    /// so accept that form for these types only when it authenticates the
+    /// exact serialized bytes, independently of the reader's version.
+    ///
     /// Non-tree elements and non-empty trees pass through untouched:
     /// their binding is the caller's responsibility.
     fn verify_empty_tree_binding(
@@ -2515,9 +2521,17 @@ impl GroveDb {
                 ));
             }
         } else if element.is_any_tree() && !element.is_non_empty_tree() {
-            let expected_value_hash = combine_hash(value_hash(value_bytes).value(), &NULL_HASH)
-                .value()
-                .to_owned();
+            let element_hash = value_hash(value_bytes).value().to_owned();
+            if matches!(
+                element,
+                Element::CountSumTree(None, ..)
+                    | Element::ProvableCountTree(None, ..)
+                    | Element::ProvableCountSumTree(None, ..)
+            ) && hash == &element_hash
+            {
+                return Ok(());
+            }
+            let expected_value_hash = combine_hash(&element_hash, &NULL_HASH).value().to_owned();
             if hash != &expected_value_hash {
                 return Err(Error::InvalidProof(
                     query.clone(),

--- a/grovedb/src/tests/mod.rs
+++ b/grovedb/src/tests/mod.rs
@@ -34,6 +34,7 @@ mod non_merk_limited_page_tests;
 mod per_instance_gate_coverage_tests;
 mod per_instance_limit_tests;
 mod private_document_store_tests;
+mod unbound_empty_tree_tests;
 // NOTE: the former `count_indexed_tree_tests` (~12.3k LOC) was written
 // against the now-removed non-provable `Element::CountIndexedTree` and was
 // carried here behind a `#[cfg(any())]` gate that made it permanently dead —

--- a/grovedb/src/tests/unbound_empty_tree_tests.rs
+++ b/grovedb/src/tests/unbound_empty_tree_tests.rs
@@ -22,6 +22,7 @@ use grovedb_version::version::GroveVersion;
 use crate::{
     operations::proof::{GroveDBProof, GroveDBProofV1, ProofBytes},
     query_result_type::QueryResultType,
+    reference_path::ReferencePathType,
     tests::{make_test_grovedb, TempGroveDb, TEST_LEAF},
     Element, GroveDb, PathQuery, Query, SizedQuery,
 };
@@ -35,9 +36,28 @@ enum Kind {
     Tree,
     SumTree,
     ProvableCountTree,
+    /// Two child Merks: the empty form commits
+    /// `combine_hash_three(H(value), NULL_HASH, NULL_HASH)`.
+    ProvableSumIndexedTree,
+    ProvableCountIndexedTree,
+    /// Axes list: the empty form commits
+    /// `combine_hash_three(H(value), NULL_HASH, axes_digest(zero_axes))`.
+    ProvableCountProvableSumIndexedTree,
 }
 
-const KINDS: [Kind; 3] = [Kind::Tree, Kind::SumTree, Kind::ProvableCountTree];
+const KINDS: [Kind; 6] = [
+    Kind::Tree,
+    Kind::SumTree,
+    Kind::ProvableCountTree,
+    Kind::ProvableSumIndexedTree,
+    Kind::ProvableCountIndexedTree,
+    Kind::ProvableCountProvableSumIndexedTree,
+];
+
+/// The PCPSIT fixture indexes all three axes.
+fn pcpsit_axes() -> Vec<(u8, Option<Vec<u8>>)> {
+    vec![(0, None), (1, None), (2, None)]
+}
 
 impl Kind {
     fn empty(self) -> Element {
@@ -45,13 +65,90 @@ impl Kind {
             Kind::Tree => Element::empty_tree(),
             Kind::SumTree => Element::empty_sum_tree(),
             Kind::ProvableCountTree => Element::empty_provable_count_tree(),
+            Kind::ProvableSumIndexedTree => Element::empty_provable_sum_indexed_tree(),
+            Kind::ProvableCountIndexedTree => Element::empty_provable_count_indexed_tree(),
+            Kind::ProvableCountProvableSumIndexedTree => {
+                Element::empty_provable_count_provable_sum_indexed_tree(pcpsit_axes())
+                    .expect("canonical axes")
+            }
         }
     }
 
-    fn row(self, i: u8) -> Element {
+    /// Insert row `i` under `TEST_LEAF/docs` through the tree's own
+    /// insert path.
+    fn insert_row(self, db: &TempGroveDb, i: u8, grove_version: &GroveVersion) {
+        let path = [TEST_LEAF, DOCS];
+        let key = [b'k', i];
         match self {
-            Kind::Tree | Kind::ProvableCountTree => Element::new_item(vec![i]),
-            Kind::SumTree => Element::new_sum_item(i as i64 + 1),
+            Kind::Tree | Kind::ProvableCountTree => {
+                db.insert(
+                    path.as_ref(),
+                    &key,
+                    Element::new_item(vec![i]),
+                    None,
+                    None,
+                    grove_version,
+                )
+                .unwrap()
+                .expect("insert row");
+            }
+            Kind::SumTree => {
+                db.insert(
+                    path.as_ref(),
+                    &key,
+                    Element::new_sum_item(i as i64 + 1),
+                    None,
+                    None,
+                    grove_version,
+                )
+                .unwrap()
+                .expect("insert row");
+            }
+            Kind::ProvableSumIndexedTree => {
+                db.insert_into_provable_sum_indexed_tree(
+                    path.as_ref(),
+                    &key,
+                    Element::new_sum_item(i as i64 + 1),
+                    None,
+                    grove_version,
+                )
+                .unwrap()
+                .expect("insert PSIT row");
+            }
+            Kind::ProvableCountIndexedTree => {
+                // PCIT rows are counted subtrees; give each one an item
+                // so the row is a non-empty tree.
+                db.insert_into_count_indexed_tree(
+                    path.as_ref(),
+                    &key,
+                    Element::empty_provable_count_tree(),
+                    None,
+                    grove_version,
+                )
+                .unwrap()
+                .expect("insert PCIT row");
+                db.insert(
+                    [TEST_LEAF, DOCS, key.as_slice()].as_ref(),
+                    b"v",
+                    Element::new_item(vec![i]),
+                    None,
+                    None,
+                    grove_version,
+                )
+                .unwrap()
+                .expect("insert PCIT row item");
+            }
+            Kind::ProvableCountProvableSumIndexedTree => {
+                db.insert_into_provable_count_provable_sum_indexed_tree(
+                    path.as_ref(),
+                    &key,
+                    Element::new_item_with_sum_item(vec![i], i as i64 + 1),
+                    None,
+                    grove_version,
+                )
+                .unwrap()
+                .expect("insert PCPSIT row");
+            }
         }
     }
 }
@@ -73,18 +170,22 @@ fn populate(kind: Kind, grove_version: &GroveVersion) -> TempGroveDb {
         .expect("insert tree");
     }
     for i in 0..ROWS {
-        db.insert(
-            [TEST_LEAF, DOCS].as_ref(),
-            &[b'k', i],
-            kind.row(i),
-            None,
-            None,
-            grove_version,
-        )
-        .unwrap()
-        .expect("insert row");
+        kind.insert_row(&db, i, grove_version);
     }
     db
+}
+
+/// The rejection must come from binding the claimed emptiness — the
+/// two-input check for plain trees, the three-input one for indexed
+/// trees — not from some unrelated structural complaint.
+fn assert_rejected_by_emptiness_binding(kind: Kind, include_empty: bool, error: &crate::Error) {
+    let message = format!("{error}");
+    assert!(
+        message.contains("empty tree value hash mismatch")
+            || message.contains("empty indexed-tree value hash mismatch"),
+        "{kind:?} include_empty={include_empty}: rejection must come from binding the \
+         claimed emptiness, got: {message}"
+    );
 }
 
 /// `TEST_LEAF/<key>` with a `RangeFull` subquery — a required descent.
@@ -256,14 +357,7 @@ fn forged_empty_tree_under_a_subquery_is_rejected() {
                 grove_version,
             );
             match outcome {
-                Err(e) => {
-                    let message = format!("{e}");
-                    assert!(
-                        message.contains("empty tree value hash mismatch"),
-                        "{kind:?} include_empty={include_empty}: rejection must come from \
-                         binding the claimed emptiness, got: {message}"
-                    );
-                }
+                Err(e) => assert_rejected_by_emptiness_binding(kind, include_empty, &e),
                 Ok((root, rows)) => panic!(
                     "{kind:?} include_empty={include_empty}: forged-empty tree under a \
                      subquery verified as {} rows against root {} (honest root {})",
@@ -306,14 +400,7 @@ fn forged_empty_tree_at_a_terminal_position_is_rejected() {
                 grove_version,
             );
             match outcome {
-                Err(e) => {
-                    let message = format!("{e}");
-                    assert!(
-                        message.contains("empty tree value hash mismatch"),
-                        "{kind:?} include_empty={include_empty}: rejection must come from \
-                         binding the claimed emptiness, got: {message}"
-                    );
-                }
+                Err(e) => assert_rejected_by_emptiness_binding(kind, include_empty, &e),
                 Ok((_, rows)) => panic!(
                     "{kind:?} include_empty={include_empty}: forged-empty terminal tree \
                      verified as {} rows",
@@ -406,5 +493,49 @@ fn genuinely_empty_trees_keep_verifying_and_match_trusted_reads() {
             expected_excluded,
             "{kind:?}: exclusion applies to plain empty trees only"
         );
+    }
+}
+
+#[test]
+fn unbound_non_tree_classification_under_a_subquery_is_rejected() {
+    // The arm chain's last resort: an element that is neither an item,
+    // a descended tree, a reported row, nor a bound empty tree. Honest
+    // V1 proofs dereference references into their target's bytes, so
+    // raw reference bytes under a subquery can only come from a prover
+    // rewriting the (unhashed) element bytes. They used to be skipped
+    // silently — another route to a verified absence.
+    let grove_version = GroveVersion::latest();
+    let db = populate(Kind::Tree, grove_version);
+    let query = descent_query(DOCS);
+    let honest = db
+        .prove_query(&query, None, grove_version)
+        .unwrap()
+        .expect("prove");
+    let fake = Element::new_reference(ReferencePathType::AbsolutePathReference(vec![
+        TEST_LEAF.to_vec(),
+        EMPTY.to_vec(),
+    ]));
+    let forged = forge_element_bytes(&honest, DOCS, &fake, grove_version);
+    for include_empty in [false, true] {
+        let outcome = GroveDb::verify_query_with_options(
+            &forged,
+            &query,
+            options(include_empty),
+            grove_version,
+        );
+        match outcome {
+            Err(e) => {
+                let message = format!("{e}");
+                assert!(
+                    message.contains("neither descended into nor bound"),
+                    "include_empty={include_empty}: got: {message}"
+                );
+            }
+            Ok((_, rows)) => panic!(
+                "include_empty={include_empty}: unbound reference under a subquery verified \
+                 as {} rows",
+                rows.len()
+            ),
+        }
     }
 }

--- a/grovedb/src/tests/unbound_empty_tree_tests.rs
+++ b/grovedb/src/tests/unbound_empty_tree_tests.rs
@@ -1,0 +1,410 @@
+//! Issue #869 — the V1 verifier must not act on a tree's *claimed*
+//! emptiness before binding it.
+//!
+//! A merk `KVValueHash*` node hashes the key and the `value_hash`, never
+//! the element bytes, so a prover can rewrite a non-empty tree's bytes
+//! into the empty form of the same type without disturbing the root.
+//! The verifier authenticates the bytes of trees it descends into
+//! (through the lower layer's root) and of empty trees it *reports*
+//! (`combine_hash(H(value), NULL_HASH)`), but two paths used to act on
+//! the unbound classification alone: an "empty" tree under a subquery
+//! was charged as an empty child and skipped, and an "empty" plain tree
+//! at a terminal position was dropped when empty trees are excluded
+//! from results. Either turns an omitted descent into a verified
+//! absence against a valid root.
+//!
+//! These tests forge exactly that and require rejection, and check that
+//! genuinely empty trees keep verifying and agree with trusted reads.
+
+use grovedb_merk::proofs::{encoding::encode_into, query::VerifyOptions, Decoder, Node, Op};
+use grovedb_version::version::GroveVersion;
+
+use crate::{
+    operations::proof::{GroveDBProof, GroveDBProofV1, ProofBytes},
+    query_result_type::QueryResultType,
+    tests::{make_test_grovedb, TempGroveDb, TEST_LEAF},
+    Element, GroveDb, PathQuery, Query, SizedQuery,
+};
+
+const DOCS: &[u8] = b"docs";
+const EMPTY: &[u8] = b"empty";
+const ROWS: u8 = 3;
+
+#[derive(Clone, Copy, Debug)]
+enum Kind {
+    Tree,
+    SumTree,
+    ProvableCountTree,
+}
+
+const KINDS: [Kind; 3] = [Kind::Tree, Kind::SumTree, Kind::ProvableCountTree];
+
+impl Kind {
+    fn empty(self) -> Element {
+        match self {
+            Kind::Tree => Element::empty_tree(),
+            Kind::SumTree => Element::empty_sum_tree(),
+            Kind::ProvableCountTree => Element::empty_provable_count_tree(),
+        }
+    }
+
+    fn row(self, i: u8) -> Element {
+        match self {
+            Kind::Tree | Kind::ProvableCountTree => Element::new_item(vec![i]),
+            Kind::SumTree => Element::new_sum_item(i as i64 + 1),
+        }
+    }
+}
+
+/// `TEST_LEAF/docs` — a populated tree of `kind` — and `TEST_LEAF/empty`,
+/// a genuinely empty tree of the same kind.
+fn populate(kind: Kind, grove_version: &GroveVersion) -> TempGroveDb {
+    let db = make_test_grovedb(grove_version);
+    for key in [DOCS, EMPTY] {
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            key,
+            kind.empty(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert tree");
+    }
+    for i in 0..ROWS {
+        db.insert(
+            [TEST_LEAF, DOCS].as_ref(),
+            &[b'k', i],
+            kind.row(i),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert row");
+    }
+    db
+}
+
+/// `TEST_LEAF/<key>` with a `RangeFull` subquery — a required descent.
+fn descent_query(key: &[u8]) -> PathQuery {
+    let mut root = Query::new_single_key(key.to_vec());
+    root.set_subquery(Query::new_range_full());
+    PathQuery::new_unsized(vec![TEST_LEAF.to_vec()], root)
+}
+
+/// `TEST_LEAF/<key>` with no subquery — the tree element itself is the
+/// terminal row.
+fn terminal_query(key: &[u8], limit: Option<u16>) -> PathQuery {
+    PathQuery::new(
+        vec![TEST_LEAF.to_vec()],
+        SizedQuery::new(Query::new_single_key(key.to_vec()), limit, None),
+    )
+}
+
+fn trusted_row_count(db: &TempGroveDb, query: &PathQuery, grove_version: &GroveVersion) -> usize {
+    db.query_raw(
+        query,
+        true,
+        true,
+        true,
+        QueryResultType::QueryPathKeyElementTrioResultType,
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("trusted read")
+    .0
+    .len()
+}
+
+fn options(include_empty_trees_in_result: bool) -> VerifyOptions {
+    VerifyOptions {
+        absence_proofs_for_non_existing_searched_keys: false,
+        verify_proof_succinctness: true,
+        include_empty_trees_in_result,
+    }
+}
+
+fn decode_envelope(proof: &[u8]) -> GroveDBProof {
+    bincode::decode_from_slice(
+        proof,
+        bincode::config::standard()
+            .with_big_endian()
+            .with_limit::<{ 256 * 1024 * 1024 }>(),
+    )
+    .expect("decode envelope")
+    .0
+}
+
+fn reencode_envelope(decoded: GroveDBProof) -> Vec<u8> {
+    bincode::encode_to_vec(
+        decoded,
+        bincode::config::standard()
+            .with_big_endian()
+            .with_no_limit(),
+    )
+    .expect("re-encode envelope")
+}
+
+/// Rewrite the merk node carrying `target_key` in the `TEST_LEAF` layer
+/// so its element bytes decode as `fake`, keeping the node's
+/// authenticated `value_hash` (and feature type) untouched, and drop any
+/// lower layer under that key. The merk root is unchanged: nothing the
+/// node hashes was modified.
+fn forge_element_bytes(
+    proof: &[u8],
+    target_key: &[u8],
+    fake: &Element,
+    grove_version: &GroveVersion,
+) -> Vec<u8> {
+    let mut decoded = decode_envelope(proof);
+    let GroveDBProof::V1(GroveDBProofV1 { root_layer }) = &mut decoded else {
+        panic!("expected a V1 envelope");
+    };
+    let layer = root_layer
+        .lower_layers
+        .get_mut(TEST_LEAF)
+        .expect("TEST_LEAF lower layer");
+    layer.lower_layers.remove(target_key);
+    let ProofBytes::Merk(bytes) = &mut layer.merk_proof else {
+        panic!("TEST_LEAF layer is a merk proof");
+    };
+    let fake_bytes = fake.serialize(grove_version).expect("serialize fake");
+
+    let mut ops: Vec<Op> = Decoder::new(bytes).map(|r| r.expect("decode op")).collect();
+    let mut forged = false;
+    for op in &mut ops {
+        let node = match op {
+            Op::Push(node) | Op::PushInverted(node) => node,
+            _ => continue,
+        };
+        let replacement = match node {
+            Node::KVValueHash(key, _, value_hash) if key.as_slice() == target_key => {
+                Node::KVValueHash(key.clone(), fake_bytes.clone(), *value_hash)
+            }
+            Node::KVValueHashFeatureType(key, _, value_hash, feature_type)
+                if key.as_slice() == target_key =>
+            {
+                Node::KVValueHashFeatureType(
+                    key.clone(),
+                    fake_bytes.clone(),
+                    *value_hash,
+                    feature_type.clone(),
+                )
+            }
+            // Drop the child hash: the merk verifier would otherwise
+            // bind the bytes through it. The V1 verifier only demands
+            // a child hash for trees it believes are NON-empty.
+            Node::KVValueHashFeatureTypeWithChildHash(key, _, value_hash, feature_type, _)
+                if key.as_slice() == target_key =>
+            {
+                Node::KVValueHashFeatureType(
+                    key.clone(),
+                    fake_bytes.clone(),
+                    *value_hash,
+                    feature_type.clone(),
+                )
+            }
+            _ => continue,
+        };
+        *node = replacement;
+        forged = true;
+    }
+    assert!(forged, "the TEST_LEAF layer must carry the target node");
+    let mut new_bytes = Vec::new();
+    encode_into(ops.iter(), &mut new_bytes);
+    *bytes = new_bytes;
+    reencode_envelope(decoded)
+}
+
+#[test]
+fn forged_empty_tree_under_a_subquery_is_rejected() {
+    // A required descent whose lower layer was omitted and whose
+    // element bytes now claim "empty": the verifier must not settle for
+    // the claim, it must bind it — and the claim is false.
+    let grove_version = GroveVersion::latest();
+    for kind in KINDS {
+        let db = populate(kind, grove_version);
+        let query = descent_query(DOCS);
+        let trusted = trusted_row_count(&db, &query, grove_version);
+        assert_eq!(
+            trusted, ROWS as usize,
+            "{kind:?}: trusted read sees the rows"
+        );
+
+        let honest = db
+            .prove_query(&query, None, grove_version)
+            .unwrap()
+            .expect("prove");
+        let (honest_root, rows) =
+            GroveDb::verify_query_with_options(&honest, &query, options(false), grove_version)
+                .expect("honest proof verifies");
+        assert_eq!(
+            rows.len(),
+            trusted,
+            "{kind:?}: honest proof matches trusted read"
+        );
+
+        let forged = forge_element_bytes(&honest, DOCS, &kind.empty(), grove_version);
+        for include_empty in [false, true] {
+            let outcome = GroveDb::verify_query_with_options(
+                &forged,
+                &query,
+                options(include_empty),
+                grove_version,
+            );
+            match outcome {
+                Err(e) => {
+                    let message = format!("{e}");
+                    assert!(
+                        message.contains("empty tree value hash mismatch"),
+                        "{kind:?} include_empty={include_empty}: rejection must come from \
+                         binding the claimed emptiness, got: {message}"
+                    );
+                }
+                Ok((root, rows)) => panic!(
+                    "{kind:?} include_empty={include_empty}: forged-empty tree under a \
+                     subquery verified as {} rows against root {} (honest root {})",
+                    rows.len(),
+                    hex::encode(root),
+                    hex::encode(honest_root)
+                ),
+            }
+        }
+    }
+}
+
+#[test]
+fn forged_empty_tree_at_a_terminal_position_is_rejected() {
+    // The tree itself is the queried row. With empty trees excluded from
+    // results the verifier used to drop a plain `Tree(None)` without
+    // binding it, so a forged-empty non-empty tree became a verified
+    // absence of its key.
+    let grove_version = GroveVersion::latest();
+    for kind in KINDS {
+        let db = populate(kind, grove_version);
+        let query = terminal_query(DOCS, None);
+        assert_eq!(trusted_row_count(&db, &query, grove_version), 1);
+
+        let honest = db
+            .prove_query(&query, None, grove_version)
+            .unwrap()
+            .expect("prove");
+        let (_, rows) =
+            GroveDb::verify_query_with_options(&honest, &query, options(false), grove_version)
+                .expect("honest proof verifies");
+        assert_eq!(rows.len(), 1, "{kind:?}: a non-empty tree is a result row");
+
+        let forged = forge_element_bytes(&honest, DOCS, &kind.empty(), grove_version);
+        for include_empty in [false, true] {
+            let outcome = GroveDb::verify_query_with_options(
+                &forged,
+                &query,
+                options(include_empty),
+                grove_version,
+            );
+            match outcome {
+                Err(e) => {
+                    let message = format!("{e}");
+                    assert!(
+                        message.contains("empty tree value hash mismatch"),
+                        "{kind:?} include_empty={include_empty}: rejection must come from \
+                         binding the claimed emptiness, got: {message}"
+                    );
+                }
+                Ok((_, rows)) => panic!(
+                    "{kind:?} include_empty={include_empty}: forged-empty terminal tree \
+                     verified as {} rows",
+                    rows.len()
+                ),
+            }
+        }
+    }
+
+    // The absence-proof projection is the sharpest form of the outcome:
+    // the searched key would come back as a proven `None`.
+    let db = populate(Kind::Tree, grove_version);
+    let query = terminal_query(DOCS, Some(1));
+    let honest = db
+        .prove_query(&query, None, grove_version)
+        .unwrap()
+        .expect("prove");
+    let forged = forge_element_bytes(&honest, DOCS, &Element::empty_tree(), grove_version);
+    let outcome = GroveDb::verify_query_with_options(
+        &forged,
+        &query,
+        VerifyOptions {
+            absence_proofs_for_non_existing_searched_keys: true,
+            verify_proof_succinctness: true,
+            include_empty_trees_in_result: false,
+        },
+        grove_version,
+    );
+    assert!(
+        outcome.is_err(),
+        "a forged-empty tree must not project to a proven absence, got {:?}",
+        outcome.map(|(_, rows)| rows)
+    );
+}
+
+#[test]
+fn genuinely_empty_trees_keep_verifying_and_match_trusted_reads() {
+    let grove_version = GroveVersion::latest();
+    for kind in KINDS {
+        let db = populate(kind, grove_version);
+
+        // Required descent into an empty tree: an empty child, no rows.
+        let query = descent_query(EMPTY);
+        let trusted = trusted_row_count(&db, &query, grove_version);
+        assert_eq!(trusted, 0, "{kind:?}: nothing under an empty tree");
+        let proof = db
+            .prove_query(&query, None, grove_version)
+            .unwrap()
+            .expect("prove");
+        for include_empty in [false, true] {
+            let (_, rows) = GroveDb::verify_query_with_options(
+                &proof,
+                &query,
+                options(include_empty),
+                grove_version,
+            )
+            .unwrap_or_else(|e| panic!("{kind:?} include_empty={include_empty}: {e}"));
+            assert_eq!(
+                rows.len(),
+                trusted,
+                "{kind:?}: empty descent yields no rows"
+            );
+        }
+
+        // The empty tree as the terminal row: reported only when the
+        // caller asks for empty trees (plain `Tree`), or always for the
+        // typed empties, exactly as before.
+        let query = terminal_query(EMPTY, None);
+        let proof = db
+            .prove_query(&query, None, grove_version)
+            .unwrap()
+            .expect("prove");
+        let (_, excluded) =
+            GroveDb::verify_query_with_options(&proof, &query, options(false), grove_version)
+                .unwrap_or_else(|e| panic!("{kind:?} exclude-empty: {e}"));
+        let (_, included) =
+            GroveDb::verify_query_with_options(&proof, &query, options(true), grove_version)
+                .unwrap_or_else(|e| panic!("{kind:?} include-empty: {e}"));
+        assert_eq!(
+            included.len(),
+            1,
+            "{kind:?}: included empty tree is one row"
+        );
+        let expected_excluded = match kind {
+            Kind::Tree => 0,
+            _ => 1,
+        };
+        assert_eq!(
+            excluded.len(),
+            expected_excluded,
+            "{kind:?}: exclusion applies to plain empty trees only"
+        );
+    }
+}

--- a/grovedb/src/tests/unbound_empty_tree_tests.rs
+++ b/grovedb/src/tests/unbound_empty_tree_tests.rs
@@ -35,7 +35,9 @@ const ROWS: u8 = 3;
 enum Kind {
     Tree,
     SumTree,
+    CountSumTree,
     ProvableCountTree,
+    ProvableCountSumTree,
     /// Two child Merks: the empty form commits
     /// `combine_hash_three(H(value), NULL_HASH, NULL_HASH)`.
     ProvableSumIndexedTree,
@@ -45,10 +47,12 @@ enum Kind {
     ProvableCountProvableSumIndexedTree,
 }
 
-const KINDS: [Kind; 6] = [
+const KINDS: [Kind; 8] = [
     Kind::Tree,
     Kind::SumTree,
+    Kind::CountSumTree,
     Kind::ProvableCountTree,
+    Kind::ProvableCountSumTree,
     Kind::ProvableSumIndexedTree,
     Kind::ProvableCountIndexedTree,
     Kind::ProvableCountProvableSumIndexedTree,
@@ -64,7 +68,9 @@ impl Kind {
         match self {
             Kind::Tree => Element::empty_tree(),
             Kind::SumTree => Element::empty_sum_tree(),
+            Kind::CountSumTree => Element::empty_count_sum_tree(),
             Kind::ProvableCountTree => Element::empty_provable_count_tree(),
+            Kind::ProvableCountSumTree => Element::empty_provable_count_sum_tree(),
             Kind::ProvableSumIndexedTree => Element::empty_provable_sum_indexed_tree(),
             Kind::ProvableCountIndexedTree => Element::empty_provable_count_indexed_tree(),
             Kind::ProvableCountProvableSumIndexedTree => {
@@ -92,7 +98,7 @@ impl Kind {
                 .unwrap()
                 .expect("insert row");
             }
-            Kind::SumTree => {
+            Kind::SumTree | Kind::CountSumTree | Kind::ProvableCountSumTree => {
                 db.insert(
                     path.as_ref(),
                     &key,
@@ -537,5 +543,105 @@ fn unbound_non_tree_classification_under_a_subquery_is_rejected() {
                 rows.len()
             ),
         }
+    }
+}
+
+#[test]
+fn mixed_legacy_and_layered_empty_commitments_verify_after_upgrade() {
+    use grovedb_version::version::{v1::GROVE_V1, v2::GROVE_V2, v3::GROVE_V3};
+
+    use crate::batch::QualifiedGroveDbOp;
+
+    let latest = GroveVersion::latest();
+    for kind in [
+        Kind::CountSumTree,
+        Kind::ProvableCountTree,
+        Kind::ProvableCountSumTree,
+    ] {
+        let db = make_test_grovedb(latest);
+        // Mix both commitment formats in the same parent Merk. The read
+        // version cannot tell us which writer committed any particular row.
+        for (index, writer) in [&GROVE_V1, &GROVE_V2, &GROVE_V3, latest]
+            .into_iter()
+            .enumerate()
+        {
+            for batch in [false, true] {
+                let key = format!("v{}-{}", index + 1, if batch { "batch" } else { "direct" })
+                    .into_bytes();
+                if batch {
+                    db.apply_batch(
+                        vec![QualifiedGroveDbOp::insert_or_replace_op(
+                            vec![TEST_LEAF.to_vec()],
+                            key,
+                            kind.empty(),
+                        )],
+                        None,
+                        None,
+                        writer,
+                    )
+                    .unwrap()
+                    .expect("batch insert empty tree");
+                } else {
+                    db.insert([TEST_LEAF].as_ref(), &key, kind.empty(), None, None, writer)
+                        .unwrap()
+                        .expect("direct insert empty tree");
+                }
+            }
+        }
+        let root = db.root_hash(None, latest).unwrap().unwrap();
+        for reader in [&GROVE_V3, latest] {
+            for ascending in [false, true] {
+                for descend in [true, false] {
+                    let mut query = Query::new_range_full();
+                    query.left_to_right = ascending;
+                    if descend {
+                        query.set_subquery(Query::new_range_full());
+                    }
+                    let query = PathQuery::new_unsized(vec![TEST_LEAF.to_vec()], query);
+                    let trusted = trusted_row_count(&db, &query, reader);
+                    assert_eq!(trusted, if descend { 0 } else { 8 });
+                    let proof = db.prove_query(&query, None, reader).unwrap().unwrap();
+                    for include_empty in [false, true] {
+                        let (verified_root, rows) = GroveDb::verify_query_with_options(
+                            &proof,
+                            &query,
+                            options(include_empty),
+                            reader,
+                        )
+                        .unwrap_or_else(|e| {
+                            panic!(
+                                "{kind:?} ascending={ascending} descend={descend} \
+                                 include_empty={include_empty}: {e}"
+                            )
+                        });
+                        assert_eq!(verified_root, root);
+                        assert_eq!(rows.len(), trusted);
+                    }
+
+                    // The legacy alternative must authenticate the actual
+                    // serialized bytes, not just accept this family of types.
+                    let fake = match kind {
+                        Kind::CountSumTree => Element::empty_provable_count_sum_tree(),
+                        _ => Element::empty_count_sum_tree(),
+                    };
+                    let forged = forge_element_bytes(&proof, b"v1-direct", &fake, reader);
+                    for include_empty in [false, true] {
+                        let err = GroveDb::verify_query_with_options(
+                            &forged,
+                            &query,
+                            options(include_empty),
+                            reader,
+                        )
+                        .expect_err("changing a legacy empty tree's bytes must be rejected");
+                        assert_rejected_by_emptiness_binding(kind, include_empty, &err);
+                    }
+                }
+            }
+        }
+        assert_eq!(
+            db.root_hash(None, latest).unwrap().unwrap(),
+            root,
+            "serving proofs must preserve stored commitments"
+        );
     }
 }


### PR DESCRIPTION
Fixes #869.

A prover could rewrite a populated tree's unauthenticated element bytes into an empty form, omit the required child proof, and make the V1 verifier return zero rows against the genuine root. The verifier now authenticates claimed emptiness before skipping a subquery descent or excluding an empty terminal tree.

## Changes

- Extract `verify_empty_tree_binding` and use it for reported empty trees, empty subquery children, and excluded empty terminal trees.
- Verify ordinary layered commitments with `combine_hash(H(value), NULL_HASH)` and indexed commitments with the existing three-input checks.
- Preserve GROVE_V1/V2 direct-write commitments for empty `CountSumTree`, `ProvableCountTree`, and `ProvableCountSumTree`: accept `H(value)` only when it matches the authenticated hash for those types. Old and new commitments can coexist in a V3/V4 read without changing stored data.
- Reject otherwise unhandled elements rather than silently accepting an unbound classification.

This changes V1 verification only. The wire format, write paths, and version gates are unchanged.

## Validation

- Reproduced the compatibility regression before the fix: valid proofs of legacy empty trees failed with an empty-tree value hash mismatch.
- Expanded forged-empty and genuine-empty coverage to eight tree types, including all three types with legacy plain-value commitments and all three indexed types.
- Added mixed direct/batch writes from GROVE_V1 through GROVE_V4 in the same parent Merk, verified under V3/V4 in both directions, at terminal and subquery positions, with both empty-tree inclusion settings. Altered legacy bytes must still be rejected, and proof serving must preserve the root.
- All five empty-tree binding tests pass, including the mixed-version regression.
- `cargo test -p grovedb --offline --all-features --lib`: 3,030 passed, 0 failed, 2 ignored.
- `cargo clippy -p grovedb --offline --all-features --lib -- -D warnings`: passed.
- `cargo check -p grovedb --offline --no-default-features --features verify`: passed, with existing unused-code warnings outside the changed files.
- Formatting, diff checks, and all commit hooks passed.
