### PR TITLE
fix(insert): refuse a reference whose terminal is a tree on the direct path (GROVE_V4+)

### DIFF
--- a/docs/book/src/reference-system.md
+++ b/docs/book/src/reference-system.md
@@ -299,6 +299,20 @@ Otherwise they use the stored terminal. This works for mixed write histories
 and after an upgrade without rewriting data or changing roots. A changed
 terminal that matches neither representation still fails verification.
 
+### A reference must terminate at a value
+
+The terminal of a reference chain must be an item (`Item`, `SumItem`,
+`ItemWithSumItem`, optionally `NonCounted`-wrapped). A tree element cannot be a
+terminal: the reference would only bind `H(tree element bytes)`, which says
+nothing about the subtree behind it, so the subtree could change without
+disturbing the reference's commitment or `verify_grovedb`, and the row could
+not be proved (the V1 verifier expects a lower layer for a non-empty tree).
+The batch reference resolver has always rejected such a reference with
+`InvalidBatchOperation("references can not point to trees being updated")`.
+Direct insert on `GROVE_V4`+ rejects it too, with
+`InvalidInput("references can not point to trees")`; `GROVE_V3` direct inserts
+keep the legacy behaviour of accepting it.
+
 ## Cycle Detection
 
 The `visited` HashSet tracks all paths we've seen. If we encounter a path we've

--- a/grovedb-version/src/version/v4.rs
+++ b/grovedb-version/src/version/v4.rs
@@ -220,8 +220,12 @@
 //!   so overwriting the item `B` of `A -> B` with a reference to `A` looked
 //!   acyclic and committed `A -> B -> A`, after which every `get`, proof and
 //!   `verify_grovedb` on either key failed. The batch path already refuses
-//!   it. Gated because (i) moves a committed root and (ii) flips an
-//!   accepted/rejected outcome.
+//!   it. (iii) It is refused with `InvalidInput` if its chain terminates at
+//!   a tree element, which the batch resolver has always rejected; v1
+//!   accepted it and committed only `H(tree element bytes)`, a hash that does
+//!   not bind the subtree's contents, so the row could not be proved and
+//!   subtree changes never disturbed it. Gated because (i) moves a committed
+//!   root and (ii)/(iii) flip an accepted/rejected outcome.
 //!
 //! Note that `GroveVersion::latest()` resolves to this version, so anything
 //! defaulting to "latest" — tests, benchmarks, tools — exercises every gate
