### PR TITLE
fix(proofs): V1 layer proofs must be encoded in the family of their walk direction (#863)

### DIFF
--- a/grovedb/src/operations/proof/aggregate_common.rs
+++ b/grovedb/src/operations/proof/aggregate_common.rs
@@ -35,7 +35,10 @@
 //! thin wrapper, preserving the original error text.
 
 use grovedb_merk::{
-    proofs::{query::QueryProofVerify, Query as MerkQuery},
+    proofs::{
+        query::{QueryProofVerify, PROOF_VERSION_LATEST},
+        Query as MerkQuery,
+    },
     CryptoHash,
 };
 use grovedb_query::{Query, QueryItem};
@@ -97,7 +100,7 @@ pub(in crate::operations::proof) fn verify_single_key_layer_proof_v0(
     };
 
     let (root_hash, merk_result) = level_query
-        .execute_proof(merk_bytes, None, true, 0)
+        .execute_proof(merk_bytes, None, true, PROOF_VERSION_LATEST)
         .unwrap()
         .map_err(|e| {
             Error::InvalidProof(
@@ -190,9 +193,12 @@ pub(in crate::operations::proof) fn execute_carrier_layer_proof(
 
     // Walk direction must match the prover's; otherwise the merk
     // walker stops at the first out-of-order boundary and only the last
-    // key in the proof is returned.
+    // key in the proof is returned. Strict mode (#863) makes that a
+    // hard requirement on the stream's op family, so a carrier stream
+    // in the wrong family cannot fill a limited outer walk from the
+    // wrong end of the range.
     let (root_hash, merk_result) = level_query
-        .execute_proof(merk_bytes, outer_limit, left_to_right, 0)
+        .execute_proof(merk_bytes, outer_limit, left_to_right, PROOF_VERSION_LATEST)
         .unwrap()
         .map_err(|e| {
             Error::InvalidProof(

--- a/grovedb/src/operations/proof/indexed_axis/verify.rs
+++ b/grovedb/src/operations/proof/indexed_axis/verify.rs
@@ -20,6 +20,8 @@ use super::{aggregate_range_out_of_domain, AxisEntries, IndexedTargetChain};
 // Test-oracle-only imports (see the module doc): the standalone
 // verifiers and their inner cores are `#[cfg(test)]`.
 #[cfg(test)]
+use grovedb_merk::proofs::query::PROOF_VERSION_LATEST;
+#[cfg(test)]
 use grovedb_merk::{
     proofs::{
         query::{
@@ -285,7 +287,7 @@ fn execute_single_key_proof(
     let mut query = MerkQuery::new();
     query.insert_item(MerkQueryItem::Key(target_key.to_vec()));
     let (root_hash, result) = query
-        .execute_proof(proof_bytes, None, true, 0)
+        .execute_proof(proof_bytes, None, true, PROOF_VERSION_LATEST)
         .unwrap()
         .map_err(|e| {
             Error::CorruptedData(format!(
@@ -657,7 +659,7 @@ fn verify_indexed_axis_range_inner(
             &envelope.secondary_proof,
             limit_for_verify,
             left_to_right,
-            0,
+            PROOF_VERSION_LATEST,
         )
         .unwrap()
         .map_err(|e| {

--- a/grovedb/src/operations/proof/verify.rs
+++ b/grovedb/src/operations/proof/verify.rs
@@ -1056,15 +1056,21 @@ impl GroveDb {
                     let secondary_query =
                         crate::query::axis_lowering::axis_bounded_merk_query(axis_query)?;
                     let left_to_right = secondary_query.left_to_right;
-                    // proof_version 0 (lenient) matches the standalone
-                    // envelope's choice and is safe HERE because the
-                    // axis decoders consume only `proved.key` — bound
-                    // into the recomputed secondary root — never
-                    // `proved.value`. If a future change starts reading
-                    // secondary VALUES, it must move to
-                    // PROOF_VERSION_LATEST first.
+                    // Strict mode (#863): the secondary stream must be
+                    // encoded in the family of the direction it is
+                    // walked in, or an upright stream handed to a
+                    // descending axis read would fill the page from the
+                    // wrong end of the range. The strict value checks
+                    // that come with it are moot here — the axis
+                    // decoders consume only `proved.key`, bound into the
+                    // recomputed secondary root — but harmless.
                     let (root, res) = secondary_query
-                        .execute_proof(&payload.secondary_proof, Some(*limit), left_to_right, 0)
+                        .execute_proof(
+                            &payload.secondary_proof,
+                            Some(*limit),
+                            left_to_right,
+                            PROOF_VERSION_LATEST,
+                        )
                         .unwrap()
                         .map_err(|e| {
                             Error::InvalidProof(
@@ -1424,8 +1430,21 @@ impl GroveDb {
         merk_proof_bytes: &[u8],
         query: &PathQuery,
     ) -> Result<CryptoHash, Error> {
-        let (root_hash, _) = Query::new()
-            .execute_proof(merk_proof_bytes, None, true, PROOF_VERSION_LATEST)
+        // The layer was emitted in the direction of the query that
+        // generated the proof, which this (subset) query does not know.
+        // No row is reported, so the direction carries no semantics
+        // here; it only has to match the stream's own family for the
+        // #863 orientation check, which still refuses a mixed stream.
+        let left_to_right = grovedb_merk::proofs::query::proof_stream_direction(merk_proof_bytes)
+            .map_err(|e| {
+                Error::InvalidProof(
+                    query.clone(),
+                    format!("Invalid V1 lower layer proof (root derivation): {}", e),
+                )
+            })?
+            .unwrap_or(true);
+        let (root_hash, _) = Query::new_with_direction(left_to_right)
+            .execute_proof(merk_proof_bytes, None, left_to_right, PROOF_VERSION_LATEST)
             .unwrap()
             .map_err(|e| {
                 Error::InvalidProof(
@@ -1555,6 +1574,17 @@ impl GroveDb {
         // binds the result stays where it was: the reconstructed root
         // hash still has to match what the parent layer committed, and
         // `QueryItem::contains` still gates every returned key.
+        //
+        // For every other level the direction is the query's, and
+        // `execute_proof` itself (#863) refuses a stream that is not
+        // homogeneous in that direction's op family — an upright
+        // stream walked descending, or a mixed stream that rebuilds
+        // the honest tree in a non-monotonic visit order, would
+        // otherwise read an absence, or a page from the wrong end of
+        // the range, out of an authentic root hash. The same check
+        // runs on a synthesized level, where the direction read off
+        // the stream trivially matches it (`proof_stream_direction`
+        // already refuses a mixed stream).
         let single_key_synthesized_level = internal_query.synthesized_path_component
             && matches!(
                 internal_query.items.as_slice(),

--- a/grovedb/src/tests/mod.rs
+++ b/grovedb/src/tests/mod.rs
@@ -92,6 +92,7 @@ mod partial_batch_consistency_tests;
 mod proof_advanced_tests;
 mod proof_coverage_tests;
 mod proof_depth_limit_tests;
+mod proof_orientation_tests;
 mod proof_size_measurement;
 mod provable_count_indexed_tree_tests;
 mod provable_count_provable_sum_indexed_tree_tests;

--- a/grovedb/src/tests/proof_orientation_tests.rs
+++ b/grovedb/src/tests/proof_orientation_tests.rs
@@ -1,0 +1,353 @@
+//! Issue #863: a query level's proof must be encoded in the op family of
+//! the direction the verifier walks it in.
+//!
+//! The merk interpreter checks, per op, that upright pushes ascend and
+//! inverted pushes descend — but it never ties the family to the walk
+//! direction the query supplies, and it lets the two families mix in one
+//! stream. `execute_proof`'s bound-witness logic reads "the previously
+//! visited node" as "the neighbouring key in the tree", which only holds
+//! when the visit order is the tree's in-order (all upright) or its exact
+//! reverse (all inverted) *and* that is the order the walk expects. Break
+//! either and an authentic root hash can carry a wrong absence, or fill a
+//! descending page from the wrong end of the range.
+//!
+//! Every forgery here is either an honest proof of a *different* query
+//! handed to the victim query, or a re-shuffled op stream that rebuilds
+//! the honest tree byte-for-byte at the root. All must be rejected; the
+//! honest counterparts must keep verifying and agree with trusted reads.
+
+#[cfg(test)]
+mod tests {
+    use grovedb_merk::proofs::{encode_into, Decoder, Node, Op};
+    use grovedb_version::version::GroveVersion;
+
+    use crate::{
+        operations::proof::{GroveDBProof, LayerProof, ProofBytes},
+        tests::{make_test_grovedb, TempGroveDb, TEST_LEAF},
+        Element, Error, GroveDb, PathQuery, Query, SizedQuery,
+    };
+
+    const DOCS: &[u8] = b"docs";
+    const KEYS: [&[u8]; 3] = [b"b", b"c", b"d"];
+
+    /// `[TEST_LEAF, docs]` holding items `b`, `c`, `d`. Three keys in
+    /// insertion order settle as root `c` with `b` and `d` as leaves.
+    fn build_fixture(gv: &GroveVersion) -> TempGroveDb {
+        let db = make_test_grovedb(gv);
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            DOCS,
+            Element::empty_tree(),
+            None,
+            None,
+            gv,
+        )
+        .unwrap()
+        .expect("insert docs tree");
+        for key in KEYS {
+            db.insert(
+                [TEST_LEAF, DOCS].as_ref(),
+                key,
+                Element::new_item(key.to_vec()),
+                None,
+                None,
+                gv,
+            )
+            .unwrap()
+            .expect("insert item");
+        }
+        db
+    }
+
+    fn docs_query(query: Query, limit: Option<u16>) -> PathQuery {
+        PathQuery::new(
+            vec![TEST_LEAF.to_vec(), DOCS.to_vec()],
+            SizedQuery::new(query, limit, None),
+        )
+    }
+
+    fn keys_query(keys: &[&[u8]], left_to_right: bool) -> PathQuery {
+        let mut q = Query::new_with_direction(left_to_right);
+        for key in keys {
+            q.insert_key(key.to_vec());
+        }
+        docs_query(q, None)
+    }
+
+    fn full_range_query(left_to_right: bool, limit: Option<u16>) -> PathQuery {
+        let mut q = Query::new_with_direction(left_to_right);
+        q.insert_all();
+        docs_query(q, limit)
+    }
+
+    fn trusted_keys(db: &TempGroveDb, pq: &PathQuery, gv: &GroveVersion) -> Vec<Vec<u8>> {
+        db.query_item_value(pq, true, true, true, None, gv)
+            .unwrap()
+            .expect("trusted read")
+            .0
+    }
+
+    fn prove(db: &TempGroveDb, pq: &PathQuery, gv: &GroveVersion) -> Vec<u8> {
+        db.prove_query(pq, None, gv).unwrap().expect("prove")
+    }
+
+    fn verified_keys(
+        proof: &[u8],
+        pq: &PathQuery,
+        gv: &GroveVersion,
+    ) -> Result<Vec<Vec<u8>>, Error> {
+        GroveDb::verify_query(proof, pq, gv).map(|(_, rows)| {
+            rows.into_iter()
+                .map(|(_, key, element)| {
+                    assert!(element.is_some(), "rows carry their element");
+                    key
+                })
+                .collect()
+        })
+    }
+
+    /// Replaces the merk op stream of the `[TEST_LEAF, docs]` layer.
+    fn rewrite_docs_layer_ops(proof: &[u8], mutate: impl FnOnce(Vec<Op>) -> Vec<Op>) -> Vec<u8> {
+        let config = bincode::config::standard().with_big_endian();
+        let (mut decoded, _): (GroveDBProof, usize) =
+            bincode::decode_from_slice(proof, config).expect("decode envelope");
+        let GroveDBProof::V1(ref mut v1) = decoded else {
+            panic!("expected V1 envelope");
+        };
+        let docs_layer: &mut LayerProof = v1
+            .root_layer
+            .lower_layers
+            .get_mut(TEST_LEAF)
+            .expect("TEST_LEAF layer")
+            .lower_layers
+            .get_mut(DOCS)
+            .expect("docs layer");
+        let ProofBytes::Merk(bytes) = &docs_layer.merk_proof else {
+            panic!("docs layer is a merk proof");
+        };
+        let ops: Vec<Op> = Decoder::new(bytes)
+            .map(|op| op.expect("decode op"))
+            .collect();
+        let mut rewritten = Vec::new();
+        encode_into(mutate(ops).iter(), &mut rewritten);
+        docs_layer.merk_proof = ProofBytes::Merk(rewritten);
+        bincode::encode_to_vec(&decoded, config).expect("re-encode envelope")
+    }
+
+    fn assert_rejected(result: Result<Vec<Vec<u8>>, Error>, what: &str) {
+        match result {
+            Err(Error::InvalidProof(..)) => {}
+            other => panic!("{what} must be rejected as an invalid proof, got {other:?}"),
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Honest behaviour: both directions verify and agree with trusted
+    // reads, limited and unlimited.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn honest_proofs_agree_with_trusted_reads_in_both_directions() {
+        let gv = GroveVersion::latest();
+        let db = build_fixture(gv);
+        for left_to_right in [true, false] {
+            for limit in [None, Some(1), Some(2)] {
+                let pq = full_range_query(left_to_right, limit);
+                let expected = trusted_keys(&db, &pq, gv);
+                let proof = prove(&db, &pq, gv);
+                let got = verified_keys(&proof, &pq, gv).unwrap_or_else(|e| {
+                    panic!("honest (ltr={left_to_right}, limit={limit:?}): {e}")
+                });
+                assert_eq!(got, expected, "ltr={left_to_right}, limit={limit:?}");
+            }
+            for key in KEYS {
+                let pq = keys_query(&[key], left_to_right);
+                let proof = prove(&db, &pq, gv);
+                let got = verified_keys(&proof, &pq, gv)
+                    .unwrap_or_else(|e| panic!("honest key {key:?} (ltr={left_to_right}): {e}"));
+                assert_eq!(got, vec![key.to_vec()]);
+            }
+            // An honest absence in both directions.
+            let pq = keys_query(&[b"bb"], left_to_right);
+            let proof = prove(&db, &pq, gv);
+            let got = verified_keys(&proof, &pq, gv)
+                .unwrap_or_else(|e| panic!("honest absence (ltr={left_to_right}): {e}"));
+            assert!(got.is_empty(), "bb is absent");
+        }
+    }
+
+    // -----------------------------------------------------------------
+    // Forgery 1: an honest proof of the opposite direction. The victim
+    // query is a descending single-key read of `c` (present); the proof
+    // is the honest ASCENDING proof of `{b, d}`, which abridges `c` to
+    // its kv hash. Walked descending, `b` is met first and read as the
+    // rightmost node of the tree, the `Key(c)` item is consumed as
+    // "before this key", and `c` is reported absent.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn ascending_proof_cannot_prove_a_descending_absence() {
+        let gv = GroveVersion::latest();
+        let db = build_fixture(gv);
+        let victim = keys_query(&[b"c"], false);
+        assert_eq!(trusted_keys(&db, &victim, gv), vec![b"c".to_vec()]);
+
+        let forged = prove(&db, &keys_query(&[b"b", b"d"], true), gv);
+        assert_rejected(
+            verified_keys(&forged, &victim, gv),
+            "an upright stream handed to a descending query",
+        );
+    }
+
+    #[test]
+    fn descending_proof_cannot_prove_an_ascending_absence() {
+        let gv = GroveVersion::latest();
+        let db = build_fixture(gv);
+        let victim = keys_query(&[b"c"], true);
+        assert_eq!(trusted_keys(&db, &victim, gv), vec![b"c".to_vec()]);
+
+        let forged = prove(&db, &keys_query(&[b"b", b"d"], false), gv);
+        assert_rejected(
+            verified_keys(&forged, &victim, gv),
+            "an inverted stream handed to an ascending query",
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // Forgery 2: "give me the latest entry". A descending full range
+    // with limit 1 reads `d`. The honest ASCENDING limit-1 proof reveals
+    // `b` and abridges the rest — exactly the shape a satisfied limit
+    // permits — so walked descending it fills the page with `b`.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn ascending_limited_proof_cannot_fill_a_descending_page() {
+        let gv = GroveVersion::latest();
+        let db = build_fixture(gv);
+        let victim = full_range_query(false, Some(1));
+        assert_eq!(trusted_keys(&db, &victim, gv), vec![b"d".to_vec()]);
+
+        let forged = prove(&db, &full_range_query(true, Some(1)), gv);
+        assert_rejected(
+            verified_keys(&forged, &victim, gv),
+            "an upright limited stream handed to a descending page",
+        );
+    }
+
+    #[test]
+    fn descending_limited_proof_cannot_fill_an_ascending_page() {
+        let gv = GroveVersion::latest();
+        let db = build_fixture(gv);
+        let victim = full_range_query(true, Some(1));
+        assert_eq!(trusted_keys(&db, &victim, gv), vec![b"b".to_vec()]);
+
+        let forged = prove(&db, &full_range_query(false, Some(1)), gv);
+        assert_rejected(
+            verified_keys(&forged, &victim, gv),
+            "an inverted limited stream handed to an ascending page",
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // Forgery 3: a MIXED stream in the query's own direction. Start from
+    // the honest ascending proof of `{b, d}` (ops: Push(b) · Push(KVHash
+    // c) · Parent · Push(d) · Child) and re-shuffle it as
+    //
+    //   Push(b) · Push(d) · PushInverted(KVHash c) · ParentInverted · Parent
+    //
+    // which rebuilds the very same tree (`ParentInverted` hangs `d` to
+    // the right of `c`, `Parent` hangs `b` to its left) but visits `b`,
+    // `d`, then the abridged `c`. Per-op key checks pass — `d > b` for
+    // the upright family and a kv-hash node carries no key — yet the
+    // ascending walk for `Key(c)` sees `b` and `d` as adjacent key
+    // pushes and endorses the gap between them as an absence.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn mixed_family_stream_cannot_prove_an_absence() {
+        let gv = GroveVersion::latest();
+        let db = build_fixture(gv);
+        let victim = keys_query(&[b"c"], true);
+        assert_eq!(trusted_keys(&db, &victim, gv), vec![b"c".to_vec()]);
+
+        let honest = prove(&db, &keys_query(&[b"b", b"d"], true), gv);
+        let forged = rewrite_docs_layer_ops(&honest, |ops| {
+            let push_b = ops
+                .iter()
+                .find(|op| matches!(op, Op::Push(Node::KV(k, _)) if k.as_slice() == b"b"))
+                .cloned()
+                .expect("honest proof reveals b");
+            let push_d = ops
+                .iter()
+                .find(|op| matches!(op, Op::Push(Node::KV(k, _)) if k.as_slice() == b"d"))
+                .cloned()
+                .expect("honest proof reveals d");
+            let Some(Op::Push(Node::KVHash(c_kv_hash))) = ops
+                .iter()
+                .find(|op| matches!(op, Op::Push(Node::KVHash(_))))
+                .cloned()
+            else {
+                panic!("honest proof abridges c to a kv hash");
+            };
+            vec![
+                push_b,
+                push_d,
+                Op::PushInverted(Node::KVHash(c_kv_hash)),
+                Op::ParentInverted,
+                Op::Parent,
+            ]
+        });
+        assert_rejected(verified_keys(&forged, &victim, gv), "a mixed-family stream");
+    }
+
+    /// The mixed stream above really is a faithful reconstruction: it
+    /// must be rejected for its op families, not for its hash.
+    #[test]
+    fn mixed_family_stream_rebuilds_the_honest_root() {
+        let gv = GroveVersion::latest();
+        let db = build_fixture(gv);
+        let honest = prove(&db, &keys_query(&[b"b", b"d"], true), gv);
+        let config = bincode::config::standard().with_big_endian();
+        let (decoded, _): (GroveDBProof, usize) =
+            bincode::decode_from_slice(&honest, config).expect("decode envelope");
+        let GroveDBProof::V1(v1) = decoded else {
+            panic!("expected V1 envelope");
+        };
+        let ProofBytes::Merk(bytes) =
+            &v1.root_layer.lower_layers[TEST_LEAF].lower_layers[DOCS].merk_proof
+        else {
+            panic!("docs layer is a merk proof");
+        };
+        let ops: Vec<Op> = Decoder::new(bytes).map(|op| op.expect("op")).collect();
+        let honest_root =
+            grovedb_merk::proofs::tree::execute(ops.iter().cloned().map(Ok), false, |_| Ok(()))
+                .unwrap()
+                .expect("honest ops execute")
+                .hash()
+                .unwrap();
+        let Some(Op::Push(Node::KVHash(c_kv_hash))) = ops
+            .iter()
+            .find(|op| matches!(op, Op::Push(Node::KVHash(_))))
+            .cloned()
+        else {
+            panic!("honest proof abridges c");
+        };
+        let mixed = vec![
+            ops[0].clone(),
+            ops.iter()
+                .find(|op| matches!(op, Op::Push(Node::KV(k, _)) if k.as_slice() == b"d"))
+                .cloned()
+                .expect("d"),
+            Op::PushInverted(Node::KVHash(c_kv_hash)),
+            Op::ParentInverted,
+            Op::Parent,
+        ];
+        let mixed_root =
+            grovedb_merk::proofs::tree::execute(mixed.into_iter().map(Ok), false, |_| Ok(()))
+                .unwrap()
+                .expect("mixed ops execute")
+                .hash()
+                .unwrap();
+        assert_eq!(mixed_root, honest_root);
+    }
+}

--- a/grovedb/src/tests/proof_orientation_tests.rs
+++ b/grovedb/src/tests/proof_orientation_tests.rs
@@ -300,6 +300,71 @@ mod tests {
         assert_rejected(verified_keys(&forged, &victim, gv), "a mixed-family stream");
     }
 
+    // -----------------------------------------------------------------
+    // Subset verification that stops at a tree element the proof
+    // descended into: the lower layer is consumed for its root hash
+    // only. Its direction is the generating query's, which the narrower
+    // query does not know, so it is read off the stream — and a mixed
+    // stream is still refused there.
+    // -----------------------------------------------------------------
+
+    fn docs_element_query() -> PathQuery {
+        let mut q = Query::new();
+        q.insert_key(DOCS.to_vec());
+        PathQuery::new_unsized(vec![TEST_LEAF.to_vec()], q)
+    }
+
+    #[test]
+    fn subset_verification_reads_a_descending_lower_layer_for_its_root() {
+        let gv = GroveVersion::latest();
+        let db = build_fixture(gv);
+        // A DESCENDING wide read, so the `docs` layer is emitted inverted.
+        let wide = full_range_query(false, None);
+        let proof = prove(&db, &wide, gv);
+        let (root_hash, rows) = GroveDb::verify_subset_query(&proof, &docs_element_query(), gv)
+            .expect("narrower query stops at the docs element");
+        assert_eq!(
+            root_hash,
+            db.root_hash(None, gv).unwrap().expect("root hash")
+        );
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].1, DOCS.to_vec());
+        assert!(
+            matches!(rows[0].2, Some(Element::Tree(..))),
+            "the tree element itself is reported, got {:?}",
+            rows[0].2
+        );
+    }
+
+    #[test]
+    fn subset_verification_refuses_a_mixed_lower_layer() {
+        let gv = GroveVersion::latest();
+        let db = build_fixture(gv);
+        let proof = prove(&db, &full_range_query(false, None), gv);
+        // Flip the family of the stream's last structural op. The
+        // orientation read runs before any op is executed, so the
+        // rejection is the mixed-family one, not a hash mismatch.
+        let forged = rewrite_docs_layer_ops(&proof, |mut ops| {
+            let last = ops
+                .iter()
+                .rposition(|op| matches!(op, Op::ParentInverted | Op::ChildInverted))
+                .expect("descending stream has a structural op");
+            ops[last] = match ops[last] {
+                Op::ParentInverted => Op::Parent,
+                Op::ChildInverted => Op::Child,
+                _ => unreachable!(),
+            };
+            ops
+        });
+        match GroveDb::verify_subset_query(&forged, &docs_element_query(), gv) {
+            Err(Error::InvalidProof(_, msg)) => assert!(
+                msg.contains("root derivation") && msg.contains("mixes upright and inverted"),
+                "expected the lower layer's orientation read to refuse the mixed stream, got: {msg}"
+            ),
+            other => panic!("a mixed lower layer must be rejected, got {other:?}"),
+        }
+    }
+
     /// The mixed stream above really is a faithful reconstruction: it
     /// must be rejected for its op families, not for its hash.
     #[test]

--- a/grovedb/src/tests/provable_count_provable_sum_tree_tests.rs
+++ b/grovedb/src/tests/provable_count_provable_sum_tree_tests.rs
@@ -2056,12 +2056,18 @@ mod tests {
         let result = GroveDb::verify_aggregate_count_and_sum_query(&reencoded, &pq, v);
         match result {
             Err(crate::Error::InvalidProof(_, msg)) => {
-                // Either the intermediate type gate fires or the chain
-                // mismatch fires first — both rejections mean the type
-                // confusion didn't pass.
+                // Any of three gates may fire first — the strict merk
+                // walk refusing an Item inside a value-hash node (the
+                // single-key layer walk runs in strict mode since #863),
+                // the intermediate type gate, or the chain mismatch —
+                // and every one of them means the type confusion didn't
+                // pass.
                 assert!(
-                    msg.contains("is not a tree element") || msg.contains("chain mismatch"),
-                    "expected intermediate-type-gate or chain-mismatch rejection, got: {msg}"
+                    msg.contains("must not contain an item element")
+                        || msg.contains("is not a tree element")
+                        || msg.contains("chain mismatch"),
+                    "expected strict-node, intermediate-type-gate or chain-mismatch rejection, \
+                     got: {msg}"
                 );
             }
             other => panic!("expected InvalidProof, got {:?}", other),

--- a/merk/src/proofs/query/merk_integration_tests.rs
+++ b/merk/src/proofs/query/merk_integration_tests.rs
@@ -4715,3 +4715,213 @@ fn test_forged_row_under_right_hash_node_is_rejected() {
         "forged row under a right-side Node::Hash must be rejected, got {result:?}"
     );
 }
+
+// ---------------------------------------------------------------------
+// Issue #863: the op family a layer proof is encoded in must be the
+// family of the direction the verifier walks it in.
+//
+// `execute` checks per op that upright pushes ascend and inverted pushes
+// descend, but it never ties the family to the caller's `left_to_right`,
+// and it lets the two families mix. The bound-witness machinery in
+// `execute_proof` reads "the previous visited node" as "the neighbouring
+// key in the tree", which is only true when the visit order is the
+// tree's in-order (all upright) or its reverse (all inverted) AND that
+// order is the one the walk expects. Every test below hands the verifier
+// a stream whose root hash is authentic and gets an answer that
+// disagrees with the tree.
+// ---------------------------------------------------------------------
+
+/// The 3-node tree {3, 5, 7}: an honest ASCENDING proof of `{3, 7}`
+/// (5 abridged to its kv hash) handed to a DESCENDING single-key query
+/// for `5`. Walked right-to-left the verifier meets `3` first, reads it
+/// as the rightmost node, consumes the `Key(5)` item as "before this
+/// key", and never runs the end-of-stream absence check: `5` is
+/// reported absent although it is the root of the tree.
+#[test]
+fn ascending_stream_walked_descending_must_not_prove_absence() {
+    let grove_version = GroveVersion::latest();
+    let mut tree = make_3_node_tree();
+    let expected_root = tree.hash().unwrap();
+    let mut walker = RefWalker::new(&mut tree, PanicSource {});
+    let (proof, ..) = walker
+        .create_proof(
+            &[QueryItem::Key(vec![3]), QueryItem::Key(vec![7])],
+            None,
+            true,
+            grove_version,
+        )
+        .unwrap()
+        .expect("create_proof errored");
+    let mut bytes = vec![];
+    encode_into(proof.iter(), &mut bytes);
+
+    let mut query = Query::new_with_direction(false);
+    query.insert_key(vec![5]);
+    let result = query
+        .verify_proof(bytes.as_slice(), None, false, expected_root)
+        .unwrap();
+    assert!(
+        matches!(result, Err(Error::InvalidProofError(_))),
+        "an upright stream walked descending must be rejected, got {result:?}"
+    );
+}
+
+/// Mirror image: an honest DESCENDING proof of `{3, 7}` walked
+/// ASCENDING for `Key(5)`.
+#[test]
+fn descending_stream_walked_ascending_must_not_prove_absence() {
+    let grove_version = GroveVersion::latest();
+    let mut tree = make_3_node_tree();
+    let expected_root = tree.hash().unwrap();
+    let mut walker = RefWalker::new(&mut tree, PanicSource {});
+    let (proof, ..) = walker
+        .create_proof(
+            &[QueryItem::Key(vec![3]), QueryItem::Key(vec![7])],
+            None,
+            false,
+            grove_version,
+        )
+        .unwrap()
+        .expect("create_proof errored");
+    let mut bytes = vec![];
+    encode_into(proof.iter(), &mut bytes);
+
+    let mut query = Query::new();
+    query.insert_key(vec![5]);
+    let result = query
+        .verify_proof(bytes.as_slice(), None, true, expected_root)
+        .unwrap();
+    assert!(
+        matches!(result, Err(Error::InvalidProofError(_))),
+        "an inverted stream walked ascending must be rejected, got {result:?}"
+    );
+}
+
+/// "Give me the latest entry": a DESCENDING range with limit 1 over
+/// {3, 5, 7} answers `7`. An honest ASCENDING limit-1 proof of the same
+/// range reveals `3` and abridges the rest; walked descending it fills
+/// the limit with `3`, and the abridged tail is exactly what a
+/// satisfied limit allows. The verifier answers `3` for a query whose
+/// trusted read is `7`.
+#[test]
+fn ascending_limited_stream_walked_descending_must_not_fill_the_page() {
+    let grove_version = GroveVersion::latest();
+    let mut tree = make_3_node_tree();
+    let expected_root = tree.hash().unwrap();
+    let mut walker = RefWalker::new(&mut tree, PanicSource {});
+    let (proof, ..) = walker
+        .create_proof(&[QueryItem::RangeFull(..)], Some(1), true, grove_version)
+        .unwrap()
+        .expect("create_proof errored");
+    let mut bytes = vec![];
+    encode_into(proof.iter(), &mut bytes);
+
+    let mut query = Query::new_with_direction(false);
+    query.insert_all();
+    let result = query
+        .verify_proof(bytes.as_slice(), Some(1), false, expected_root)
+        .unwrap();
+    assert!(
+        matches!(result, Err(Error::InvalidProofError(_))),
+        "an upright limited stream walked descending must be rejected, got {result:?}"
+    );
+}
+
+/// A MIXED stream that reconstructs the honest tree exactly (root hash
+/// authentic) while visiting `3`, then `7`, then the abridged root `5`:
+///
+/// ```text
+/// Push(KV 3) · Push(KV 7) · PushInverted(KVHash 5) · ParentInverted · Parent
+/// ```
+///
+/// `ParentInverted` hangs `7` on the right of `5`, `Parent` hangs `3`
+/// on its left — the honest shape. The per-op key check passes (`7 > 3`
+/// upright, and a `KVHash` carries no key), yet walked ascending for
+/// `Key(5)` the verifier sees `3` then `7` as adjacent key-bearing
+/// pushes and endorses the gap between them as proof that `5` is absent.
+#[test]
+fn mixed_op_families_must_not_prove_absence() {
+    let tree = make_3_node_tree();
+    let expected_root = tree.hash().unwrap();
+    let root_kv_hash = *tree.kv_hash();
+
+    let mixed = [
+        Op::Push(Node::KV(vec![3], vec![3])),
+        Op::Push(Node::KV(vec![7], vec![7])),
+        Op::PushInverted(Node::KVHash(root_kv_hash)),
+        Op::ParentInverted,
+        Op::Parent,
+    ];
+    let mut bytes = vec![];
+    encode_into(mixed.iter(), &mut bytes);
+
+    // The stream really does rebuild the honest tree.
+    let rebuilt = super::super::tree::execute(Decoder::new(&bytes), false, |_| Ok(()))
+        .unwrap()
+        .expect("mixed stream reconstructs");
+    assert_eq!(rebuilt.hash().unwrap(), expected_root);
+
+    let mut query = Query::new();
+    query.insert_key(vec![5]);
+    let result = query
+        .verify_proof(bytes.as_slice(), None, true, expected_root)
+        .unwrap();
+    assert!(
+        matches!(result, Err(Error::InvalidProofError(_))),
+        "a mixed-family stream must be rejected, got {result:?}"
+    );
+}
+
+/// The honest counterparts of the forgeries above still verify, in
+/// both directions, and agree with the tree.
+#[test]
+fn homogeneous_streams_matching_the_walk_direction_verify() {
+    let grove_version = GroveVersion::latest();
+    for left_to_right in [true, false] {
+        let mut tree = make_3_node_tree();
+        let expected_root = tree.hash().unwrap();
+        let mut walker = RefWalker::new(&mut tree, PanicSource {});
+        let (proof, ..) = walker
+            .create_proof(
+                &[QueryItem::Key(vec![5])],
+                None,
+                left_to_right,
+                grove_version,
+            )
+            .unwrap()
+            .expect("create_proof errored");
+        let mut bytes = vec![];
+        encode_into(proof.iter(), &mut bytes);
+
+        let mut query = Query::new_with_direction(left_to_right);
+        query.insert_key(vec![5]);
+        let res = query
+            .verify_proof(bytes.as_slice(), None, left_to_right, expected_root)
+            .unwrap()
+            .unwrap_or_else(|e| panic!("honest proof (ltr={left_to_right}) must verify: {e}"));
+        compare_result_tuples_not_optional!(res.result_set, vec![(vec![5], vec![5])]);
+
+        let (proof, ..) = RefWalker::new(&mut tree, PanicSource {})
+            .create_proof(
+                &[QueryItem::RangeFull(..)],
+                Some(1),
+                left_to_right,
+                grove_version,
+            )
+            .unwrap()
+            .expect("create_proof errored");
+        let mut bytes = vec![];
+        encode_into(proof.iter(), &mut bytes);
+        let mut query = Query::new_with_direction(left_to_right);
+        query.insert_all();
+        let res = query
+            .verify_proof(bytes.as_slice(), Some(1), left_to_right, expected_root)
+            .unwrap()
+            .unwrap_or_else(|e| {
+                panic!("honest limited proof (ltr={left_to_right}) must verify: {e}")
+            });
+        let expected: Vec<u8> = if left_to_right { vec![3] } else { vec![7] };
+        let expected_rows = [(expected.clone(), expected)];
+        compare_result_tuples_not_optional!(res.result_set, expected_rows);
+    }
+}

--- a/merk/src/proofs/query/mod.rs
+++ b/merk/src/proofs/query/mod.rs
@@ -41,7 +41,7 @@ use grovedb_version::version::GroveVersion;
 pub use map::{Map, MapBuilder};
 #[cfg(any(feature = "minimal", feature = "verify"))]
 pub use verify::{
-    boundaries_in_proof, key_exists_as_boundary_in_proof, proof_stream_direction,
+    boundaries_in_proof, key_exists_as_boundary_in_proof, op_is_upright, proof_stream_direction,
     ProofVerificationResult, ProvedKeyOptionalValue, ProvedKeyValue, QueryProofVerify,
     VerifyOptions, PROOF_VERSION_LATEST,
 };

--- a/merk/src/proofs/query/verify.rs
+++ b/merk/src/proofs/query/verify.rs
@@ -155,7 +155,50 @@ impl QueryProofVerify for Query {
 
         let mut decoder = Decoder::new(bytes);
 
-        let root_wrapped = execute(decoder.by_ref(), true, |node| {
+        // Issue #863: the stream must be encoded in the op family of the
+        // direction it is walked in, and in that family only.
+        //
+        // `execute` checks per op that upright pushes ascend and inverted
+        // pushes descend, but it never ties the family to `left_to_right`
+        // and it lets the two families mix. Everything below that turns a
+        // visited node into a bound witness — "the previous push was
+        // key-bearing, so nothing lies between it and this key", "this is
+        // the first push, so it is the leftmost (rightmost) node", "the
+        // limit is met, so the abridged tail is fine" — assumes the visit
+        // order is the tree's in-order for an ascending walk and its exact
+        // reverse for a descending one. That holds only for a homogeneous
+        // stream in the walk's own family: an upright stream walked
+        // descending reads the smallest revealed key as the rightmost
+        // node, and a mixed stream can rebuild the honest tree while
+        // visiting an abridged root *after* both of its children, so two
+        // revealed leaves look adjacent. Either way an authentic root hash
+        // carries a wrong absence or a page filled from the wrong end.
+        //
+        // Enforced for V1 proofs only: V0 is a locked wire format whose
+        // verifier is not to change, and it is gated at `proof_version`
+        // like the other V1-only strictness checks in this function.
+        let oriented_ops = decoder.by_ref().map(|op_result| {
+            let op = op_result?;
+            if proof_version >= 1 && op_is_upright(&op) != left_to_right {
+                return Err(Error::InvalidProofError(format!(
+                    "Proof op family does not match the query direction: {} op in a {} walk; a \
+                     layer proof is emitted entirely in the family of its own direction",
+                    if op_is_upright(&op) {
+                        "upright"
+                    } else {
+                        "inverted"
+                    },
+                    if left_to_right {
+                        "left-to-right"
+                    } else {
+                        "right-to-left"
+                    },
+                )));
+            }
+            Ok(op)
+        });
+
+        let root_wrapped = execute(oriented_ops, true, |node| {
             let mut execute_node = |key: &Vec<u8>,
                                     value: Option<&Vec<u8>>,
                                     value_hash: CryptoHash,
@@ -1119,6 +1162,19 @@ mod provable_count_provable_sum_tree_bound_regression_tests {
     }
 }
 
+/// Whether `op` belongs to the upright (left-to-right) op family.
+///
+/// `Push` / `Parent` / `Child` are the family an ascending walk is
+/// encoded in; `PushInverted` / `ParentInverted` / `ChildInverted` are
+/// the descending family. A layer proof is emitted entirely in one
+/// family, chosen by the generating query's direction.
+pub fn op_is_upright(op: &Op) -> bool {
+    match op {
+        Op::Push(_) | Op::Parent | Op::Child => true,
+        Op::PushInverted(_) | Op::ParentInverted | Op::ChildInverted => false,
+    }
+}
+
 /// The orientation of a Merk layer proof's op stream, read off the op
 /// families in the bytes themselves.
 ///
@@ -1165,10 +1221,7 @@ pub fn proof_stream_direction(proof_bytes: &[u8]) -> Result<Option<bool>, Error>
                 MAX_PROOF_OPS
             )));
         }
-        let upright = match op_result? {
-            Op::Push(_) | Op::Parent | Op::Child => true,
-            Op::PushInverted(_) | Op::ParentInverted | Op::ChildInverted => false,
-        };
+        let upright = op_is_upright(&op_result?);
         match direction {
             None => direction = Some(upright),
             Some(previous) if previous == upright => {}


### PR DESCRIPTION
Closes #863.

## Verdict: real, reproduced at the public API

A V1 layer proof is a stream of ops in one of two families — upright (`Push` / `Parent` / `Child`, visiting keys ascending) or inverted (`PushInverted` / `ParentInverted` / `ChildInverted`, descending). `execute` checks per op that upright pushes ascend and inverted pushes descend, but it never ties the family to the `left_to_right` the verifier walks with, and it lets the two families mix in one stream.

Every bound-witness rule in `execute_proof` — "the previous push was key-bearing, so nothing lies between it and this key", "this is the first push, so it is the leftmost (rightmost) node", "the limit is met, so the abridged tail is fine" — assumes the visit order is the tree's in-order for an ascending walk and its exact reverse for a descending one. That only holds for a homogeneous stream in the walk's own family. Two ways to break it, both with an authentic root hash:

* **Opposite family.** The honest ascending proof of `{b, d}` (root `c` abridged to its kv-hash) handed to a descending `Key(c)` query: `b` is met first, read as the rightmost node, `Key(c)` is consumed as "before this key", and `c` is verified **absent** although it is the root. Likewise the honest ascending limit-1 proof handed to a descending limit-1 range ("give me the latest entry") fills the page with the **smallest** key.
* **Mixed families.** `Push(b) · Push(d) · PushInverted(KVHash c) · ParentInverted · Parent` rebuilds the honest tree byte-for-byte at the root, passes every per-op key check, and visits `b`, `d`, then the abridged root — so an ascending walk for `Key(c)` sees two adjacent key-bearing pushes and endorses the gap as an absence.

All of this goes through `prove_query` / `verify_query` with no hand-crafted bytes needed for the first case: it is literally an honest proof of a different query. On `develop` the new tests fail with `got Ok([])` (false absence) and `got Ok([[98]])` (page filled with `b` where the trusted read says `d`).

## Fix (V1 only, no version gate)

`Query::execute_proof` now requires, for `proof_version >= 1`, that every op is in the family of the walk direction it was given. An op in the other family — or a mixed stream — is rejected before it reaches the bound-witness logic. V0 (`proof_version == 0`) is untouched: it is a locked wire format and its verifier is not changed.

No `GroveVersion` gate: honest V1 proofs are unaffected. Prover and verifier take each real level's direction from the same `query_items_at_path`, synthesized one-key levels keep reading the direction off the stream (#818, unchanged), and `proof_stream_direction` already refused mixed streams there. The check only removes forged shapes no prover emits, so nothing an honest GROVE_V3 node produces changes verdict.

Callers aligned:

* `merk_layer_root_hash` (row-less root derivation for a subset query that stops at a tree element) reads the direction off the stream, since it cannot know the generating query's direction and reports no rows. It still refuses a mixed stream.
* The axis-descent secondary walk and the aggregate carrier / single-key layer walks move from the lenient `proof_version 0` to `PROOF_VERSION_LATEST` so a wrong-family secondary stream cannot fill a limited page from the wrong end. Their honest streams already satisfied strict mode.
* The `#[cfg(test)]` indexed-axis oracles do the same.

Verified unaffected: the count-offset and aggregate verifiers walk the reconstructed tree structurally, not the visit order.

## Tests

* `merk_integration_tests`: the two opposite-family absences, the opposite-family limited page, the mixed-family absence (asserting the mixed stream really rebuilds the honest root), and honest homogeneous streams in both directions.
* `grovedb/src/tests/proof_orientation_tests.rs`: the same forgeries end-to-end through `prove_query` / `verify_query` against trusted reads, plus honest ascending/descending reads (unlimited, limit 1, limit 2, single keys, and an honest absence) agreeing with trusted reads in both directions.
* Existing `merged_descending_subset_bound_tests` cover the synthesized-path handling from #818 and keep passing.

One existing test was widened: `combined_v1_envelope_non_tree_intermediate_rejected` forges an Item into a tree slot of the single-key layer and asserted on the aggregate chain gate's message; with that walk now strict, the merk verifier refuses the same forgery one step earlier (`KVValueHash node must not contain an item element`). The assertion accepts either gate.

Local runs: `cargo test -p grovedb-merk` (731 + 9 pass), `cargo test -p grovedb --features full,verify,estimated_costs,unsafe-dump-load,serde,zk_client` (3034 pass, 2 ignored; `--all-features` needs the `grovedbg` download, which was unavailable here), `cargo fmt`. `cargo clippy --all-targets -D warnings` on the local stable 1.97 flags pre-existing lines in untouched files; the only lint in new code is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved proof verification to consistently use the latest proof protocol.
  * Rejects proofs with mismatched traversal directions or mixed operation orientations, including limited-range queries.
  * Prevents incorrectly oriented proofs from being accepted even when they produce a valid root hash.

* **Tests**
  * Added comprehensive regression coverage for proof direction validation, including ascending, descending, limited, and nested proofs.
  * Confirmed that valid proofs continue to verify when query and proof directions match.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->