### PR TITLE
fix(proofs): bind every tree and reference row of trunk/branch chunk proofs (#859)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renamed `prove_internal` to `prove_query_non_serialized` for clarity (#373)
 
 ### Fixed
+- Trunk and branch chunk proofs (`prove_trunk_chunk` / `prove_branch_chunk`) bind every tree and reference row to the root hash on `GROVE_V4` (`proof.chunk_proof_row_binding: 1`). Released versions waived the value-hash check for any row that deserialized as a tree, so the returned tree metadata (type, aggregate count or sum, root key) was unbound and an item could be disguised as a tree under a genuine root hash; reference rows never verified. The prover now emits `KVValueHashFeatureTypeWithChildHash` for those rows and the verifier requires it. Chunks containing an indexed-tree row are refused, since no proof node carries its three-input binding (#859)
 - Direct and batch references to `NonCounted`-wrapped items now commit to identical stored terminal bytes on `GROVE_V4` (`add_element_on_transaction: 2`). `verify_grovedb` and V1 proof generation select the terminal representation matching each reference's stored commitment, preserving older direct-write hashes across upgrades. Offset-paginated proof rows resolved through a reference may surface the wrapped target (`CountOffsetReturnedItem::resolved_from_reference`) (#858)
 - Corrected proof verification logic in GroveDb (#371)
 - Added ASCII check before appending string to hex display for better visualization (#376)

--- a/grovedb-version/src/version/grovedb_versions.rs
+++ b/grovedb-version/src/version/grovedb_versions.rs
@@ -308,6 +308,40 @@ pub struct GroveDBOperationsProofVersions {
     /// non-empty **Merk** trees have required the child hash since V3 and
     /// stay bound at every version.
     pub terminal_non_merk_tree_child_hash: FeatureVersion,
+    /// Whether a **trunk / branch chunk proof** binds every composite row —
+    /// a tree of any kind, or a reference — to the `value_hash` its Merk
+    /// commits to.
+    ///
+    /// A merk chunk proof (`prove_trunk_chunk` / `prove_branch_chunk`) binds
+    /// an item row through `KV`, whose value bytes the verifier hashes itself,
+    /// but a tree or reference row through `KVValueHash` /
+    /// `KVValueHashFeatureType`, whose embedded `value_hash` the merk verifier
+    /// treats as opaque. That hash is `combine_hash(H(value), child_root)` for
+    /// a tree (`combine_hash(H(value), H(referenced))` for a reference), which
+    /// cannot be reproduced from the value bytes alone.
+    ///
+    /// - `0` (V1..V3): the prover leaves those rows as the merk chunk emitted
+    ///   them, and the verifier waives the `H(value) == value_hash` check for
+    ///   any row whose bytes deserialize as a tree. The returned tree metadata
+    ///   — tree type, aggregate count or sum, root key — is therefore unbound:
+    ///   a prover can substitute any tree-family element (or disguise an item
+    ///   as a tree) under a genuine root hash. Reference rows never verify at
+    ///   all under these versions, since they are not waived.
+    /// - `1` (V4+): the prover rewrites every composite row to
+    ///   `KVValueHashFeatureTypeWithChildHash` carrying the child Merk root
+    ///   (`NULL_HASH` for an empty tree), the non-Merk tree's own state root,
+    ///   or the referenced element's value hash, and the verifier requires
+    ///   that node for every tree or reference row, closing the loop with the
+    ///   merk-level `combine_hash(H(value), child_hash) == value_hash` check.
+    ///   Indexed trees commit a three-input hash no proof node can carry, so
+    ///   the prover refuses to serve a chunk containing one and the verifier
+    ///   rejects any such row rather than return its metadata as verified.
+    ///
+    /// Gated because it flips an accepted/rejected outcome — an upgraded
+    /// verifier rejects the unbound rows released provers emit — and because
+    /// deriving each child root costs the prover storage reads and hash
+    /// calls the released path never paid.
+    pub chunk_proof_row_binding: FeatureVersion,
     /// Whether the V1 proof envelope carries **axis-ordered descents**
     /// into indexed trees (`ProofBytes::IndexedTreeAxisDescent`),
     /// serving `PathQuery`s whose query node holds `ReadMode::Axis`.

--- a/grovedb-version/src/version/v1.rs
+++ b/grovedb-version/src/version/v1.rs
@@ -181,6 +181,7 @@ pub const GROVE_V1: GroveVersion = GroveVersion {
                 verify_query_with_chained_path_queries: 0,
                 verify_query_get_parent_tree_info_with_options: 0,
                 terminal_non_merk_tree_child_hash: 0,
+                chunk_proof_row_binding: 0,
                 axis_descent_in_v1_envelope: 0,
                 sum_budget_in_v1_envelope: 0,
             },

--- a/grovedb-version/src/version/v2.rs
+++ b/grovedb-version/src/version/v2.rs
@@ -181,6 +181,7 @@ pub const GROVE_V2: GroveVersion = GroveVersion {
                 verify_query_with_chained_path_queries: 0,
                 verify_query_get_parent_tree_info_with_options: 0,
                 terminal_non_merk_tree_child_hash: 0,
+                chunk_proof_row_binding: 0,
                 axis_descent_in_v1_envelope: 0,
                 sum_budget_in_v1_envelope: 0,
             },

--- a/grovedb-version/src/version/v3.rs
+++ b/grovedb-version/src/version/v3.rs
@@ -185,6 +185,7 @@ pub const GROVE_V3: GroveVersion = GroveVersion {
                 verify_query_with_chained_path_queries: 0,
                 verify_query_get_parent_tree_info_with_options: 0,
                 terminal_non_merk_tree_child_hash: 0,
+                chunk_proof_row_binding: 0,
                 axis_descent_in_v1_envelope: 0,
                 sum_budget_in_v1_envelope: 0,
             },

--- a/grovedb-version/src/version/v4.rs
+++ b/grovedb-version/src/version/v4.rs
@@ -32,6 +32,20 @@
 //!   flips a rejected/accepted outcome and because deriving the state root
 //!   costs the prover extra storage reads and hash calls.
 //!
+//! - `proof.chunk_proof_row_binding: 1` — a trunk or branch chunk proof
+//!   (`prove_trunk_chunk` / `prove_branch_chunk`) carries every tree and
+//!   reference row as `KVValueHashFeatureTypeWithChildHash`, with the child
+//!   Merk root, the non-Merk tree's state root, or the referenced value hash,
+//!   and the verifier requires that node for every such row. V1..V3 emit a
+//!   bare `KVValueHash` and the verifier waives the value-hash check for any
+//!   row that deserializes as a tree, so the returned tree metadata (type,
+//!   aggregate count or sum, root key) is unbound and an item can be disguised
+//!   as a tree under a genuine root hash. Indexed-tree rows, whose three-input
+//!   binding no proof node carries, are refused by the prover and rejected by
+//!   the verifier. Gated because it flips an accepted/rejected outcome and
+//!   because deriving each child root costs the prover storage reads and hash
+//!   calls.
+//!
 //! - `proof.axis_descent_in_v1_envelope: 1` — the V1 proof envelope carries
 //!   axis-ordered descents into indexed trees
 //!   (`ProofBytes::IndexedTreeAxisDescent`): a proof over the queried
@@ -411,6 +425,7 @@ pub const GROVE_V4: GroveVersion = GroveVersion {
                 verify_query_with_chained_path_queries: 0,
                 verify_query_get_parent_tree_info_with_options: 0,
                 terminal_non_merk_tree_child_hash: 1, // bind terminal non-Merk tree element bytes to the parent value_hash
+                chunk_proof_row_binding: 1, // bind every tree / reference row of a trunk or branch chunk proof
                 axis_descent_in_v1_envelope: 1, // axis-ordered descents in the V1 envelope (ReadMode::Axis)
                 sum_budget_in_v1_envelope: 1, // sum-budget windows in the V1 envelope (ReadMode::SumBudget)
             },

--- a/grovedb/src/operations/proof/chunk_proof_row_binding/mod.rs
+++ b/grovedb/src/operations/proof/chunk_proof_row_binding/mod.rs
@@ -1,0 +1,123 @@
+//! Trunk / branch chunk-proof composite-row binding — versioned dispatch
+//! (#859).
+//!
+//! A merk chunk proof (`prove_trunk_chunk` / `prove_branch_chunk`) binds an
+//! item row through `KV`, whose value bytes the verifier hashes itself, but a
+//! tree or reference row through `KVValueHash` / `KVValueHashFeatureType`,
+//! whose embedded `value_hash` the merk verifier treats as opaque. That hash is
+//! `combine_hash(H(value), child_root)` for a tree and
+//! `combine_hash(H(value), H(referenced))` for a reference — a composition the
+//! value bytes alone cannot reproduce. Checking the target root and the
+//! ancestor chain therefore says nothing about the returned tree element's own
+//! metadata: its type, aggregate count or sum, and root key.
+//!
+//! Two functions share one gate, `proof.chunk_proof_row_binding`, so prover
+//! and verifier move together at the protocol boundary:
+//!
+//! * [`GroveDb::bind_chunk_proof_rows`] (prover) rewrites every composite row
+//!   of the chunk ops to `KVValueHashFeatureTypeWithChildHash`.
+//! * [`GroveDb::check_chunk_proof_row`] (verifier) decides, per extracted
+//!   row, whether the node form binds the element bytes it carries.
+//!
+//! * **[v0]** — released behaviour, `GROVE_V1`..`GROVE_V3`. The prover leaves
+//!   the rows as the merk chunk emitted them and the verifier waives the
+//!   `H(value) == value_hash` check for any row that deserializes as a tree.
+//!   The returned tree metadata is unbound: a prover can substitute any
+//!   tree-family element, or disguise an item as a tree, under a genuine root
+//!   hash. Reference rows are not waived and never verify.
+//! * **[v1]** — `GROVE_V4`+. Every tree or reference row carries its child
+//!   hash and the verifier requires it, so the merk-level
+//!   `combine_hash(H(value), child_hash) == value_hash` check closes the loop.
+//!   Indexed trees commit a three-input hash no proof node can carry: the
+//!   prover refuses to serve a chunk containing one and the verifier rejects
+//!   any such row rather than return its metadata as verified.
+//!
+//! The split cannot be applied unconditionally: it flips an accepted/rejected
+//! outcome, and deriving each child root costs the prover storage reads and
+//! hash calls the released path never paid — cost feeds fees. See
+//! `grovedb-version`'s `v4.rs` for the landing-zone rationale.
+//!
+//! [v0]: self::v0
+//! [v1]: self::v1
+
+mod v0;
+mod v1;
+
+#[cfg(feature = "minimal")]
+use grovedb_costs::{CostResult, CostsExt, OperationCost};
+use grovedb_merk::proofs::Node;
+#[cfg(feature = "minimal")]
+use grovedb_merk::proofs::Op;
+use grovedb_version::version::GroveVersion;
+
+#[cfg(feature = "minimal")]
+use crate::Transaction;
+use crate::{Element, Error, GroveDb};
+
+impl GroveDb {
+    /// Bind every composite row of a trunk / branch chunk proof to the
+    /// `value_hash` its Merk commits to, if the grove version calls for it.
+    ///
+    /// `ops` are the chunk ops as the merk `trunk_query` / `branch_query`
+    /// emitted them; `target_path` is the path of the Merk they were taken
+    /// from, so a tree row's own data lives one level below under the row's
+    /// key.
+    #[cfg(feature = "minimal")]
+    pub(crate) fn bind_chunk_proof_rows(
+        &self,
+        ops: &mut [Op],
+        target_path: &[&[u8]],
+        tx: &Transaction,
+        grove_version: &GroveVersion,
+    ) -> CostResult<(), Error> {
+        match grove_version
+            .grovedb_versions
+            .operations
+            .proof
+            .chunk_proof_row_binding
+        {
+            0 => Self::bind_chunk_proof_rows_v0(ops),
+            1 => self.bind_chunk_proof_rows_v1(ops, target_path, tx, grove_version),
+            version => Err(Error::VersionError(
+                grovedb_version::error::GroveVersionError::UnknownVersionMismatch {
+                    method: "bind_chunk_proof_rows".to_string(),
+                    known_versions: vec![0, 1],
+                    received: version,
+                },
+            ))
+            .wrap_with_cost(OperationCost::default()),
+        }
+    }
+
+    /// Decide whether a trunk / branch chunk-proof row binds the element
+    /// bytes it carries, per the grove version.
+    ///
+    /// `node` is the proof node the row was extracted from, `key` / `value`
+    /// its key and value bytes, and `element` the already-deserialized value.
+    /// Runs after the merk root hash (and, for a trunk, the ancestor chain)
+    /// has been checked, so a row only reaches here under a genuine root.
+    pub(crate) fn check_chunk_proof_row(
+        node: &Node,
+        key: &[u8],
+        value: &[u8],
+        element: &Element,
+        grove_version: &GroveVersion,
+    ) -> Result<(), Error> {
+        match grove_version
+            .grovedb_versions
+            .operations
+            .proof
+            .chunk_proof_row_binding
+        {
+            0 => Self::check_chunk_proof_row_v0(node, key, value, element),
+            1 => Self::check_chunk_proof_row_v1(node, key, value, element),
+            version => Err(Error::VersionError(
+                grovedb_version::error::GroveVersionError::UnknownVersionMismatch {
+                    method: "check_chunk_proof_row".to_string(),
+                    known_versions: vec![0, 1],
+                    received: version,
+                },
+            )),
+        }
+    }
+}

--- a/grovedb/src/operations/proof/chunk_proof_row_binding/v0.rs
+++ b/grovedb/src/operations/proof/chunk_proof_row_binding/v0.rs
@@ -1,0 +1,122 @@
+//! Chunk-proof row binding — **v0** (released behaviour,
+//! `GROVE_V1`..`GROVE_V3`).
+//!
+//! The prover leaves the chunk ops exactly as the merk `trunk_query` /
+//! `branch_query` emitted them: an item as `KV`, a tree or reference as a bare
+//! `KVValueHash` (or `KVValueHashFeatureType` in a `Provable*` host), which
+//! hashes only `(key, value_hash)`.
+//!
+//! The verifier checks `H(value) == value_hash` for those two node forms but
+//! **waives the check when the value deserializes as a tree**, because a
+//! tree's committed `value_hash` is `combine_hash(H(value), child_root)` and
+//! the child root travels nowhere in the proof. The waiver is the hole: the
+//! merk root check only ever covers `value_hash`, so a prover can serve any
+//! tree-family element — a different type, an inflated count or sum, a
+//! phantom root key — or disguise an item as a tree, and the row is returned
+//! as verified. A reference row is not waived, so an honest chunk that
+//! contains one never verifies under these versions.
+//!
+//! This is a **known soundness gap**, not an oversight to fix in place: it is
+//! preserved here because `GROVE_V3` is live — closing it changes both an
+//! accepted/rejected outcome and the prover's tracked cost. [`super::v1`]
+//! closes it from `GROVE_V4` onward.
+//!
+//! Deliberately takes the same arguments as [`super::v1`] and ignores those it
+//! does not need, so the dispatch in [`super`][`mod@super`] stays a plain
+//! version match.
+
+#[cfg(feature = "minimal")]
+use grovedb_costs::{CostResult, CostsExt, OperationCost};
+#[cfg(feature = "minimal")]
+use grovedb_merk::proofs::Op;
+use grovedb_merk::{
+    proofs::Node,
+    tree::{combine_hash, value_hash},
+};
+
+use crate::{Element, Error, GroveDb, PathQuery, Query};
+
+impl GroveDb {
+    /// `bind_chunk_proof_rows` v0 — see the module documentation.
+    #[cfg(feature = "minimal")]
+    pub(crate) fn bind_chunk_proof_rows_v0(_ops: &mut [Op]) -> CostResult<(), Error> {
+        Ok(()).wrap_with_cost(OperationCost::default())
+    }
+
+    /// `check_chunk_proof_row` v0 — see the module documentation.
+    pub(crate) fn check_chunk_proof_row_v0(
+        node: &Node,
+        key: &[u8],
+        value: &[u8],
+        element: &Element,
+    ) -> Result<(), Error> {
+        match node {
+            Node::KVValueHash(_, _, node_value_hash)
+            | Node::KVValueHashFeatureType(_, _, node_value_hash, _) => {
+                let computed_vh = value_hash(value).value().to_owned();
+                if computed_vh != *node_value_hash {
+                    // For tree elements, value_hash = combine_hash(H(value),
+                    // child_root_hash). The child root travels nowhere in a
+                    // v0 chunk, so the check is waived — leaving the tree's
+                    // metadata unbound (see the module docs).
+                    if !element.is_any_tree() {
+                        return Err(Error::InvalidProof(
+                            PathQuery::new_unsized(Vec::new(), Query::default()),
+                            format!(
+                                "trunk/branch proof value hash mismatch at key {}: H(value) = \
+                                 {} but embedded value_hash = {}",
+                                hex::encode(key),
+                                hex::encode(computed_vh),
+                                hex::encode(node_value_hash),
+                            ),
+                        ));
+                    }
+                }
+                Ok(())
+            }
+            Node::KVValueHashFeatureTypeWithChildHash(_, _, node_value_hash, _, child_hash) => {
+                let element_vh = value_hash(value).value().to_owned();
+                let computed_vh = combine_hash(&element_vh, child_hash).value().to_owned();
+                if computed_vh != *node_value_hash {
+                    return Err(Error::InvalidProof(
+                        PathQuery::new_unsized(Vec::new(), Query::default()),
+                        format!(
+                            "trunk/branch proof value/child hash mismatch at key {}: \
+                             combine_hash(H(value), child_hash) = {} but value_hash = {}",
+                            hex::encode(key),
+                            hex::encode(computed_vh),
+                            hex::encode(node_value_hash),
+                        ),
+                    ));
+                }
+                Ok(())
+            }
+            Node::KVRefValueHash(..)
+            | Node::KVRefValueHashCount(..)
+            | Node::KVRefValueHashSum(..)
+            | Node::KVRefValueHashCountSum(..) => {
+                // KVRefValueHash{,Count,Sum,CountSum} carries an opaque
+                // node_value_hash that cannot be recomputed from the value
+                // bytes alone — the hash is `combine_hash(node_value_hash,
+                // value_hash(referenced_value))`, and the verifier never
+                // gets to see the referenced_value at this layer. Without
+                // this rejection, a forged value could ride along in a
+                // KVRefValueHashSum / KVRefValueHashCountSum trunk/branch
+                // node while the merk-level hash chain still appears
+                // valid, because the embedded opaque hash is treated as
+                // authoritative. These node types should never appear in
+                // trunk/branch chunk proofs.
+                Err(Error::InvalidProof(
+                    PathQuery::new_unsized(Vec::new(), Query::default()),
+                    format!(
+                        "trunk/branch proof contains unexpected KVRefValueHash node at key {}",
+                        hex::encode(key),
+                    ),
+                ))
+            }
+            // KV, KVCount, KVSum, KVCountSum: the value is used directly in
+            // the hash computation — bound.
+            _ => Ok(()),
+        }
+    }
+}

--- a/grovedb/src/operations/proof/chunk_proof_row_binding/v1.rs
+++ b/grovedb/src/operations/proof/chunk_proof_row_binding/v1.rs
@@ -1,0 +1,176 @@
+//! Chunk-proof row binding — **v1** (`GROVE_V4`+).
+//!
+//! The prover rewrites every composite row of the chunk ops — a tree of any
+//! kind, or a reference — to `KVValueHashFeatureTypeWithChildHash` through the
+//! same per-row binder the sum-budget window uses
+//! (`GroveDb::bind_composite_row`): a Merk tree carries its child root
+//! (`NULL_HASH` when empty), a non-Merk tree its own state root, a reference
+//! the referenced element's value hash. Each is exactly the second input of
+//! the `combine_hash` the parent committed, so the merk-level
+//! `combine_hash(H(value), child_hash) == value_hash` check now covers the
+//! element bytes. Item rows are left as the merk chunk emitted them; their
+//! bytes are hashed by the verifier directly.
+//!
+//! The verifier requires that node for every tree or reference row and no
+//! longer waives anything: a `KVValueHash` / `KVValueHashFeatureType` row must
+//! satisfy `H(value) == value_hash` and must not deserialize as a tree or
+//! reference, and a plain `KV`-family row must not either. Indexed trees
+//! commit `combine_hash_three(H(value), primary_root, attestation)`, a
+//! three-input hash no proof node carries, so the prover refuses to serve a
+//! chunk containing one and the verifier rejects any such row rather than
+//! return its metadata as verified.
+//!
+//! This differs from [`super::v0`] in that the prover reads storage (one child
+//! Merk open per tree row, a reference resolution per reference row) and
+//! mutates the ops, and the verifier rejects rows the released verifier
+//! returned. Those are why it cannot apply to the released versions; see the
+//! module docs in [`super`][`mod@super`].
+
+#[cfg(feature = "minimal")]
+use grovedb_costs::{cost_return_on_error, CostResult, CostsExt, OperationCost};
+#[cfg(feature = "minimal")]
+use grovedb_merk::proofs::Op;
+use grovedb_merk::{
+    proofs::Node,
+    tree::{combine_hash, value_hash},
+};
+
+#[cfg(feature = "minimal")]
+use crate::Transaction;
+use crate::{Element, Error, GroveDb, PathQuery, Query};
+
+impl GroveDb {
+    /// `bind_chunk_proof_rows` v1 — see the module documentation.
+    #[cfg(feature = "minimal")]
+    pub(crate) fn bind_chunk_proof_rows_v1(
+        &self,
+        ops: &mut [Op],
+        target_path: &[&[u8]],
+        tx: &Transaction,
+        grove_version: &grovedb_version::version::GroveVersion,
+    ) -> CostResult<(), Error> {
+        let mut cost = OperationCost::default();
+
+        for op in ops.iter_mut() {
+            let node = match op {
+                Op::Push(node) | Op::PushInverted(node) => node,
+                _ => continue,
+            };
+            cost_return_on_error!(
+                &mut cost,
+                self.bind_composite_row(
+                    node,
+                    target_path,
+                    tx,
+                    grove_version,
+                    "trunk/branch chunk proof: the row",
+                )
+            );
+        }
+
+        Ok(()).wrap_with_cost(cost)
+    }
+
+    /// `check_chunk_proof_row` v1 — see the module documentation.
+    pub(crate) fn check_chunk_proof_row_v1(
+        node: &Node,
+        key: &[u8],
+        value: &[u8],
+        element: &Element,
+    ) -> Result<(), Error> {
+        let reject = |message: String| {
+            Err(Error::InvalidProof(
+                PathQuery::new_unsized(Vec::new(), Query::default()),
+                message,
+            ))
+        };
+
+        // No proof node can carry an indexed tree's three-input binding, so
+        // its metadata can never be returned as verified from a chunk proof.
+        if element.is_indexed_tree() {
+            return reject(format!(
+                "trunk/branch proof row at key {} is an indexed tree, whose three-input \
+                 binding no proof node can carry; its metadata cannot be verified",
+                hex::encode(key),
+            ));
+        }
+
+        let composite = element.is_any_tree() || element.is_reference();
+
+        match node {
+            Node::KVValueHashFeatureTypeWithChildHash(_, _, node_value_hash, _, child_hash) => {
+                let element_vh = value_hash(value).value().to_owned();
+                let computed_vh = combine_hash(&element_vh, child_hash).value().to_owned();
+                if computed_vh != *node_value_hash {
+                    return reject(format!(
+                        "trunk/branch proof value/child hash mismatch at key {}: \
+                         combine_hash(H(value), child_hash) = {} but value_hash = {}",
+                        hex::encode(key),
+                        hex::encode(computed_vh),
+                        hex::encode(node_value_hash),
+                    ));
+                }
+                // The composition checked out, so the row is what its Merk
+                // committed. Only a tree or reference is ever committed
+                // through a combine_hash; anything else here is a prover
+                // bug, and its bytes must not be returned as an element of
+                // a shape the row cannot have.
+                if !composite {
+                    return reject(format!(
+                        "trunk/branch proof row at key {} carries a child hash but is neither \
+                         a tree nor a reference",
+                        hex::encode(key),
+                    ));
+                }
+                Ok(())
+            }
+            Node::KVValueHash(_, _, node_value_hash)
+            | Node::KVValueHashFeatureType(_, _, node_value_hash, _) => {
+                if composite {
+                    // The committed value_hash of a tree or reference is a
+                    // combine_hash the value bytes alone cannot reproduce;
+                    // without the child hash the metadata would be unbound.
+                    return reject(format!(
+                        "trunk/branch proof composite row at key {} must carry its child hash \
+                         (KVValueHashFeatureTypeWithChildHash); the tree metadata would \
+                         otherwise be unbound",
+                        hex::encode(key),
+                    ));
+                }
+                let computed_vh = value_hash(value).value().to_owned();
+                if computed_vh != *node_value_hash {
+                    return reject(format!(
+                        "trunk/branch proof value hash mismatch at key {}: H(value) = {} but \
+                         embedded value_hash = {}",
+                        hex::encode(key),
+                        hex::encode(computed_vh),
+                        hex::encode(node_value_hash),
+                    ));
+                }
+                Ok(())
+            }
+            Node::KVRefValueHash(..)
+            | Node::KVRefValueHashCount(..)
+            | Node::KVRefValueHashSum(..)
+            | Node::KVRefValueHashCountSum(..) => reject(format!(
+                "trunk/branch proof contains unexpected KVRefValueHash node at key {}",
+                hex::encode(key),
+            )),
+            // KV, KVCount, KVSum, KVCountSum: the merk verifier hashes the
+            // value bytes itself, which binds an item. A tree or reference
+            // is never committed that way, so one here is a forgery attempt
+            // that happens to have survived the root check — or a prover
+            // bug; either way its metadata must not be returned.
+            _ => {
+                if composite {
+                    return reject(format!(
+                        "trunk/branch proof composite row at key {} must carry its child hash \
+                         (KVValueHashFeatureTypeWithChildHash), not a plain key/value node",
+                        hex::encode(key),
+                    ));
+                }
+                Ok(())
+            }
+        }
+    }
+}

--- a/grovedb/src/operations/proof/generate.rs
+++ b/grovedb/src/operations/proof/generate.rs
@@ -552,127 +552,171 @@ impl GroveDb {
                 Op::Push(node) | Op::PushInverted(node) => node,
                 _ => continue,
             };
-            let (key, value, node_value_hash, feature_type) = match &*node {
-                Node::KVValueHash(key, value, value_hash) => (
-                    key.clone(),
-                    value.clone(),
-                    *value_hash,
-                    TreeFeatureType::BasicMerkNode,
-                ),
-                Node::KVValueHashFeatureType(key, value, value_hash, feature_type) => {
-                    (key.clone(), value.clone(), *value_hash, *feature_type)
-                }
-                // Items are pushed as KV / KVCount / KVSum / KVCountSum,
-                // whose value bytes the merk verifier hashes itself.
-                _ => continue,
-            };
-            let element = cost_return_on_error_no_add!(
-                cost,
-                Element::deserialize(&value, grove_version).map_err(Error::from)
-            )
-            .into_underlying();
-            if element.is_indexed_tree() {
-                return Err(Error::NotSupported(format!(
-                    "sum-budget window: the scanned row {} is an indexed tree, whose \
-                     three-input binding no proof node can carry",
-                    hex_to_ascii(&key)
-                )))
-                .wrap_with_cost(cost);
+            cost_return_on_error!(
+                &mut cost,
+                self.bind_composite_row(
+                    node,
+                    target_path,
+                    transaction,
+                    grove_version,
+                    "sum-budget window: the scanned row",
+                )
+            );
+        }
+
+        Ok(()).wrap_with_cost(cost)
+    }
+
+    /// Bind one value-bearing proof row to the element bytes it carries, if
+    /// the row is composite (#870, #859).
+    ///
+    /// A `KVValueHash` / `KVValueHashFeatureType` row whose value is a tree or
+    /// a reference is rewritten to `KVValueHashFeatureTypeWithChildHash`,
+    /// carrying the second input of the `combine_hash` the parent committed:
+    ///
+    /// - Merk trees: the child root (`NULL_HASH` for an empty tree), verified
+    ///   as `combine_hash(H(value), child_root) == value_hash` — the
+    ///   composition `insert` commits.
+    /// - References: the referenced element's value hash, which is the
+    ///   reference's committed composition.
+    /// - Non-Merk trees: [`Self::bind_terminal_non_merk_tree`] (their own
+    ///   state root).
+    /// - Indexed trees commit a three-input hash no proof node carries, so the
+    ///   row is refused with `NotSupported` rather than emitted unbound;
+    ///   `context` prefixes that message with the caller's name for the row.
+    ///
+    /// Item rows, and node shapes that carry no `value_hash`, are left as the
+    /// merk prover emitted them.
+    pub(crate) fn bind_composite_row(
+        &self,
+        node: &mut Node,
+        target_path: &[&[u8]],
+        transaction: &Transaction,
+        grove_version: &GroveVersion,
+        context: &str,
+    ) -> CostResult<(), Error> {
+        let mut cost = OperationCost::default();
+
+        let (key, value, node_value_hash, feature_type) = match &*node {
+            Node::KVValueHash(key, value, value_hash) => (
+                key.clone(),
+                value.clone(),
+                *value_hash,
+                TreeFeatureType::BasicMerkNode,
+            ),
+            Node::KVValueHashFeatureType(key, value, value_hash, feature_type) => {
+                (key.clone(), value.clone(), *value_hash, *feature_type)
             }
-            match element {
-                Element::Reference(reference_path, ..)
-                | Element::ReferenceWithSumItem(reference_path, ..) => {
-                    let absolute_path = cost_return_on_error_into!(
+            // Items are pushed as KV / KVCount / KVSum / KVCountSum,
+            // whose value bytes the merk verifier hashes itself.
+            _ => return Ok(()).wrap_with_cost(cost),
+        };
+        let element = cost_return_on_error_no_add!(
+            cost,
+            Element::deserialize(&value, grove_version).map_err(Error::from)
+        )
+        .into_underlying();
+        if element.is_indexed_tree() {
+            return Err(Error::NotSupported(format!(
+                "{context} {} is an indexed tree, whose three-input binding no proof node \
+                 can carry",
+                hex_to_ascii(&key)
+            )))
+            .wrap_with_cost(cost);
+        }
+        match element {
+            Element::Reference(reference_path, ..)
+            | Element::ReferenceWithSumItem(reference_path, ..) => {
+                let absolute_path = cost_return_on_error_into!(
+                    &mut cost,
+                    path_from_reference_path_type(
+                        reference_path,
+                        target_path,
+                        Some(key.as_slice())
+                    )
+                    .wrap_with_cost(OperationCost::default())
+                );
+                let referenced = cost_return_on_error_into!(
+                    &mut cost,
+                    self.follow_reference_as_stored(
+                        absolute_path.as_slice().into(),
+                        true,
+                        Some(transaction),
+                        grove_version
+                    )
+                );
+                // Legacy direct writes and stored-terminal commitments
+                // can coexist. Select the bytes using this row's actual
+                // commitment, independently of the version serving it.
+                let referenced = if referenced.is_wrapped() {
+                    let reference_element_hash = value_hash(&value).unwrap_add_cost(&mut cost);
+                    cost_return_on_error!(
                         &mut cost,
-                        path_from_reference_path_type(
-                            reference_path,
-                            target_path,
-                            Some(key.as_slice())
+                        Self::reference_terminal_as_committed(
+                            referenced,
+                            &reference_element_hash,
+                            &node_value_hash,
+                            grove_version,
                         )
-                        .wrap_with_cost(OperationCost::default())
-                    );
-                    let referenced = cost_return_on_error_into!(
+                    )
+                } else {
+                    referenced
+                };
+                let referenced_bytes = cost_return_on_error_no_add!(
+                    cost,
+                    referenced.serialize(grove_version).map_err(Error::from)
+                );
+                let referenced_hash = value_hash(&referenced_bytes).unwrap_add_cost(&mut cost);
+                *node = Node::KVValueHashFeatureTypeWithChildHash(
+                    key,
+                    value,
+                    node_value_hash,
+                    feature_type,
+                    referenced_hash,
+                );
+            }
+            non_merk @ (Element::MmrTree(..)
+            | Element::BulkAppendTree(..)
+            | Element::DenseAppendOnlyFixedSizeTree(..)
+            | Element::CommitmentTree(..)
+            | Element::PrivateDocumentStore(..)) => {
+                cost_return_on_error!(
+                    &mut cost,
+                    self.bind_terminal_non_merk_tree(
+                        node,
+                        &non_merk,
+                        target_path,
+                        transaction,
+                        grove_version,
+                    )
+                );
+            }
+            tree if tree.is_any_tree() => {
+                let child_root = if tree.is_non_empty_merk_tree() {
+                    let mut child_path = target_path.to_vec();
+                    child_path.push(key.as_slice());
+                    let child_merk = cost_return_on_error!(
                         &mut cost,
-                        self.follow_reference_as_stored(
-                            absolute_path.as_slice().into(),
-                            true,
-                            Some(transaction),
+                        self.open_transactional_merk_at_path(
+                            child_path.as_slice().into(),
+                            transaction,
+                            None,
                             grove_version
                         )
                     );
-                    // Legacy direct writes and stored-terminal commitments
-                    // can coexist. Select the bytes using this row's actual
-                    // commitment, independently of the version serving it.
-                    let referenced = if referenced.is_wrapped() {
-                        let reference_element_hash = value_hash(&value).unwrap_add_cost(&mut cost);
-                        cost_return_on_error!(
-                            &mut cost,
-                            Self::reference_terminal_as_committed(
-                                referenced,
-                                &reference_element_hash,
-                                &node_value_hash,
-                                grove_version,
-                            )
-                        )
-                    } else {
-                        referenced
-                    };
-                    let referenced_bytes = cost_return_on_error_no_add!(
-                        cost,
-                        referenced.serialize(grove_version).map_err(Error::from)
-                    );
-                    let referenced_hash = value_hash(&referenced_bytes).unwrap_add_cost(&mut cost);
-                    *node = Node::KVValueHashFeatureTypeWithChildHash(
-                        key,
-                        value,
-                        node_value_hash,
-                        feature_type,
-                        referenced_hash,
-                    );
-                }
-                non_merk @ (Element::MmrTree(..)
-                | Element::BulkAppendTree(..)
-                | Element::DenseAppendOnlyFixedSizeTree(..)
-                | Element::CommitmentTree(..)
-                | Element::PrivateDocumentStore(..)) => {
-                    cost_return_on_error!(
-                        &mut cost,
-                        self.bind_terminal_non_merk_tree(
-                            node,
-                            &non_merk,
-                            target_path,
-                            transaction,
-                            grove_version,
-                        )
-                    );
-                }
-                tree if tree.is_any_tree() => {
-                    let child_root = if tree.is_non_empty_merk_tree() {
-                        let mut child_path = target_path.to_vec();
-                        child_path.push(key.as_slice());
-                        let child_merk = cost_return_on_error!(
-                            &mut cost,
-                            self.open_transactional_merk_at_path(
-                                child_path.as_slice().into(),
-                                transaction,
-                                None,
-                                grove_version
-                            )
-                        );
-                        child_merk.root_hash().unwrap_add_cost(&mut cost)
-                    } else {
-                        NULL_HASH
-                    };
-                    *node = Node::KVValueHashFeatureTypeWithChildHash(
-                        key,
-                        value,
-                        node_value_hash,
-                        feature_type,
-                        child_root,
-                    );
-                }
-                _ => continue,
+                    child_merk.root_hash().unwrap_add_cost(&mut cost)
+                } else {
+                    NULL_HASH
+                };
+                *node = Node::KVValueHashFeatureTypeWithChildHash(
+                    key,
+                    value,
+                    node_value_hash,
+                    feature_type,
+                    child_root,
+                );
             }
+            _ => return Ok(()).wrap_with_cost(cost),
         }
 
         Ok(()).wrap_with_cost(cost)
@@ -1629,8 +1673,16 @@ impl GroveDb {
                 .map_err(Error::MerkError)
         );
 
+        // Bind every tree / reference row of the chunk to the bytes it
+        // carries (#859). A no-op below GROVE_V4.
+        let mut trunk_ops = trunk_result.proof;
+        cost_return_on_error!(
+            &mut cost,
+            self.bind_chunk_proof_rows(&mut trunk_ops, path_slices.as_slice(), &tx, grove_version)
+        );
+
         let mut trunk_proof_encoded = Vec::new();
-        encode_into(trunk_result.proof.iter(), &mut trunk_proof_encoded);
+        encode_into(trunk_ops.iter(), &mut trunk_proof_encoded);
 
         // Start with the innermost LayerProof using ProofBytes::Merk
         let mut current_layer = LayerProof {
@@ -1746,11 +1798,23 @@ impl GroveDb {
         );
 
         // Perform the branch query - returns BranchQueryResult directly
-        let branch_result = cost_return_on_error!(
+        let mut branch_result = cost_return_on_error!(
             &mut cost,
             target_tree
                 .branch_query(&query.key, query.depth, grove_version)
                 .map_err(Error::MerkError)
+        );
+
+        // Bind every tree / reference row of the chunk to the bytes it
+        // carries (#859). A no-op below GROVE_V4.
+        cost_return_on_error!(
+            &mut cost,
+            self.bind_chunk_proof_rows(
+                &mut branch_result.proof,
+                path_slices.as_slice(),
+                &tx,
+                grove_version
+            )
         );
 
         Ok(branch_result).wrap_with_cost(cost)

--- a/grovedb/src/operations/proof/mod.rs
+++ b/grovedb/src/operations/proof/mod.rs
@@ -13,6 +13,9 @@ mod aggregate_sum;
 /// `value_hash`. Consensus-critical — see the module docs.
 #[cfg(feature = "minimal")]
 mod bind_terminal_non_merk_tree;
+/// Trunk / branch chunk proofs: composite-row binding (#859), versioned.
+#[cfg(any(feature = "minimal", feature = "verify"))]
+mod chunk_proof_row_binding;
 #[cfg(feature = "minimal")]
 mod generate;
 // The prover lives in `indexed_axis::generate` and is `minimal`-gated there;

--- a/grovedb/src/operations/proof/verify.rs
+++ b/grovedb/src/operations/proof/verify.rs
@@ -4483,75 +4483,11 @@ impl GroveDb {
 
         let element = Element::deserialize(&value, grove_version)?;
 
-        // Verify embedded value_hash for node types that carry one.
-        // Without this, an attacker could replace KV(key, real_value)
-        // with KVValueHash(key, forged_value, real_value_hash) and the
-        // merk execute() would accept it since it uses the embedded hash.
-        match &tree.node {
-            Node::KVValueHash(_, _, node_value_hash)
-            | Node::KVValueHashFeatureType(_, _, node_value_hash, _) => {
-                let computed_vh = value_hash(&value).value().to_owned();
-                if computed_vh != *node_value_hash {
-                    // For tree elements, value_hash = combine_hash(H(value),
-                    // child_root_hash). We can't decompose the combined hash,
-                    // but the hash chain verification already validates tree
-                    // elements through the merk proof structure.
-                    if !element.is_any_tree() {
-                        return Err(Error::InvalidProof(
-                            PathQuery::new_unsized(Vec::new(), Query::default()),
-                            format!(
-                                "trunk/branch proof value hash mismatch at key {}: \
-                                 H(value) = {} but embedded value_hash = {}",
-                                hex::encode(&key),
-                                hex::encode(computed_vh),
-                                hex::encode(node_value_hash),
-                            ),
-                        ));
-                    }
-                }
-            }
-            Node::KVValueHashFeatureTypeWithChildHash(_, _, node_value_hash, _, child_hash) => {
-                let element_vh = value_hash(&value).value().to_owned();
-                let computed_vh = combine_hash(&element_vh, child_hash).value().to_owned();
-                if computed_vh != *node_value_hash {
-                    return Err(Error::InvalidProof(
-                        PathQuery::new_unsized(Vec::new(), Query::default()),
-                        format!(
-                            "trunk/branch proof value/child hash mismatch at key {}: \
-                             combine_hash(H(value), child_hash) = {} but value_hash = {}",
-                            hex::encode(&key),
-                            hex::encode(computed_vh),
-                            hex::encode(node_value_hash),
-                        ),
-                    ));
-                }
-            }
-            Node::KVRefValueHash(..)
-            | Node::KVRefValueHashCount(..)
-            | Node::KVRefValueHashSum(..)
-            | Node::KVRefValueHashCountSum(..) => {
-                // KVRefValueHash{,Count,Sum,CountSum} carries an opaque
-                // node_value_hash that cannot be recomputed from the value
-                // bytes alone — the hash is `combine_hash(node_value_hash,
-                // value_hash(referenced_value))`, and the verifier never
-                // gets to see the referenced_value at this layer. Without
-                // this rejection, a forged value could ride along in a
-                // KVRefValueHashSum / KVRefValueHashCountSum trunk/branch
-                // node while the merk-level hash chain still appears
-                // valid, because the embedded opaque hash is treated as
-                // authoritative. These node types should never appear in
-                // trunk/branch chunk proofs.
-                return Err(Error::InvalidProof(
-                    PathQuery::new_unsized(Vec::new(), Query::default()),
-                    format!(
-                        "trunk/branch proof contains unexpected KVRefValueHash node at key {}",
-                        hex::encode(&key),
-                    ),
-                ));
-            }
-            // KV, KVCount: value is used directly in hash computation — safe
-            _ => {}
-        }
+        // A row only reaches here under a genuine root hash, but the merk
+        // root covers a tree's or reference's `value_hash`, not its bytes:
+        // whether the node form binds them is version-gated (#859).
+        Self::check_chunk_proof_row(&tree.node, &key, &value, &element, grove_version)?;
+
         elements.insert(key.clone(), element);
 
         // Check if this node has Hash children (making it a leaf)

--- a/grovedb/src/tests/chunk_proof_row_binding_tests.rs
+++ b/grovedb/src/tests/chunk_proof_row_binding_tests.rs
@@ -1,0 +1,856 @@
+//! Trunk / branch chunk proofs: composite rows must be bound to the root
+//! hash (#859).
+//!
+//! A merk chunk proof binds an item row through `KV` (the verifier hashes the
+//! value bytes itself) but a tree or reference row through `KVValueHash` /
+//! `KVValueHashFeatureType`, whose `value_hash` the merk verifier treats as
+//! opaque. Nothing recomputes the tree's `combine_hash(H(value), child_root)`
+//! composition, so the returned element bytes — tree type, aggregate count or
+//! sum, root key — were free for a prover to forge under a genuine root hash.
+//! From `GROVE_V4` the prover rewrites every composite row to
+//! `KVValueHashFeatureTypeWithChildHash` and the verifier requires it.
+
+#[cfg(test)]
+mod tests {
+    use blake3::Hasher;
+    use grovedb_merk::{
+        proofs::{encode_into, Decoder, Node, Op},
+        tree::{combine_hash, value_hash},
+        TreeFeatureType,
+    };
+    use grovedb_version::version::{v1::GROVE_V1, v3::GROVE_V3, GroveVersion};
+
+    use crate::{
+        operations::proof::{GroveDBProof, GroveDBProofV1, ProofBytes},
+        query::{PathBranchChunkQuery, PathTrunkChunkQuery},
+        reference_path::ReferencePathType,
+        tests::{common::EMPTY_PATH, make_empty_grovedb, TempGroveDb},
+        Element, Error, GroveDb,
+    };
+
+    fn bincode_config() -> bincode::config::Configuration<
+        bincode::config::BigEndian,
+        bincode::config::Varint,
+        bincode::config::NoLimit,
+    > {
+        bincode::config::standard()
+            .with_big_endian()
+            .with_no_limit()
+    }
+
+    fn decode_v1(proof: &[u8]) -> GroveDBProofV1 {
+        let decoded: GroveDBProof = bincode::decode_from_slice(proof, bincode_config())
+            .expect("decode proof")
+            .0;
+        match decoded {
+            GroveDBProof::V1(v1) => v1,
+            GroveDBProof::V0(_) => panic!("expected a V1 trunk proof"),
+        }
+    }
+
+    fn target_layer_ops(proof_v1: &GroveDBProofV1, key: &[u8]) -> Vec<Op> {
+        let layer = proof_v1
+            .root_layer
+            .lower_layers
+            .get(key)
+            .expect("target layer");
+        let ProofBytes::Merk(bytes) = &layer.merk_proof else {
+            panic!("expected Merk bytes at the target layer");
+        };
+        Decoder::new(bytes)
+            .collect::<Result<Vec<_>, _>>()
+            .expect("decode ops")
+    }
+
+    fn rebuild_with_target_ops(mut proof_v1: GroveDBProofV1, key: &[u8], ops: &[Op]) -> Vec<u8> {
+        let mut encoded = Vec::new();
+        encode_into(ops.iter(), &mut encoded);
+        proof_v1
+            .root_layer
+            .lower_layers
+            .get_mut(key)
+            .expect("target layer")
+            .merk_proof = ProofBytes::Merk(encoded);
+        bincode::encode_to_vec(GroveDBProof::V1(proof_v1), bincode_config()).expect("encode")
+    }
+
+    fn encode_ops(ops: &[Op]) -> Vec<u8> {
+        let mut encoded = Vec::new();
+        encode_into(ops.iter(), &mut encoded);
+        encoded
+    }
+
+    /// A forged tree element: a different tree type, a large aggregate
+    /// count, and a root key that does not exist.
+    fn forged_tree_bytes(grove_version: &GroveVersion) -> Vec<u8> {
+        Element::CountTree(Some(b"phantom".to_vec()), 1_000_000, None)
+            .serialize(grove_version)
+            .expect("serialize forged tree")
+    }
+
+    fn node_of(op: &Op) -> Option<&Node> {
+        match op {
+            Op::Push(node) | Op::PushInverted(node) => Some(node),
+            _ => None,
+        }
+    }
+
+    /// Downgrade attack: strip the child hash from the first bound composite
+    /// row and substitute forged bytes, keeping the committed `value_hash`
+    /// (and feature type) so the merk root hash is unchanged.
+    fn downgrade_first_bound_row(ops: &mut [Op], forged: &[u8]) -> Option<Vec<u8>> {
+        for op in ops.iter_mut() {
+            if let Op::Push(Node::KVValueHashFeatureTypeWithChildHash(key, _, vh, ft, _)) = op {
+                let key = key.clone();
+                let replacement = if *ft == TreeFeatureType::BasicMerkNode {
+                    Node::KVValueHash(key.clone(), forged.to_vec(), *vh)
+                } else {
+                    Node::KVValueHashFeatureType(key.clone(), forged.to_vec(), *vh, *ft)
+                };
+                *op = Op::Push(replacement);
+                return Some(key);
+            }
+        }
+        None
+    }
+
+    /// In-place attack: keep the bound node form, swap the value bytes.
+    fn forge_first_bound_row_in_place(ops: &mut [Op], forged: &[u8]) -> Option<Vec<u8>> {
+        for op in ops.iter_mut() {
+            if let Op::Push(Node::KVValueHashFeatureTypeWithChildHash(key, value, ..)) = op {
+                *value = forged.to_vec();
+                return Some(key.clone());
+            }
+        }
+        None
+    }
+
+    /// Disguise attack: present an item row as a tree, keeping the item's
+    /// committed `value_hash` (`H(item)`) so the merk root is unchanged.
+    fn disguise_first_item_as_tree(ops: &mut [Op], forged: &[u8]) -> Option<Vec<u8>> {
+        for op in ops.iter_mut() {
+            if let Op::Push(Node::KV(key, value)) = op {
+                let real_vh = value_hash(value).unwrap();
+                let key = key.clone();
+                *op = Op::Push(Node::KVValueHash(key.clone(), forged.to_vec(), real_vh));
+                return Some(key);
+            }
+        }
+        None
+    }
+
+    fn assert_rejected_unbound(result: Result<impl std::fmt::Debug, Error>, what: &str) {
+        match result {
+            Ok(returned) => panic!("{what} verified; returned {returned:?}"),
+            Err(e) => {
+                let msg = format!("{e:?}");
+                assert!(
+                    msg.contains("must carry its child hash")
+                        || msg.contains("value/child hash mismatch")
+                        || msg.contains("value hash mismatch"),
+                    "{what}: unexpected rejection: {msg}"
+                );
+            }
+        }
+    }
+
+    /// Count tree host with five items and three subtrees (one populated).
+    fn count_tree_with_subtrees(grove_version: &GroveVersion, host: Element) -> TempGroveDb {
+        let db = make_empty_grovedb();
+        db.insert(EMPTY_PATH, b"ct", host, None, None, grove_version)
+            .unwrap()
+            .expect("insert host");
+        for i in 0u8..5 {
+            db.insert(
+                &[b"ct"],
+                format!("item_{i}").as_bytes(),
+                Element::new_item(vec![i; 8]),
+                None,
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("insert item");
+        }
+        for i in 0u8..3 {
+            db.insert(
+                &[b"ct"],
+                format!("sub_{i}").as_bytes(),
+                Element::empty_tree(),
+                None,
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("insert subtree");
+        }
+        db.insert(
+            &[b"ct".as_slice(), b"sub_0".as_slice()],
+            b"inner",
+            Element::new_item(vec![7]),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert inner item");
+        db
+    }
+
+    fn trunk_query() -> PathTrunkChunkQuery {
+        PathTrunkChunkQuery::new(vec![b"ct".to_vec()], 4)
+    }
+
+    fn prove_trunk(db: &TempGroveDb, grove_version: &GroveVersion) -> Vec<u8> {
+        db.prove_trunk_chunk(&trunk_query(), grove_version)
+            .unwrap()
+            .expect("prove trunk")
+    }
+
+    // ── Honest proofs ──────────────────────────────────────────────────
+
+    #[test]
+    fn trunk_v4_binds_every_tree_row_and_returns_stored_elements() {
+        let grove_version = GroveVersion::latest();
+        let db = count_tree_with_subtrees(grove_version, Element::empty_count_tree());
+
+        let proof = prove_trunk(&db, grove_version);
+        let (_, result) = GroveDb::verify_trunk_chunk_proof(&proof, &trunk_query(), grove_version)
+            .expect("honest proof verifies");
+
+        let ops = target_layer_ops(&decode_v1(&proof), b"ct");
+        let mut bound_tree_rows = 0;
+        for node in ops.iter().filter_map(node_of) {
+            match node {
+                Node::KVValueHashFeatureTypeWithChildHash(key, value, vh, _, child) => {
+                    let element = Element::deserialize(value, grove_version).unwrap();
+                    assert!(
+                        element.is_any_tree(),
+                        "bound row {} is not a tree",
+                        hex::encode(key)
+                    );
+                    assert_eq!(
+                        combine_hash(&value_hash(value).unwrap(), child).unwrap(),
+                        *vh,
+                        "child hash must reproduce the committed value hash"
+                    );
+                    bound_tree_rows += 1;
+                }
+                Node::KVValueHash(key, ..) | Node::KVValueHashFeatureType(key, ..) => {
+                    panic!("row {} was left unbound under GROVE_V4", hex::encode(key));
+                }
+                _ => {}
+            }
+        }
+        assert_eq!(
+            bound_tree_rows, 3,
+            "all three subtrees are within the trunk"
+        );
+
+        // Returned elements are the stored ones: sub_0 is populated, the
+        // other two are empty.
+        assert!(matches!(
+            result.elements.get(b"sub_0".as_slice()),
+            Some(Element::Tree(Some(_), _))
+        ));
+        assert!(matches!(
+            result.elements.get(b"sub_1".as_slice()),
+            Some(Element::Tree(None, _))
+        ));
+        assert_eq!(result.elements.len(), 8);
+    }
+
+    #[test]
+    fn honest_chunk_proofs_with_reference_rows_verify_under_v4() {
+        let grove_version = GroveVersion::latest();
+        let db = count_tree_with_subtrees(grove_version, Element::empty_count_tree());
+        db.insert(
+            EMPTY_PATH,
+            b"target",
+            Element::new_item(b"referenced".to_vec()),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert target");
+        db.insert(
+            &[b"ct"],
+            b"ref",
+            Element::new_reference(ReferencePathType::AbsolutePathReference(vec![
+                b"target".to_vec()
+            ])),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert reference");
+
+        let proof = prove_trunk(&db, grove_version);
+        let (_, result) = GroveDb::verify_trunk_chunk_proof(&proof, &trunk_query(), grove_version)
+            .expect("honest trunk proof with a reference row verifies");
+        assert!(
+            matches!(
+                result.elements.get(b"ref".as_slice()),
+                Some(Element::Reference(..))
+            ),
+            "reference row should be returned"
+        );
+
+        let ops = target_layer_ops(&decode_v1(&proof), b"ct");
+        let ref_row = ops
+            .iter()
+            .filter_map(node_of)
+            .find(|node| matches!(node, Node::KVValueHashFeatureTypeWithChildHash(key, ..) if key == b"ref"))
+            .expect("reference row is bound");
+        let Node::KVValueHashFeatureTypeWithChildHash(_, _, _, _, child) = ref_row else {
+            unreachable!()
+        };
+        let referenced_bytes = Element::new_item(b"referenced".to_vec())
+            .serialize(grove_version)
+            .unwrap();
+        assert_eq!(
+            *child,
+            value_hash(&referenced_bytes).unwrap(),
+            "a reference row carries the referenced element's value hash"
+        );
+    }
+
+    // ── Trunk attacks ──────────────────────────────────────────────────
+
+    #[test]
+    fn trunk_rejects_downgraded_tree_row_with_forged_metadata() {
+        let grove_version = GroveVersion::latest();
+        let db = count_tree_with_subtrees(grove_version, Element::empty_count_tree());
+        let proof = prove_trunk(&db, grove_version);
+        let proof_v1 = decode_v1(&proof);
+
+        let mut ops = target_layer_ops(&proof_v1, b"ct");
+        downgrade_first_bound_row(&mut ops, &forged_tree_bytes(grove_version))
+            .expect("a bound tree row to downgrade");
+        let tampered = rebuild_with_target_ops(proof_v1, b"ct", &ops);
+
+        assert_rejected_unbound(
+            GroveDb::verify_trunk_chunk_proof(&tampered, &trunk_query(), grove_version),
+            "trunk proof with a downgraded tree row",
+        );
+    }
+
+    #[test]
+    fn trunk_rejects_downgraded_tree_row_in_provable_count_host() {
+        let grove_version = GroveVersion::latest();
+        let db = count_tree_with_subtrees(grove_version, Element::empty_provable_count_tree());
+        let proof = prove_trunk(&db, grove_version);
+        let proof_v1 = decode_v1(&proof);
+
+        let mut ops = target_layer_ops(&proof_v1, b"ct");
+        // In a Provable* host the merk chunk emits KVValueHashFeatureType,
+        // so the downgrade keeps the feature type (and the count it hashes).
+        let key = downgrade_first_bound_row(&mut ops, &forged_tree_bytes(grove_version))
+            .expect("a bound tree row to downgrade");
+        assert!(ops
+            .iter()
+            .filter_map(node_of)
+            .any(|node| matches!(node, Node::KVValueHashFeatureType(k, ..) if *k == key)));
+        let tampered = rebuild_with_target_ops(proof_v1, b"ct", &ops);
+
+        assert_rejected_unbound(
+            GroveDb::verify_trunk_chunk_proof(&tampered, &trunk_query(), grove_version),
+            "trunk proof with a downgraded feature-type tree row",
+        );
+    }
+
+    #[test]
+    fn trunk_rejects_in_place_forged_tree_row() {
+        let grove_version = GroveVersion::latest();
+        let db = count_tree_with_subtrees(grove_version, Element::empty_count_tree());
+        let proof = prove_trunk(&db, grove_version);
+        let proof_v1 = decode_v1(&proof);
+
+        let mut ops = target_layer_ops(&proof_v1, b"ct");
+        forge_first_bound_row_in_place(&mut ops, &forged_tree_bytes(grove_version))
+            .expect("a bound tree row to forge");
+        let tampered = rebuild_with_target_ops(proof_v1, b"ct", &ops);
+
+        let result = GroveDb::verify_trunk_chunk_proof(&tampered, &trunk_query(), grove_version);
+        let msg = format!("{:?}", result.err().expect("forged bound row rejected"));
+        assert!(msg.contains("value/child hash mismatch"), "{msg}");
+    }
+
+    #[test]
+    fn trunk_rejects_item_disguised_as_tree() {
+        let grove_version = GroveVersion::latest();
+        let db = count_tree_with_subtrees(grove_version, Element::empty_count_tree());
+        let proof = prove_trunk(&db, grove_version);
+        let proof_v1 = decode_v1(&proof);
+
+        let mut ops = target_layer_ops(&proof_v1, b"ct");
+        disguise_first_item_as_tree(&mut ops, &forged_tree_bytes(grove_version))
+            .expect("an item row to disguise");
+        let tampered = rebuild_with_target_ops(proof_v1, b"ct", &ops);
+
+        assert_rejected_unbound(
+            GroveDb::verify_trunk_chunk_proof(&tampered, &trunk_query(), grove_version),
+            "trunk proof with an item disguised as a tree",
+        );
+    }
+
+    // ── Branch ─────────────────────────────────────────────────────────
+
+    /// Count tree of 100 hashed keys mixing items, empty subtrees and
+    /// references, so a trunk at depth 5 leaves branches holding composite
+    /// rows.
+    fn wide_count_tree(grove_version: &GroveVersion) -> TempGroveDb {
+        let db = make_empty_grovedb();
+        db.insert(
+            EMPTY_PATH,
+            b"ct",
+            Element::empty_count_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert count tree");
+        db.insert(
+            EMPTY_PATH,
+            b"target",
+            Element::new_item(b"referenced".to_vec()),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert target");
+        for i in 0u32..100 {
+            let mut hasher = Hasher::new();
+            hasher.update(&i.to_be_bytes());
+            let key: [u8; 32] = *hasher.finalize().as_bytes();
+            let element = match i % 3 {
+                0 => Element::new_item(vec![i as u8; 4]),
+                1 => Element::empty_tree(),
+                _ => Element::new_reference(ReferencePathType::AbsolutePathReference(vec![
+                    b"target".to_vec(),
+                ])),
+            };
+            db.insert(&[b"ct"], &key, element, None, None, grove_version)
+                .unwrap()
+                .expect("insert row");
+        }
+        db
+    }
+
+    /// Every branch of the wide tree, as `(query, honest proof, expected
+    /// hash)`.
+    fn wide_tree_branches(
+        db: &TempGroveDb,
+        grove_version: &GroveVersion,
+    ) -> Vec<(PathBranchChunkQuery, Vec<u8>, [u8; 32])> {
+        let trunk_query = PathTrunkChunkQuery::new(vec![b"ct".to_vec()], 5);
+        let trunk_proof = db
+            .prove_trunk_chunk(&trunk_query, grove_version)
+            .unwrap()
+            .expect("prove trunk");
+        let (_, trunk) =
+            GroveDb::verify_trunk_chunk_proof(&trunk_proof, &trunk_query, grove_version)
+                .expect("honest trunk verifies");
+        let remaining_depth = trunk.chunk_depths[1];
+        trunk
+            .leaf_keys
+            .iter()
+            .map(|(leaf_key, leaf_info)| {
+                let query = PathBranchChunkQuery::new(
+                    vec![b"ct".to_vec()],
+                    leaf_key.clone(),
+                    remaining_depth,
+                );
+                let proof = db
+                    .prove_branch_chunk(&query, grove_version)
+                    .unwrap()
+                    .expect("prove branch");
+                (query, proof, leaf_info.hash)
+            })
+            .collect()
+    }
+
+    #[test]
+    fn branch_v4_binds_every_composite_row_and_honest_branches_verify() {
+        let grove_version = GroveVersion::latest();
+        let db = wide_count_tree(grove_version);
+
+        let mut trees = 0;
+        let mut references = 0;
+        for (query, proof, expected_hash) in wide_tree_branches(&db, grove_version) {
+            let result =
+                GroveDb::verify_branch_chunk_proof(&proof, &query, expected_hash, grove_version)
+                    .expect("honest branch verifies");
+            for element in result.elements.values() {
+                if element.is_any_tree() {
+                    trees += 1;
+                } else if element.is_reference() {
+                    references += 1;
+                }
+            }
+            let ops: Vec<Op> = Decoder::new(&proof).collect::<Result<_, _>>().unwrap();
+            for node in ops.iter().filter_map(node_of) {
+                if let Node::KVValueHash(key, ..) | Node::KVValueHashFeatureType(key, ..) = node {
+                    panic!(
+                        "branch row {} left unbound under GROVE_V4",
+                        hex::encode(key)
+                    );
+                }
+            }
+        }
+        assert!(
+            trees > 0 && references > 0,
+            "branches should hold composite rows"
+        );
+    }
+
+    #[test]
+    fn branch_rejects_downgraded_tree_row_with_forged_metadata() {
+        let grove_version = GroveVersion::latest();
+        let db = wide_count_tree(grove_version);
+        let forged = forged_tree_bytes(grove_version);
+
+        let mut attacked = 0;
+        for (query, proof, expected_hash) in wide_tree_branches(&db, grove_version) {
+            let mut ops: Vec<Op> = Decoder::new(&proof).collect::<Result<_, _>>().unwrap();
+            if downgrade_first_bound_row(&mut ops, &forged).is_none() {
+                continue;
+            }
+            attacked += 1;
+            assert_rejected_unbound(
+                GroveDb::verify_branch_chunk_proof(
+                    &encode_ops(&ops),
+                    &query,
+                    expected_hash,
+                    grove_version,
+                ),
+                "branch proof with a downgraded composite row",
+            );
+        }
+        assert!(attacked > 0, "no branch held a bound composite row");
+    }
+
+    #[test]
+    fn branch_rejects_item_disguised_as_tree() {
+        let grove_version = GroveVersion::latest();
+        let db = wide_count_tree(grove_version);
+        let forged = forged_tree_bytes(grove_version);
+
+        let mut attacked = 0;
+        for (query, proof, expected_hash) in wide_tree_branches(&db, grove_version) {
+            let mut ops: Vec<Op> = Decoder::new(&proof).collect::<Result<_, _>>().unwrap();
+            if disguise_first_item_as_tree(&mut ops, &forged).is_none() {
+                continue;
+            }
+            attacked += 1;
+            assert_rejected_unbound(
+                GroveDb::verify_branch_chunk_proof(
+                    &encode_ops(&ops),
+                    &query,
+                    expected_hash,
+                    grove_version,
+                ),
+                "branch proof with an item disguised as a tree",
+            );
+        }
+        assert!(attacked > 0, "no branch held an item row");
+    }
+
+    // ── Non-Merk trees ─────────────────────────────────────────────────
+
+    #[test]
+    fn trunk_binds_non_merk_tree_rows_and_rejects_forged_entry_count() {
+        let grove_version = GroveVersion::latest();
+        let db = count_tree_with_subtrees(grove_version, Element::empty_count_tree());
+        db.insert(
+            &[b"ct"],
+            b"mmr",
+            Element::empty_mmr_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert mmr");
+        for i in 0u8..2 {
+            db.mmr_tree_append(
+                [b"ct".as_slice()].as_ref(),
+                b"mmr",
+                vec![i; 8],
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("append leaf");
+        }
+
+        let proof = prove_trunk(&db, grove_version);
+        let (_, result) = GroveDb::verify_trunk_chunk_proof(&proof, &trunk_query(), grove_version)
+            .expect("honest proof verifies");
+        let stored = db
+            .get_raw(
+                grovedb_path::SubtreePath::from([b"ct".as_slice()].as_ref()),
+                b"mmr",
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("stored mmr element");
+        assert!(matches!(stored, Element::MmrTree(size, _) if size > 0));
+        assert_eq!(
+            result.elements.get(b"mmr".as_slice()),
+            Some(&stored),
+            "returned MMR must be the stored element"
+        );
+
+        let proof_v1 = decode_v1(&proof);
+        let mut ops = target_layer_ops(&proof_v1, b"ct");
+        let forged_mmr = Element::new_mmr_tree(999, None)
+            .serialize(grove_version)
+            .unwrap();
+        let mut found = false;
+        for op in ops.iter_mut() {
+            if let Op::Push(Node::KVValueHashFeatureTypeWithChildHash(key, _, vh, ..)) = op
+                && key == b"mmr"
+            {
+                *op = Op::Push(Node::KVValueHash(key.clone(), forged_mmr.clone(), *vh));
+                found = true;
+            }
+        }
+        assert!(found, "the MMR row is bound and within the trunk");
+        let tampered = rebuild_with_target_ops(proof_v1, b"ct", &ops);
+        assert_rejected_unbound(
+            GroveDb::verify_trunk_chunk_proof(&tampered, &trunk_query(), grove_version),
+            "trunk proof with a forged MMR entry count",
+        );
+    }
+
+    // ── Indexed trees ──────────────────────────────────────────────────
+
+    #[test]
+    fn chunk_proofs_refuse_indexed_tree_rows() {
+        let grove_version = GroveVersion::latest();
+        let db = count_tree_with_subtrees(grove_version, Element::empty_count_tree());
+        db.insert(
+            &[b"ct"],
+            b"idx",
+            Element::empty_provable_count_indexed_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert indexed tree");
+
+        let err = db
+            .prove_trunk_chunk(&trunk_query(), grove_version)
+            .unwrap()
+            .err()
+            .expect("trunk over a host with an indexed row is refused");
+        assert!(
+            matches!(&err, Error::NotSupported(msg) if msg.contains("indexed tree")),
+            "unexpected error: {err:?}"
+        );
+
+        let branch_query = PathBranchChunkQuery::new(vec![b"ct".to_vec()], b"idx".to_vec(), 1);
+        let err = db
+            .prove_branch_chunk(&branch_query, grove_version)
+            .unwrap()
+            .err()
+            .expect("branch rooted at an indexed row is refused");
+        assert!(
+            matches!(&err, Error::NotSupported(msg) if msg.contains("indexed tree")),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[test]
+    fn check_chunk_proof_row_v1_rejects_rows_no_node_form_can_bind() {
+        let grove_version = GroveVersion::latest();
+        let key = b"k".to_vec();
+
+        // An indexed tree's three-input binding has no carrier: rejected in
+        // every node form, even one whose two-input composition checks out.
+        let indexed = Element::empty_provable_count_indexed_tree();
+        let indexed_bytes = indexed.serialize(grove_version).unwrap();
+        let child = [9u8; 32];
+        let vh = combine_hash(&value_hash(&indexed_bytes).unwrap(), &child).unwrap();
+        let node = Node::KVValueHashFeatureTypeWithChildHash(
+            key.clone(),
+            indexed_bytes.clone(),
+            vh,
+            TreeFeatureType::BasicMerkNode,
+            child,
+        );
+        let msg = format!(
+            "{:?}",
+            GroveDb::check_chunk_proof_row(&node, &key, &indexed_bytes, &indexed, grove_version)
+                .err()
+                .expect("indexed row rejected")
+        );
+        assert!(msg.contains("indexed tree"), "{msg}");
+
+        // A tree in a plain KV node: never committed that way.
+        let tree = Element::empty_tree();
+        let tree_bytes = tree.serialize(grove_version).unwrap();
+        let node = Node::KV(key.clone(), tree_bytes.clone());
+        let msg = format!(
+            "{:?}",
+            GroveDb::check_chunk_proof_row(&node, &key, &tree_bytes, &tree, grove_version)
+                .err()
+                .expect("tree in KV rejected")
+        );
+        assert!(msg.contains("must carry its child hash"), "{msg}");
+
+        // An item in a child-hash node whose composition checks out: the
+        // row cannot have that shape.
+        let item = Element::new_item(vec![1]);
+        let item_bytes = item.serialize(grove_version).unwrap();
+        let vh = combine_hash(&value_hash(&item_bytes).unwrap(), &child).unwrap();
+        let node = Node::KVValueHashFeatureTypeWithChildHash(
+            key.clone(),
+            item_bytes.clone(),
+            vh,
+            TreeFeatureType::BasicMerkNode,
+            child,
+        );
+        let msg = format!(
+            "{:?}",
+            GroveDb::check_chunk_proof_row(&node, &key, &item_bytes, &item, grove_version)
+                .err()
+                .expect("item in child-hash node rejected")
+        );
+        assert!(msg.contains("neither a tree nor a reference"), "{msg}");
+
+        // The honest shapes pass.
+        let node = Node::KV(key.clone(), item_bytes.clone());
+        GroveDb::check_chunk_proof_row(&node, &key, &item_bytes, &item, grove_version)
+            .expect("item in KV accepted");
+        let vh = combine_hash(&value_hash(&tree_bytes).unwrap(), &child).unwrap();
+        let node = Node::KVValueHashFeatureTypeWithChildHash(
+            key.clone(),
+            tree_bytes.clone(),
+            vh,
+            TreeFeatureType::BasicMerkNode,
+            child,
+        );
+        GroveDb::check_chunk_proof_row(&node, &key, &tree_bytes, &tree, grove_version)
+            .expect("bound tree accepted");
+    }
+
+    // ── Version gate ───────────────────────────────────────────────────
+
+    /// Consensus version gate for `proof.chunk_proof_row_binding`.
+    ///
+    /// Under **v0** (`GROVE_V3`, the released shape) the trunk prover emits
+    /// a bare `KVValueHash` for a subtree row and the verifier waives the
+    /// value-hash check for it, so forged tree metadata verifies against the
+    /// real root hash. Under **v1** (`GROVE_V4`+) the row carries its child
+    /// hash, the verifier requires it, and the same forgery is rejected.
+    ///
+    /// Pins both sides so the gate cannot silently collapse to one behaviour
+    /// — which would either reject honest released proofs or reopen the
+    /// forgery.
+    #[test]
+    fn chunk_proof_row_binding_version_gate() {
+        let build_and_forge = |grove_version: &GroveVersion| {
+            let db = count_tree_with_subtrees(grove_version, Element::empty_count_tree());
+            let proof = prove_trunk(&db, grove_version);
+            GroveDb::verify_trunk_chunk_proof(&proof, &trunk_query(), grove_version)
+                .expect("honest proof verifies at every version");
+
+            let proof_v1 = decode_v1(&proof);
+            let mut ops = target_layer_ops(&proof_v1, b"ct");
+            let bound = ops
+                .iter()
+                .filter_map(node_of)
+                .any(|node| matches!(node, Node::KVValueHashFeatureTypeWithChildHash(..)));
+            let forged = forged_tree_bytes(grove_version);
+            let forged_key = if bound {
+                downgrade_first_bound_row(&mut ops, &forged)
+            } else {
+                let mut key = None;
+                for op in ops.iter_mut() {
+                    if let Op::Push(Node::KVValueHash(k, value, _)) = op
+                        && key.is_none()
+                    {
+                        key = Some(k.clone());
+                        *value = forged.clone();
+                    }
+                }
+                key
+            }
+            .expect("a subtree row to forge");
+            let tampered = rebuild_with_target_ops(proof_v1, b"ct", &ops);
+            let accepted =
+                match GroveDb::verify_trunk_chunk_proof(&tampered, &trunk_query(), grove_version) {
+                    Ok((_, result)) => {
+                        assert!(
+                            matches!(
+                                result.elements.get(&forged_key),
+                                Some(Element::CountTree(Some(_), 1_000_000, _))
+                            ),
+                            "an accepted forgery returns the forged metadata"
+                        );
+                        true
+                    }
+                    Err(_) => false,
+                };
+            (bound, accepted)
+        };
+
+        // v0 — GROVE_V3, the released shape. Bare KVValueHash, forgery
+        // accepted. This is the hole; it cannot be closed in place because
+        // V3 is live.
+        let (v3_bound, v3_accepted) = build_and_forge(&GROVE_V3);
+        assert!(
+            !v3_bound,
+            "GROVE_V3 must keep emitting a bare KVValueHash for a subtree row"
+        );
+        assert!(
+            v3_accepted,
+            "GROVE_V3 is expected to still accept the forgery — if this now fails, the fix \
+             leaked into a released version and changes consensus behaviour"
+        );
+
+        // v1 — GROVE_V4, latest. Child-hash node, forgery rejected.
+        let (v4_bound, v4_accepted) = build_and_forge(GroveVersion::latest());
+        assert!(
+            v4_bound,
+            "GROVE_V4 must emit KVValueHashFeatureTypeWithChildHash for a subtree row"
+        );
+        assert!(!v4_accepted, "GROVE_V4 must reject forged tree metadata");
+    }
+
+    /// A V0 trunk envelope (produced under `GROVE_V1`) carries unbound tree
+    /// rows. It still verifies under the version that produced it, and a
+    /// `GROVE_V4` verifier rejects it rather than return unbound metadata.
+    #[test]
+    fn v0_trunk_envelope_tree_rows_are_rejected_under_v4() {
+        let db = count_tree_with_subtrees(&GROVE_V1, Element::empty_count_tree());
+        let proof = prove_trunk(&db, &GROVE_V1);
+        assert!(
+            matches!(
+                bincode::decode_from_slice::<GroveDBProof, _>(&proof, bincode_config())
+                    .unwrap()
+                    .0,
+                GroveDBProof::V0(_)
+            ),
+            "GROVE_V1 produces a V0 trunk envelope"
+        );
+
+        GroveDb::verify_trunk_chunk_proof(&proof, &trunk_query(), &GROVE_V1)
+            .expect("V0 envelope verifies under GROVE_V1");
+        let msg = format!(
+            "{:?}",
+            GroveDb::verify_trunk_chunk_proof(&proof, &trunk_query(), GroveVersion::latest())
+                .err()
+                .expect("V0 envelope with unbound tree rows is rejected under GROVE_V4")
+        );
+        assert!(msg.contains("must carry its child hash"), "{msg}");
+    }
+}

--- a/grovedb/src/tests/chunk_proof_row_binding_tests.rs
+++ b/grovedb/src/tests/chunk_proof_row_binding_tests.rs
@@ -742,6 +742,155 @@ mod tests {
             .expect("bound tree accepted");
     }
 
+    /// The released (v0) row check, pinned arm by arm: the tree waiver, the
+    /// item mismatch rejection, the child-hash composition check, and the
+    /// `KVRefValueHash` rejection.
+    #[test]
+    fn check_chunk_proof_row_v0_pins_released_arms() {
+        let grove_version = &GROVE_V3;
+        let key = b"k".to_vec();
+        let child = [9u8; 32];
+
+        let tree = Element::empty_tree();
+        let tree_bytes = tree.serialize(grove_version).unwrap();
+        let item = Element::new_item(vec![1]);
+        let item_bytes = item.serialize(grove_version).unwrap();
+
+        // A tree in a bare KVValueHash whose value_hash is a combine_hash the
+        // bytes cannot reproduce: waived (the hole this PR closes from V4).
+        let combined = combine_hash(&value_hash(&tree_bytes).unwrap(), &child).unwrap();
+        let node = Node::KVValueHash(key.clone(), tree_bytes.clone(), combined);
+        GroveDb::check_chunk_proof_row(&node, &key, &tree_bytes, &tree, grove_version)
+            .expect("v0 waives the mismatch for a tree");
+        let node = Node::KVValueHashFeatureType(
+            key.clone(),
+            tree_bytes.clone(),
+            combined,
+            TreeFeatureType::BasicMerkNode,
+        );
+        GroveDb::check_chunk_proof_row(&node, &key, &tree_bytes, &tree, grove_version)
+            .expect("v0 waives the mismatch for a tree in a feature-type node");
+
+        // An item with a mismatching value_hash is rejected.
+        let node = Node::KVValueHash(key.clone(), item_bytes.clone(), combined);
+        let msg = format!(
+            "{:?}",
+            GroveDb::check_chunk_proof_row(&node, &key, &item_bytes, &item, grove_version)
+                .err()
+                .expect("v0 rejects an item mismatch")
+        );
+        assert!(msg.contains("value hash mismatch"), "{msg}");
+        // ... and accepted when the hash matches.
+        let node = Node::KVValueHash(
+            key.clone(),
+            item_bytes.clone(),
+            value_hash(&item_bytes).unwrap(),
+        );
+        GroveDb::check_chunk_proof_row(&node, &key, &item_bytes, &item, grove_version)
+            .expect("v0 accepts a matching item");
+
+        // Child-hash node: composition checked.
+        let node = Node::KVValueHashFeatureTypeWithChildHash(
+            key.clone(),
+            tree_bytes.clone(),
+            combined,
+            TreeFeatureType::BasicMerkNode,
+            child,
+        );
+        GroveDb::check_chunk_proof_row(&node, &key, &tree_bytes, &tree, grove_version)
+            .expect("v0 accepts a correct child-hash composition");
+        let node = Node::KVValueHashFeatureTypeWithChildHash(
+            key.clone(),
+            tree_bytes.clone(),
+            combined,
+            TreeFeatureType::BasicMerkNode,
+            [0u8; 32],
+        );
+        let msg = format!(
+            "{:?}",
+            GroveDb::check_chunk_proof_row(&node, &key, &tree_bytes, &tree, grove_version)
+                .err()
+                .expect("v0 rejects a wrong child hash")
+        );
+        assert!(msg.contains("value/child hash mismatch"), "{msg}");
+
+        // KVRefValueHash family: never accepted.
+        let node = Node::KVRefValueHash(key.clone(), item_bytes.clone(), combined);
+        let msg = format!(
+            "{:?}",
+            GroveDb::check_chunk_proof_row(&node, &key, &item_bytes, &item, grove_version)
+                .err()
+                .expect("v0 rejects KVRefValueHash")
+        );
+        assert!(msg.contains("unexpected KVRefValueHash"), "{msg}");
+
+        // Plain KV: bound by the merk verifier itself.
+        let node = Node::KV(key.clone(), item_bytes.clone());
+        GroveDb::check_chunk_proof_row(&node, &key, &item_bytes, &item, grove_version)
+            .expect("v0 accepts KV");
+    }
+
+    #[test]
+    fn check_chunk_proof_row_v1_rejects_ref_nodes_and_item_mismatch() {
+        let grove_version = GroveVersion::latest();
+        let key = b"k".to_vec();
+        let item = Element::new_item(vec![1]);
+        let item_bytes = item.serialize(grove_version).unwrap();
+        let real_vh = value_hash(&item_bytes).unwrap();
+
+        let node = Node::KVRefValueHashSum(key.clone(), item_bytes.clone(), real_vh, 1);
+        let msg = format!(
+            "{:?}",
+            GroveDb::check_chunk_proof_row(&node, &key, &item_bytes, &item, grove_version)
+                .err()
+                .expect("v1 rejects KVRefValueHash family")
+        );
+        assert!(msg.contains("unexpected KVRefValueHash"), "{msg}");
+
+        let node = Node::KVValueHash(key.clone(), item_bytes.clone(), [7u8; 32]);
+        let msg = format!(
+            "{:?}",
+            GroveDb::check_chunk_proof_row(&node, &key, &item_bytes, &item, grove_version)
+                .err()
+                .expect("v1 rejects an item mismatch")
+        );
+        assert!(msg.contains("value hash mismatch"), "{msg}");
+
+        let node = Node::KVValueHash(key.clone(), item_bytes.clone(), real_vh);
+        GroveDb::check_chunk_proof_row(&node, &key, &item_bytes, &item, grove_version)
+            .expect("v1 accepts a matching item in KVValueHash");
+    }
+
+    #[test]
+    fn chunk_proof_row_binding_unknown_version_is_refused_on_both_sides() {
+        let mut unknown = GroveVersion::latest().clone();
+        unknown
+            .grovedb_versions
+            .operations
+            .proof
+            .chunk_proof_row_binding = 99;
+
+        let key = b"k".to_vec();
+        let item = Element::new_item(vec![1]);
+        let item_bytes = item.serialize(&unknown).unwrap();
+        let node = Node::KV(key.clone(), item_bytes.clone());
+        assert!(matches!(
+            GroveDb::check_chunk_proof_row(&node, &key, &item_bytes, &item, &unknown),
+            Err(Error::VersionError(_))
+        ));
+
+        let db = count_tree_with_subtrees(GroveVersion::latest(), Element::empty_count_tree());
+        assert!(matches!(
+            db.prove_trunk_chunk(&trunk_query(), &unknown).unwrap(),
+            Err(Error::VersionError(_))
+        ));
+        let branch_query = PathBranchChunkQuery::new(vec![b"ct".to_vec()], b"sub_0".to_vec(), 1);
+        assert!(matches!(
+            db.prove_branch_chunk(&branch_query, &unknown).unwrap(),
+            Err(Error::VersionError(_))
+        ));
+    }
+
     // ── Version gate ───────────────────────────────────────────────────
 
     /// Consensus version gate for `proof.chunk_proof_row_binding`.

--- a/grovedb/src/tests/mod.rs
+++ b/grovedb/src/tests/mod.rs
@@ -26,6 +26,7 @@ mod batch_unit_tests;
 mod bulk_append_tree_tests;
 mod checkpoint_tests;
 mod chunk_branch_proof_tests;
+mod chunk_proof_row_binding_tests;
 mod commitment_tree_cost_bound_tests;
 mod commitment_tree_tests;
 mod coverage_round7_tests;


### PR DESCRIPTION
Closes #859.

## Problem

Trunk and branch chunk proofs (`prove_trunk_chunk` / `prove_branch_chunk`) carried subtree rows as bare `KVValueHash` / `KVValueHashFeatureType` nodes, whose `value_hash` the merk verifier treats as opaque. The shared element extraction (`extract_elements_and_leaf_keys`) then **waived** the `H(value) == value_hash` check for any row that deserialized as a tree. Nothing ever recomputed the tree's `combine_hash(H(value), child_root)` composition, so the returned tree metadata — tree type, aggregate count or sum, root key — was unbound.

Reproduced at runtime on current `develop`, on both variants:

- a subtree row's bytes replaced by `CountTree(Some("phantom"), 1_000_000)` verifies against the genuine root hash and is returned as verified (trunk and branch);
- an **item** row can be disguised as a tree: `KV(key, item)` → `KVValueHash(key, forged_tree, H(item))` verifies and returns the forged tree;
- as a side effect of the same design, an honest chunk containing a **reference** row never verified at all (references are not waived).

The issue's audit-only claim is therefore real.

## Fix (GROVE_V4, `proof.chunk_proof_row_binding: 1`)

One new version slot gates prover and verifier together, dispatched through a new `operations/proof/chunk_proof_row_binding/{mod,v0,v1}.rs` module (no inline version branches):

- **Prover** (`bind_chunk_proof_rows`): every composite row of the chunk ops is rewritten to `KVValueHashFeatureTypeWithChildHash` via a per-row binder now **shared with the sum-budget window from #870** (`bind_composite_row`, extracted from `bind_sum_budget_window_rows` with no behaviour change): the child Merk root (`NULL_HASH` when empty), the non-Merk tree's own state root (through `bind_terminal_non_merk_tree`), or the referenced element's value hash. Hooked into `prove_trunk_chunk_non_serialized_v1` and `prove_branch_chunk_non_serialized`; a no-op below V4.
- **Verifier** (`check_chunk_proof_row`): replaces the inline waiver. v0 is the released logic moved verbatim; v1 requires the child-hash node for every tree or reference row, checks the two-input composition, and rejects trees/references in any other node form.
- **Indexed trees** commit `combine_hash_three(H(value), primary_root, attestation)`, which no proof node can carry (and the branch proof has no envelope for a side channel). Following the #870 precedent they are **refused by the prover** (`NotSupported`) and **rejected by the verifier** rather than returned as verified. Supporting them would need a branch-proof wire-format change; flagged as a follow-up if a consumer ever chunk-syncs a tree hosting indexed children.

V0 prover/verifier functions are untouched. A V0 envelope produced under GROVE_V1 still verifies under GROVE_V1; a GROVE_V4 verifier rejects its unbound tree rows (fail-closed, pinned by a test).

## Tests (`grovedb/src/tests/chunk_proof_row_binding_tests.rs`)

- honest V4 trunk binds every tree row and returns the stored elements; honest reference rows now verify (trunk and branch) and carry the referenced value hash;
- trunk/branch tamper: downgrade (strip child hash + forge, plain and Provable* host), in-place forge under the bound form, item disguised as tree — all rejected;
- non-Merk (MMR) row bound; forged entry count rejected;
- indexed row: prover refuses trunk and branch; direct unit test of the v1 check for rows no node form can bind;
- version gate pinning both sides (V3 emits bare `KVValueHash` and still accepts the forgery; V4 binds and rejects), mirroring `terminal_non_merk_tree_child_hash_version_gate`.

`cargo test -p grovedb --features full,verify,unsafe-dump-load` (3041 passed), `cargo test -p grovedb-merk` (726), `cargo test -p grovedb-version`, `cargo fmt`, clippy clean on the changed files (the remaining local clippy 1.97 lints are in untouched files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