@@ -371,6 +375,9 @@ pub const GROVE_V4: GroveVersion = GroveVersion {
                 // stale element still stored at that position, so an
                 // overwrite could commit a cycle every later read fails on.
                 // The batch path already refuses it.
+                // It also refuses a reference whose terminal is a tree
+                // element, matching the batch resolver; v1 accepted it and
+                // committed a hash that does not bind the subtree's contents.
                 add_element_on_transaction: 2,
                 add_element_without_transaction: 0,
                 insert_if_not_exists: 0,

--- a/grovedb/src/operations/insert/add_element_on_transaction/mod.rs
+++ b/grovedb/src/operations/insert/add_element_on_transaction/mod.rs
@@ -25,8 +25,10 @@
 //!   chain runs back through the position being written, which v1 accepted
 //!   when that position was being overwritten: the stale stored element
 //!   made the chain look acyclic and the write committed a cycle that every
-//!   later read failed on. The batch path already refuses it. Selected by
-//!   `GROVE_V4`+.
+//!   later read failed on. The batch path already refuses it. v2 further
+//!   refuses a reference whose terminal is a tree, as the batch resolver
+//!   always has; v0/v1 accepted it and committed a hash that does not bind
+//!   the subtree's contents. Selected by `GROVE_V4`+.
 //!
 //! The implementations are otherwise identical. See [v0] / [v1] / [v2].
 //!

--- a/grovedb/src/operations/insert/add_element_on_transaction/v2.rs
+++ b/grovedb/src/operations/insert/add_element_on_transaction/v2.rs
@@ -24,6 +24,13 @@
 //! `CyclicReference`. The batch resolver has always refused this, because the
 //! overwriting op is in `ops_by_qualified_paths`. Refusing it here flips an
 //! accepted/rejected outcome, hence the gate.
+//!
+//! v2 further refuses a reference whose chain terminates at a tree element (any
+//! `is_any_tree()` terminal, empty or populated). The batch reference resolver
+//! has always rejected that shape (`"references can not point to trees being
+//! updated"`), but v0/v1 accepted it and committed only `H(tree element
+//! bytes)` — a commitment that does not bind the subtree's contents and whose
+//! row cannot be proved. v1 keeps accepting it for the same consensus reason.
 
 use grovedb_costs::{
     cost_return_on_error, cost_return_on_error_into, cost_return_on_error_no_add, CostResult,
@@ -150,6 +157,20 @@ impl GroveDb {
                         grove_version
                     )
                 );
+
+                // A reference must terminate at a value. A tree terminal
+                // would only bind `H(tree element bytes)`: the subtree
+                // behind it is not part of the commitment, so mutating
+                // the subtree leaves the reference (and `verify_grovedb`)
+                // untouched, a subquery through the reference errors, and
+                // the row cannot be proved (the V1 verifier expects a lower
+                // layer for a non-empty tree). The batch reference resolver
+                // has always refused this; refuse it on the direct path too.
+                // `is_any_tree` looks through a `NonCounted` wrapper.
+                if referenced_item.is_any_tree() {
+                    return Err(Error::InvalidInput("references can not point to trees"))
+                        .wrap_with_cost(cost);
+                }
 
                 let referenced_element_value_hash = cost_return_on_error_into!(
                     &mut cost,

--- a/grovedb/src/tests/batch_unit_tests.rs
+++ b/grovedb/src/tests/batch_unit_tests.rs
@@ -9,7 +9,7 @@
 mod tests {
     use grovedb_merk::tree::AggregateData;
     use grovedb_merk::tree_type::TreeType;
-    use grovedb_version::version::GroveVersion;
+    use grovedb_version::version::{v3::GROVE_V3, GroveVersion};
 
     use crate::batch::key_info::KeyInfo::KnownKey;
     use crate::batch::{
@@ -1671,7 +1671,10 @@ mod tests {
         .unwrap()
         .expect("insert tree");
 
-        // Insert ref_a pointing to the tree (this is unusual but valid for insert)
+        // Insert ref_a pointing to the tree. Direct insert refuses a
+        // reference to a tree from GROVE_V4 on, so the row is written under
+        // GROVE_V3, which still accepts it — the shape an upgraded database
+        // can carry from before the refusal.
         db.insert(
             [TEST_LEAF].as_ref(),
             b"ref_a2",
@@ -1681,10 +1684,10 @@ mod tests {
             ])),
             None,
             None,
-            grove_version,
+            &GROVE_V3,
         )
         .unwrap()
-        .expect("insert ref_a2");
+        .expect("insert ref_a2 under GROVE_V3");
 
         // Batch: refresh ref_a2 (trust=true, pointing to the tree) +
         // insert ref_b2 -> ref_a2 with hops > 1

--- a/grovedb/src/tests/coverage_misc_tests.rs
+++ b/grovedb/src/tests/coverage_misc_tests.rs
@@ -11,7 +11,7 @@ mod tests {
         proofs::Query as MerkQuery,
         tree_type::TreeType,
     };
-    use grovedb_version::version::GroveVersion;
+    use grovedb_version::version::{v3::GROVE_V3, GroveVersion};
 
     use crate::{
         batch::KeyInfoPath,
@@ -198,6 +198,11 @@ mod tests {
     /// Same three element types, but reached through absolute-path
     /// references: `follow_reference` resolves to the indexed tree and
     /// the reference branch maps the aggregates identically.
+    ///
+    /// Direct insert refuses a reference to a tree from GROVE_V4 on (the
+    /// batch path always has), so such rows can only exist as legacy data
+    /// written before the refusal. The fixture writes them under GROVE_V3
+    /// and reads them under the latest version.
     #[test]
     fn query_item_value_or_sum_follows_references_to_indexed_trees() {
         let grove_version = GroveVersion::latest();
@@ -228,10 +233,10 @@ mod tests {
                 ])),
                 None,
                 None,
-                grove_version,
+                &GROVE_V3,
             )
             .unwrap()
-            .expect("insert reference to indexed tree");
+            .expect("insert legacy reference to indexed tree under GROVE_V3");
         }
 
         let mut query = MerkQuery::new();

--- a/grovedb/src/tests/mod.rs
+++ b/grovedb/src/tests/mod.rs
@@ -37,6 +37,7 @@ mod per_instance_gate_coverage_tests;
 mod per_instance_limit_tests;
 mod private_document_store_tests;
 mod reference_cycle_on_overwrite_tests;
+mod reference_to_tree_terminal_tests;
 mod unbound_empty_tree_tests;
 mod wrapped_terminal_reference_tests;
 // NOTE: the former `count_indexed_tree_tests` (~12.3k LOC) was written

--- a/grovedb/src/tests/reference_to_tree_terminal_tests.rs
+++ b/grovedb/src/tests/reference_to_tree_terminal_tests.rs
@@ -1,0 +1,480 @@
+//! Regression tests: a reference whose chain terminates at a **tree** is
+//! refused on the direct insert path (`GROVE_V4`+), as it always has been
+//! by the batch reference resolver.
+//!
+//! A reference node commits to `H(terminal bytes)`. When the terminal is a
+//! tree element that hash covers only the tree's own element bytes, not
+//! the subtree behind it: mutating the subtree leaves the reference's
+//! commitment (and `verify_grovedb`) untouched, `get` through the
+//! reference surfaces the bare tree element, a subquery through it errors
+//! ("the reference must result in an item"), and a V1 proof of the row
+//! fails to verify because the verifier expects a lower layer for a
+//! non-empty tree. `apply_batch` has always rejected the shape with
+//! `InvalidBatchOperation("references can not point to trees being
+//! updated")`; `GroveDb::insert` accepted it.
+//!
+//! `GROVE_V3` is live, so the refusal lives in `add_element_on_transaction`
+//! v2 (selected by `GROVE_V4`+). v1 keeps accepting, which is pinned here.
+
+#[cfg(test)]
+mod tests {
+    use grovedb_version::version::{v3::GROVE_V3, GroveVersion};
+
+    use crate::{
+        batch::QualifiedGroveDbOp,
+        reference_path::ReferencePathType,
+        tests::{make_test_grovedb, TempGroveDb, ANOTHER_TEST_LEAF, TEST_LEAF},
+        Element, Error,
+    };
+
+    const REF_KEY: &[u8] = b"ref_to_tree";
+    const ITEM_KEY: &[u8] = b"item";
+
+    fn absolute_reference(path: &[&[u8]]) -> Element {
+        Element::new_reference(ReferencePathType::AbsolutePathReference(
+            path.iter().map(|segment| segment.to_vec()).collect(),
+        ))
+    }
+
+    /// `ANOTHER_TEST_LEAF` holds one item, so it is a populated tree.
+    fn db_with_populated_tree(grove_version: &GroveVersion) -> TempGroveDb {
+        let db = make_test_grovedb(grove_version);
+        db.insert(
+            [ANOTHER_TEST_LEAF].as_ref(),
+            ITEM_KEY,
+            Element::new_item(b"value".to_vec()),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert item under ANOTHER_TEST_LEAF");
+        db
+    }
+
+    fn root(db: &TempGroveDb, grove_version: &GroveVersion) -> [u8; 32] {
+        db.root_hash(None, grove_version)
+            .unwrap()
+            .expect("root hash")
+    }
+
+    fn assert_direct_refusal(result: Result<(), Error>) {
+        match result {
+            Err(Error::InvalidInput(message)) => assert!(
+                message.contains("references can not point to trees"),
+                "unexpected refusal message: {message}"
+            ),
+            other => panic!("expected InvalidInput refusal, got {other:?}"),
+        }
+    }
+
+    /// The refusal must leave no trace: no row, same root, clean walk.
+    fn assert_nothing_written(
+        db: &TempGroveDb,
+        path: &[&[u8]],
+        key: &[u8],
+        root_before: [u8; 32],
+        grove_version: &GroveVersion,
+    ) {
+        let stored = db
+            .get_raw_optional(path.into(), key, None, grove_version)
+            .unwrap()
+            .expect("read back the refused key");
+        assert_eq!(stored, None, "a refused reference must not be stored");
+        assert_eq!(
+            root(db, grove_version),
+            root_before,
+            "a refused insert must not move the root"
+        );
+        let issues = db
+            .verify_grovedb(None, true, true, grove_version)
+            .expect("verify_grovedb runs");
+        assert!(
+            issues.is_empty(),
+            "integrity walk must stay clean: {issues:?}"
+        );
+    }
+
+    /// The exact reproduction: item under `ANOTHER_TEST_LEAF`, then a
+    /// direct insert of a reference to `ANOTHER_TEST_LEAF` itself.
+    #[test]
+    fn direct_insert_refuses_reference_to_populated_tree() {
+        let grove_version = GroveVersion::latest();
+        let db = db_with_populated_tree(grove_version);
+        let root_before = root(&db, grove_version);
+
+        let result = db
+            .insert(
+                [TEST_LEAF].as_ref(),
+                REF_KEY,
+                absolute_reference(&[ANOTHER_TEST_LEAF]),
+                None,
+                None,
+                grove_version,
+            )
+            .unwrap();
+        assert_direct_refusal(result);
+        assert_nothing_written(&db, &[TEST_LEAF], REF_KEY, root_before, grove_version);
+    }
+
+    /// The batch resolver refuses references to trees regardless of
+    /// whether the tree holds anything; so does the direct path, for
+    /// every tree family the direct path can create.
+    #[test]
+    fn direct_insert_refuses_reference_to_empty_tree_of_any_type() {
+        let grove_version = GroveVersion::latest();
+        let trees: Vec<(&[u8], Element)> = vec![
+            (b"tree", Element::empty_tree()),
+            (b"sum", Element::empty_sum_tree()),
+            (b"big_sum", Element::empty_big_sum_tree()),
+            (b"count", Element::empty_count_tree()),
+            (b"count_sum", Element::empty_count_sum_tree()),
+            (b"provable_count", Element::empty_provable_count_tree()),
+            (b"provable_sum", Element::empty_provable_sum_tree()),
+            (b"mmr", Element::empty_mmr_tree()),
+        ];
+        for (tree_key, tree) in trees {
+            let db = make_test_grovedb(grove_version);
+            db.insert(
+                [ANOTHER_TEST_LEAF].as_ref(),
+                tree_key,
+                tree.clone(),
+                None,
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .unwrap_or_else(|e| panic!("insert empty {tree:?}: {e}"));
+            let root_before = root(&db, grove_version);
+
+            let result = db
+                .insert(
+                    [TEST_LEAF].as_ref(),
+                    REF_KEY,
+                    absolute_reference(&[ANOTHER_TEST_LEAF, tree_key]),
+                    None,
+                    None,
+                    grove_version,
+                )
+                .unwrap();
+            assert!(
+                matches!(result, Err(Error::InvalidInput(_))),
+                "reference to empty {tree:?} must be refused, got {result:?}"
+            );
+            assert_nothing_written(&db, &[TEST_LEAF], REF_KEY, root_before, grove_version);
+        }
+
+        // The root-level leaves created by `make_test_grovedb` are empty
+        // plain trees too.
+        let db = make_test_grovedb(grove_version);
+        let root_before = root(&db, grove_version);
+        let result = db
+            .insert(
+                [TEST_LEAF].as_ref(),
+                REF_KEY,
+                absolute_reference(&[ANOTHER_TEST_LEAF]),
+                None,
+                None,
+                grove_version,
+            )
+            .unwrap();
+        assert_direct_refusal(result);
+        assert_nothing_written(&db, &[TEST_LEAF], REF_KEY, root_before, grove_version);
+    }
+
+    /// `ReferenceWithSumItem` shares the resolution arm and is refused the
+    /// same way.
+    #[test]
+    fn direct_insert_refuses_reference_with_sum_item_to_tree() {
+        let grove_version = GroveVersion::latest();
+        let db = db_with_populated_tree(grove_version);
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"sum_tree",
+            Element::empty_sum_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert sum tree");
+        let root_before = root(&db, grove_version);
+
+        let result = db
+            .insert(
+                [TEST_LEAF, b"sum_tree"].as_ref(),
+                REF_KEY,
+                Element::new_reference_with_sum_item(
+                    ReferencePathType::AbsolutePathReference(vec![ANOTHER_TEST_LEAF.to_vec()]),
+                    5,
+                ),
+                None,
+                None,
+                grove_version,
+            )
+            .unwrap();
+        assert_direct_refusal(result);
+        assert_nothing_written(
+            &db,
+            &[TEST_LEAF, b"sum_tree"],
+            REF_KEY,
+            root_before,
+            grove_version,
+        );
+    }
+
+    /// A chain is judged by its terminal. The legacy hop (a reference to
+    /// a tree) is written under `GROVE_V3`, which still accepts it; after
+    /// the upgrade a new reference that resolves through that hop to the
+    /// tree is refused.
+    #[test]
+    fn direct_insert_refuses_reference_chain_that_terminates_at_tree() {
+        let db = db_with_populated_tree(&GROVE_V3);
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"legacy_hop",
+            absolute_reference(&[ANOTHER_TEST_LEAF]),
+            None,
+            None,
+            &GROVE_V3,
+        )
+        .unwrap()
+        .expect("GROVE_V3 still accepts a reference to a tree");
+
+        let latest = GroveVersion::latest();
+        let root_before = root(&db, latest);
+        let result = db
+            .insert(
+                [TEST_LEAF].as_ref(),
+                REF_KEY,
+                absolute_reference(&[TEST_LEAF, b"legacy_hop"]),
+                None,
+                None,
+                latest,
+            )
+            .unwrap();
+        assert_direct_refusal(result);
+        assert_nothing_written(&db, &[TEST_LEAF], REF_KEY, root_before, latest);
+    }
+
+    /// A reference to an item stays accepted: the refusal is specific to
+    /// tree terminals, including when the chain hops through another
+    /// reference on its way to the item.
+    #[test]
+    fn direct_insert_still_accepts_reference_to_item_and_chain_to_item() {
+        let grove_version = GroveVersion::latest();
+        let db = db_with_populated_tree(grove_version);
+
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"ref_to_item",
+            absolute_reference(&[ANOTHER_TEST_LEAF, ITEM_KEY]),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("reference to an item is accepted");
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"ref_to_ref",
+            absolute_reference(&[TEST_LEAF, b"ref_to_item"]),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("reference chain ending at an item is accepted");
+
+        for key in [b"ref_to_item".as_slice(), b"ref_to_ref".as_slice()] {
+            let got = db
+                .get([TEST_LEAF].as_ref(), key, None, grove_version)
+                .unwrap()
+                .expect("get through reference");
+            assert_eq!(got, Element::new_item(b"value".to_vec()));
+        }
+        let issues = db
+            .verify_grovedb(None, true, true, grove_version)
+            .expect("verify_grovedb runs");
+        assert!(issues.is_empty(), "{issues:?}");
+    }
+
+    /// Every public insert entry point routes through the same arm.
+    #[test]
+    fn conditional_insert_entry_points_refuse_reference_to_tree() {
+        let grove_version = GroveVersion::latest();
+        let db = db_with_populated_tree(grove_version);
+        let root_before = root(&db, grove_version);
+        let reference = absolute_reference(&[ANOTHER_TEST_LEAF]);
+
+        let result = db
+            .insert_if_not_exists(
+                [TEST_LEAF].as_ref(),
+                REF_KEY,
+                reference.clone(),
+                None,
+                grove_version,
+            )
+            .unwrap();
+        assert!(
+            matches!(result, Err(Error::InvalidInput(_))),
+            "insert_if_not_exists must refuse, got {result:?}"
+        );
+
+        let result = db
+            .insert_if_not_exists_return_existing_element(
+                [TEST_LEAF].as_ref(),
+                REF_KEY,
+                reference.clone(),
+                None,
+                grove_version,
+            )
+            .unwrap();
+        assert!(
+            matches!(result, Err(Error::InvalidInput(_))),
+            "insert_if_not_exists_return_existing_element must refuse, got {result:?}"
+        );
+
+        let result = db
+            .insert_if_changed_value(
+                [TEST_LEAF].as_ref(),
+                REF_KEY,
+                reference,
+                None,
+                grove_version,
+            )
+            .unwrap();
+        assert!(
+            matches!(result, Err(Error::InvalidInput(_))),
+            "insert_if_changed_value must refuse, got {result:?}"
+        );
+
+        assert_nothing_written(&db, &[TEST_LEAF], REF_KEY, root_before, grove_version);
+    }
+
+    /// The refusal also holds inside an explicit transaction: the batch is
+    /// discarded and nothing reaches the transaction.
+    #[test]
+    fn direct_insert_refuses_reference_to_tree_inside_transaction() {
+        let grove_version = GroveVersion::latest();
+        let db = db_with_populated_tree(grove_version);
+        let root_before = root(&db, grove_version);
+
+        let tx = db.start_transaction();
+        let result = db
+            .insert(
+                [TEST_LEAF].as_ref(),
+                REF_KEY,
+                absolute_reference(&[ANOTHER_TEST_LEAF]),
+                None,
+                Some(&tx),
+                grove_version,
+            )
+            .unwrap();
+        assert_direct_refusal(result);
+        let stored = db
+            .get_raw_optional(
+                [TEST_LEAF].as_ref().into(),
+                REF_KEY,
+                Some(&tx),
+                grove_version,
+            )
+            .unwrap()
+            .expect("read back inside the transaction");
+        assert_eq!(stored, None);
+        db.commit_transaction(tx).unwrap().expect("commit");
+        assert_nothing_written(&db, &[TEST_LEAF], REF_KEY, root_before, grove_version);
+    }
+
+    /// Direct and batch writes of the same reference now agree: both
+    /// refuse, each with its path's typed error, and neither moves the
+    /// root.
+    #[test]
+    fn direct_and_batch_paths_agree_on_reference_to_tree() {
+        let grove_version = GroveVersion::latest();
+        let reference = absolute_reference(&[ANOTHER_TEST_LEAF]);
+
+        let direct = db_with_populated_tree(grove_version);
+        let direct_root = root(&direct, grove_version);
+        let result = direct
+            .insert(
+                [TEST_LEAF].as_ref(),
+                REF_KEY,
+                reference.clone(),
+                None,
+                None,
+                grove_version,
+            )
+            .unwrap();
+        assert_direct_refusal(result);
+
+        let batched = db_with_populated_tree(grove_version);
+        let batched_root = root(&batched, grove_version);
+        let result = batched
+            .apply_batch(
+                vec![QualifiedGroveDbOp::insert_or_replace_op(
+                    vec![TEST_LEAF.to_vec()],
+                    REF_KEY.to_vec(),
+                    reference,
+                )],
+                None,
+                None,
+                grove_version,
+            )
+            .unwrap();
+        match result {
+            Err(Error::InvalidBatchOperation(message)) => assert!(
+                message.contains("references can not point to trees"),
+                "unexpected batch refusal message: {message}"
+            ),
+            other => panic!("expected InvalidBatchOperation refusal, got {other:?}"),
+        }
+
+        assert_eq!(direct_root, batched_root, "both databases start identical");
+        assert_nothing_written(&direct, &[TEST_LEAF], REF_KEY, direct_root, grove_version);
+        assert_nothing_written(&batched, &[TEST_LEAF], REF_KEY, batched_root, grove_version);
+    }
+
+    /// Consensus pin: `GROVE_V3` is live, so its direct insert must keep
+    /// accepting a reference to a tree and committing the legacy hash of
+    /// the bare tree element. Reading that legacy row under `GROVE_V4`
+    /// must still work, and must not rewrite it.
+    #[test]
+    fn grove_v3_direct_insert_still_accepts_reference_to_tree() {
+        let db = db_with_populated_tree(&GROVE_V3);
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            REF_KEY,
+            absolute_reference(&[ANOTHER_TEST_LEAF]),
+            None,
+            None,
+            &GROVE_V3,
+        )
+        .unwrap()
+        .expect("GROVE_V3 direct insert keeps accepting a reference to a tree");
+        let root_after_legacy_write = root(&db, &GROVE_V3);
+
+        for reader_version in [&GROVE_V3, GroveVersion::latest()] {
+            let got = db
+                .get([TEST_LEAF].as_ref(), REF_KEY, None, reader_version)
+                .unwrap()
+                .expect("get through the legacy reference");
+            assert!(
+                got.is_any_tree(),
+                "the legacy reference resolves to the tree element, got {got:?}"
+            );
+            let issues = db
+                .verify_grovedb(None, true, true, reader_version)
+                .expect("verify_grovedb runs");
+            assert!(
+                issues.is_empty(),
+                "legacy row is internally consistent: {issues:?}"
+            );
+            assert_eq!(
+                root(&db, reader_version),
+                root_after_legacy_write,
+                "reads must not rewrite commitments"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`GroveDb::insert` accepted an `Element::Reference` (or `ReferenceWithSumItem`) whose resolved terminal is a tree, while `apply_batch` has always refused the same op with `InvalidBatchOperation("references can not point to trees being updated")`. A reference commits to `H(terminal bytes)`; for a tree terminal that is only the tree's own element bytes, so the commitment does not bind the subtree's contents. Reproduced on develop:

- `get` through the reference returns the bare `Tree` element.
- `query_item_value` with a subquery errors "the reference must result in an item".
- `prove_query` succeeds but `GroveDb::verify_query` fails with "V1 proof is missing lower layer for non-empty tree at key ...".
- Mutating the target subtree leaves `verify_grovedb` clean, i.e. the reference's commitment is silently stale.

This PR makes the direct insert path refuse a reference whose terminal `is_any_tree()`, matching the batch resolver.

## Change

- `grovedb/src/operations/insert/add_element_on_transaction/v2.rs`: after `follow_reference_as_stored` resolves the terminal, refuse it with `Error::InvalidInput("references can not point to trees")` if it is any tree (empty or populated; `is_any_tree` looks through a `NonCounted` wrapper). Nothing is written, the `StorageBatch` is discarded, the root does not move.
- Version gating: v2 of `add_element_on_transaction` is selected only by `GROVE_V4`+ (`add_element_on_transaction: 2` in `v4.rs`, introduced by #874), so the refusal is V4-gated by construction. v0 (`GROVE_V1`/`V2`) and v1 (`GROVE_V3`, live) are untouched and keep accepting the shape; no new sub-file was needed because v2 has no released consumer. Module docs, the `v4.rs` slot comment and the book's reference chapter are updated to say so.
- V0 proof code is not touched.

`InvalidInput` is used rather than `InvalidBatchOperation` because this is not a batch; the message mirrors the batch resolver's wording.

## Tests

New `grovedb/src/tests/reference_to_tree_terminal_tests.rs` (9 tests):

- the exact reproduction (item under `ANOTHER_TEST_LEAF`, reference to `ANOTHER_TEST_LEAF`) is refused and leaves no row, the same root and a clean `verify_grovedb`;
- references to an empty tree of every family the direct path can create (Tree, Sum, BigSum, Count, CountSum, ProvableCount, ProvableSum, Mmr) are refused;
- `ReferenceWithSumItem` to a tree is refused;
- a chain that hops through a legacy V3-written reference-to-tree and terminates at the tree is refused;
- references to an item, and chains ending at an item, are still accepted;
- `insert_if_not_exists`, `insert_if_not_exists_return_existing_element` and `insert_if_changed_value` refuse too;
- the refusal holds inside an explicit transaction;
- direct and batch paths now agree (each with its typed error);
- consensus pin: `GROVE_V3` direct insert still accepts the reference, and the legacy row reads and verifies under both V3 and V4 without being rewritten.

Without the v2 change, the 7 refusal tests fail and the 2 acceptance/pin tests pass.

Two existing fixtures created a reference-to-tree through direct insert under `latest` and now write that legacy row under `GROVE_V3` instead (the batch op / read they exercise is unchanged):

- `batch_unit_tests::test_batch_ref_to_refresh_ref_pointing_to_tree_errors` (covers the `RefreshReference` arm of `follow_reference_get_value_hash`);
- `coverage_misc_tests::query_item_value_or_sum_follows_references_to_indexed_trees` (covers the reference arm of `query_item_value_or_sum`).

Worth knowing for reviewers: `query_item_value_or_sum` has a reference arm that maps a reference resolving to a sum/count/indexed tree onto that tree's aggregate value. With this PR that arm is reachable only through rows written before `GROVE_V4` (or through the V3 insert path); nothing in this PR changes the read side.

`cargo test -p grovedb --features unsafe-dump-load` passes locally on the rebased head (3067 lib tests, 3 doc tests); `cargo fmt --all --check` is clean. The local `cargo clippy --workspace --all-features` run could not complete because the `grovedbg` build script's artifact download timed out on this network, so clippy was run over `grovedb` and `grovedb-version` with every other feature plus `--all-targets`: no finding is in a file this PR touches (the 30 reported sites are pre-existing in test/bench code that CI's non-`--all-targets` command does not lint). CI runs the full command.

Rebased over #923 (reference-cycle refusal on overwrite), which touched the same v2 arm: the tree-terminal check now sits after #923's seeded `follow_reference_as_stored_for_write` walk, and the v2 / dispatcher / `v4.rs` docs describe both refusals.

`docs/audit-non-issues.md` was checked first; nothing there covers references to trees. The batch side already had `test_batch_ref_to_existing_tree_errors`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
