### PR TITLE
fix(merk): bound chunk id recovery by the tree's depth (#883)

### DIFF
--- a/grovedb/src/replication.rs
+++ b/grovedb/src/replication.rs
@@ -1,3 +1,25 @@
+//! State synchronization: serving and restoring a grove chunk by chunk.
+//!
+//! # Request limits on the serving side
+//!
+//! [`GroveDb::fetch_chunk`] answers requests from peers that are not
+//! trusted, so the shape of a request bounds the work it can cause:
+//!
+//! - at most [`CONST_GROUP_PACKING_SIZE`] global chunk ids per request and
+//!   at most that many local chunk ids per global id; exactly one page
+//!   cursor per append-only subtree;
+//! - every Merk local chunk id is a traversal instruction of `0x00` /
+//!   `0x01` bytes no longer than the addressed subtree is deep (`height -
+//!   1` bytes). The bound is enforced by the Merk chunk producer itself
+//!   ([`ChunkProducer`]), so callers that reach the producer without going
+//!   through the packed transport get the same protection. An over-depth
+//!   id is refused before any recovery or tree work, which keeps the cost
+//!   of a request proportional to the local tree rather than to the
+//!   request (issue #883).
+//!
+//! Every limit is one an honest target never exceeds: the target only asks
+//! for ids the source itself handed it in earlier chunks.
+
 pub(crate) mod indexed_sync;
 pub(crate) mod non_merk_sync;
 mod state_sync_session;
@@ -320,6 +342,10 @@ impl GroveDb {
     ///   at most that many local chunk ids per global id, and exactly one
     ///   page cursor per append-only subtree. Larger requests are refused
     ///   before anything is served, since every id costs a buffered chunk.
+    /// - Each Merk local chunk id is bounded by the addressed subtree's
+    ///   depth (see the module docs); an id longer than the subtree is deep
+    ///   is refused by the chunk producer with a `BadTraversalInstruction`
+    ///   error, surfaced here as `Error::CorruptedData`.
     /// - Non-Merk append-only subtrees (`CommitmentTree`, `MmrTree`,
     ///   `BulkAppendTree`, `DenseAppendOnlyFixedSizeTree`,
     ///   `PrivateDocumentStore`) are served as cursor-based entry pages

--- a/grovedb/src/tests/replication_session_tests.rs
+++ b/grovedb/src/tests/replication_session_tests.rs
@@ -4300,6 +4300,89 @@ mod tests {
         );
     }
 
+    /// Issue #883: a local chunk id is a Merk traversal instruction, and a
+    /// subtree of height `h` has no node deeper than `h - 1` steps. The
+    /// producer used to backtrack an over-depth id one recursion level per
+    /// byte before failing, so a peer could make the source do work (and
+    /// consume stack) proportional to its request rather than to the tree.
+    /// Through the public `fetch_chunk` path such an id is now refused with
+    /// a descriptive error, while the honest root id keeps being served.
+    #[test]
+    fn fetch_chunk_rejects_chunk_id_longer_than_subtree_depth() {
+        let handle = std::thread::Builder::new()
+            .stack_size(1024 * 1024)
+            .spawn(|| {
+                use grovedb_storage::rocksdb_storage::RocksDbStorage;
+
+                use crate::replication::utils::{encode_global_chunk_id, pack_nested_bytes};
+
+                let grove_version = GroveVersion::latest();
+                let source = make_test_grovedb(grove_version);
+                for i in 0..15u8 {
+                    source
+                        .insert(
+                            [TEST_LEAF].as_ref(),
+                            &[i],
+                            Element::new_item(vec![i]),
+                            None,
+                            None,
+                            grove_version,
+                        )
+                        .unwrap()
+                        .expect("insert item");
+                }
+                let tx = source.start_transaction();
+                let (merk, root_key, tree_type, _element) = source
+                    .open_merk_for_replication([TEST_LEAF].as_ref().into(), &tx, grove_version)
+                    .expect("open test leaf for replication");
+                let height = merk.height().expect("non-empty subtree") as usize;
+                drop(merk);
+                drop(tx);
+                let leaf_path: &[&[u8]] = &[TEST_LEAF];
+                let leaf_prefix = RocksDbStorage::build_prefix(leaf_path.into()).unwrap();
+
+                let fetch = |local_id: Vec<u8>| {
+                    let global = encode_global_chunk_id(
+                        leaf_prefix,
+                        root_key.clone(),
+                        tree_type,
+                        vec![local_id],
+                    )
+                    .expect("encode global chunk id");
+                    source.fetch_chunk(
+                        pack_nested_bytes(vec![global]).expect("pack").as_slice(),
+                        None,
+                        CURRENT_STATE_SYNC_VERSION,
+                        grove_version,
+                    )
+                };
+                let assert_refused = |err: crate::Error, what: &str| {
+                    let message = format!("{err}");
+                    assert!(
+                        message.contains("traversal instruction"),
+                        "{what}: expected a traversal-instruction error, got {message}"
+                    );
+                };
+
+                fetch(vec![]).expect("the root chunk id must be served");
+                // the deepest node the subtree has is still a valid request
+                fetch(vec![1u8; height - 1]).expect("an id at the depth bound must be served");
+                assert_refused(
+                    fetch(vec![1u8; height]).expect_err("an id past the leaves must be refused"),
+                    "one past the depth bound",
+                );
+                assert_refused(
+                    fetch(vec![0u8; 1_000_000])
+                        .expect_err("a request-length-driven id must be refused"),
+                    "a million-step id",
+                );
+            })
+            .expect("spawn thread");
+        handle
+            .join()
+            .expect("an over-depth chunk id must not overflow the stack");
+    }
+
     /// A header page must carry exactly a header and a root chunk; any
     /// other section count is refused before the header is even decoded.
     #[test]

--- a/merk/src/merk/chunks.rs
+++ b/merk/src/merk/chunks.rs
@@ -15,7 +15,8 @@ use crate::{
                 chunk_height, chunk_index_from_traversal_instruction,
                 chunk_index_from_traversal_instruction_with_recovery,
                 generate_traversal_instruction, generate_traversal_instruction_as_vec_bytes,
-                number_of_chunks, vec_bytes_as_traversal_instruction,
+                max_traversal_instruction_len, number_of_chunks,
+                vec_bytes_as_traversal_instruction,
             },
         },
         Node, Op,
@@ -77,6 +78,22 @@ impl MultiChunk {
 /// A `ChunkProducer` allows the creation of chunk proofs, used for trustlessly
 /// replicating entire Merk trees. Chunks can be generated on the fly in a
 /// random order, or iterated in order for slightly better performance.
+///
+/// # Request limits
+///
+/// A chunk id (`chunk_id: &[u8]`) is a traversal instruction: one `0x00`
+/// (right) or `0x01` (left) byte per step down from the root. The producer
+/// bounds every id it is asked to serve by the local tree's own geometry:
+///
+/// - each byte must be `0x00` or `0x01`;
+/// - the id may not be longer than `height - 1` bytes, the depth of the
+///   deepest leaf (see [`max_traversal_instruction_len`]).
+///
+/// An id that does not meet these conditions is refused with
+/// [`ChunkError::BadTraversalInstruction`] before any tree work, so the
+/// cost of a request is proportional to the tree, never to the request.
+/// This bound is enforced here, on the producer itself, so that every
+/// caller gets it regardless of the transport that delivered the id.
 pub struct ChunkProducer<'db, S> {
     /// Represents the max height of the Merk tree
     height: usize,
@@ -115,13 +132,30 @@ where
         self.chunk_internal(chunk_index, traversal_instructions, grove_version)
     }
 
+    /// Parses a chunk id into a traversal instruction, enforcing the
+    /// producer's request limits (see the type-level docs) first.
+    fn traversal_instruction_from_chunk_id(&self, chunk_id: &[u8]) -> Result<Vec<bool>, Error> {
+        if chunk_id.len() > max_traversal_instruction_len(self.height) {
+            return Err(ChunkingError(ChunkError::BadTraversalInstruction(
+                "chunk id is longer than the tree is deep",
+            )));
+        }
+        vec_bytes_as_traversal_instruction(chunk_id)
+    }
+
     /// Returns the chunk at a given chunk id.
+    ///
+    /// An id that does not point exactly at a chunk boundary is recovered
+    /// to the nearest boundary above it. An id longer than the tree is deep
+    /// (or with bytes other than `0x00`/`0x01`) is refused with
+    /// [`ChunkError::BadTraversalInstruction`] before any work is done; see
+    /// the request limits on [`ChunkProducer`].
     pub fn chunk(
         &mut self,
         chunk_id: &[u8],
         grove_version: &GroveVersion,
     ) -> Result<(Vec<Op>, Option<Vec<u8>>), Error> {
-        let traversal_instructions = vec_bytes_as_traversal_instruction(chunk_id)?;
+        let traversal_instructions = self.traversal_instruction_from_chunk_id(chunk_id)?;
         let chunk_index = chunk_index_from_traversal_instruction_with_recovery(
             traversal_instructions.as_slice(),
             self.height,
@@ -185,6 +219,9 @@ where
     /// Generate multichunk with chunk id
     /// Multichunks accumulate as many chunks as they can until they have all
     /// chunks or hit some optional limit
+    ///
+    /// The id must point exactly at a chunk boundary and is subject to the
+    /// request limits on [`ChunkProducer`].
     pub fn multi_chunk_with_limit(
         &mut self,
         chunk_id: &[u8],
@@ -192,9 +229,11 @@ where
         grove_version: &GroveVersion,
     ) -> Result<MultiChunk, Error> {
         // we want to convert the chunk id to the index
-        let chunk_index = vec_bytes_as_traversal_instruction(chunk_id).and_then(|instruction| {
-            chunk_index_from_traversal_instruction(instruction.as_slice(), self.height)
-        })?;
+        let chunk_index = self
+            .traversal_instruction_from_chunk_id(chunk_id)
+            .and_then(|instruction| {
+                chunk_index_from_traversal_instruction(instruction.as_slice(), self.height)
+            })?;
         self.multi_chunk_with_limit_and_index(chunk_index, limit, grove_version)
     }
 
@@ -1146,5 +1185,100 @@ mod test {
         assert_eq!(chunk_result.chunk.len(), 4);
         assert_eq!(chunk_result.chunk[0], ChunkOp::ChunkId(vec![LEFT, LEFT]));
         assert_eq!(chunk_result.chunk[2], ChunkOp::ChunkId(vec![LEFT, RIGHT]));
+    }
+
+    /// Builds a height-4 Merk (15 sequential keys) for the request-bound
+    /// tests below.
+    fn height_four_merk(grove_version: &GroveVersion) -> TempMerk {
+        let mut merk = TempMerk::new(grove_version);
+        let batch = make_batch_seq(0..15);
+        merk.apply::<_, Vec<_>>(&batch, &[], None, grove_version)
+            .unwrap()
+            .expect("apply failed");
+        assert_eq!(merk.height(), Some(4));
+        merk
+    }
+
+    /// Issue #883: a chunk id is a traversal instruction, and a tree of
+    /// height `h` has no node deeper than `h - 1` steps. The producer used
+    /// to backtrack such an id one recursion level per byte before failing,
+    /// so a peer could make it do work (and consume stack) proportional to
+    /// the request rather than the tree. Over-depth ids are now refused up
+    /// front with a structured error, on both producer entry points.
+    #[test]
+    fn test_chunk_rejects_chunk_id_longer_than_tree_depth() {
+        let handle = std::thread::Builder::new()
+            .stack_size(256 * 1024)
+            .spawn(|| {
+                let grove_version = GroveVersion::latest();
+                let merk = height_four_merk(grove_version);
+                let mut chunk_producer =
+                    ChunkProducer::new(&merk).expect("should create chunk producer");
+
+                let huge_id = vec![0u8; 1_000_000];
+                assert!(matches!(
+                    chunk_producer.chunk(&huge_id, grove_version),
+                    Err(Error::ChunkingError(ChunkError::BadTraversalInstruction(_)))
+                ));
+                assert!(matches!(
+                    chunk_producer.multi_chunk_with_limit(&huge_id, None, grove_version),
+                    Err(Error::ChunkingError(ChunkError::BadTraversalInstruction(_)))
+                ));
+
+                // one step past the deepest leaf is already too long
+                let one_too_long = vec![1u8; 4];
+                assert!(matches!(
+                    chunk_producer.chunk(&one_too_long, grove_version),
+                    Err(Error::ChunkingError(ChunkError::BadTraversalInstruction(_)))
+                ));
+                assert!(matches!(
+                    chunk_producer.multi_chunk_with_limit(&one_too_long, None, grove_version),
+                    Err(Error::ChunkingError(ChunkError::BadTraversalInstruction(_)))
+                ));
+            })
+            .expect("spawn thread");
+        handle
+            .join()
+            .expect("an over-depth chunk id must not overflow the stack");
+    }
+
+    /// Ordinary recovery is preserved: an id that addresses a real node
+    /// which is not a chunk boundary still resolves to the nearest boundary
+    /// chunk index, and the empty id is the root chunk.
+    #[test]
+    fn test_chunk_recovery_for_valid_non_boundary_chunk_ids() {
+        let grove_version = GroveVersion::latest();
+        let merk = height_four_merk(grove_version);
+        let mut chunk_producer = ChunkProducer::new(&merk).expect("should create chunk producer");
+
+        // empty id == root chunk == chunk index 1
+        let (by_index, next_by_index) = chunk_producer
+            .chunk_with_index(1, grove_version)
+            .expect("root chunk by index");
+        let (by_id, next_by_id) = chunk_producer
+            .chunk(&[], grove_version)
+            .expect("root chunk by empty id");
+        assert_eq!(by_id, by_index);
+        assert_eq!(
+            next_by_id,
+            next_by_index.map(|index| {
+                generate_traversal_instruction_as_vec_bytes(4, index).expect("valid index")
+            })
+        );
+
+        // layers are [2, 2]: boundaries at lengths 0 and 2. A length-1 id
+        // backtracks to the root chunk, a length-3 id (the deepest leaf,
+        // exactly the depth bound) backtracks to the length-2 boundary.
+        let (_, next) = chunk_producer
+            .chunk(&[1u8], grove_version)
+            .expect("length-1 id recovers to chunk 1");
+        assert_eq!(next, next_by_index.map(|_| vec![1u8, 1u8]));
+        let (_, next_from_boundary) = chunk_producer
+            .chunk(&[1u8, 1u8], grove_version)
+            .expect("boundary id");
+        let (_, next_from_leaf) = chunk_producer
+            .chunk(&[1u8, 1u8, 1u8], grove_version)
+            .expect("length-3 id recovers to chunk 2");
+        assert_eq!(next_from_leaf, next_from_boundary);
     }
 }

--- a/merk/src/proofs/chunk/util.rs
+++ b/merk/src/proofs/chunk/util.rs
@@ -201,6 +201,19 @@ pub fn generate_traversal_instruction(
     Ok(instructions)
 }
 
+/// The longest traversal instruction that addresses a node of a tree of the
+/// given height.
+///
+/// The root is reached by the empty instruction and the deepest leaves by
+/// `height - 1` steps, so no instruction longer than that can address any
+/// node, chunk boundary or not. Chunk producers use this as the request
+/// bound: a chunk id longer than this is refused before any recovery work,
+/// which keeps the work a request can cause proportional to the local tree
+/// rather than to the request (issue #883).
+pub fn max_traversal_instruction_len(height: usize) -> usize {
+    height.saturating_sub(1)
+}
+
 /// Determine the chunk index given the traversal instruction and the max height
 /// of the tree
 pub fn chunk_index_from_traversal_instruction(
@@ -210,6 +223,15 @@ pub fn chunk_index_from_traversal_instruction(
     // empty traversal instruction points to the first chunk
     if traversal_instruction.is_empty() {
         return Ok(1);
+    }
+
+    // a non-empty instruction can never address a node the tree does not
+    // have (see `max_traversal_instruction_len`); this also covers the
+    // empty tree, whose layer list is empty
+    if traversal_instruction.len() > max_traversal_instruction_len(height) {
+        return Err(Error::ChunkingError(BadTraversalInstruction(
+            "traversal instruction is longer than the tree is deep",
+        )));
     }
 
     let mut chunk_count = number_of_chunks(height);
@@ -226,7 +248,8 @@ pub fn chunk_index_from_traversal_instruction(
     //      height 2 is represented by [left] or [right] len of 1
     // therefore last chunk root node is address with total_height -
     // last_chunk_height
-    if traversal_instruction.len() > height - last_layer_height {
+    // (saturating: a one-node tree still gets a chunk layer of height 2)
+    if traversal_instruction.len() > height.saturating_sub(last_layer_height) {
         return Err(Error::ChunkingError(BadTraversalInstruction(
             "traversal instruction should not address nodes past the root of the last layer chunks",
         )));
@@ -288,18 +311,35 @@ pub fn chunk_index_from_traversal_instruction(
 /// of the tree. This can recover from traversal instructions not pointing to a
 /// chunk boundary, in such a case, it backtracks until it hits a chunk
 /// boundary.
+///
+/// Recovery only applies to instructions that address a node the tree
+/// actually has, i.e. of length at most [`max_traversal_instruction_len`];
+/// a longer instruction is refused up front. That keeps the work bounded by
+/// the tree's depth rather than by the length of the (possibly
+/// peer-supplied) instruction: the backtracking loop shortens the
+/// instruction at most `height - 1` times, and the empty instruction always
+/// resolves to the first chunk (issue #883).
 pub fn chunk_index_from_traversal_instruction_with_recovery(
     traversal_instruction: &[bool],
     height: usize,
 ) -> Result<usize, Error> {
-    let chunk_index_result = chunk_index_from_traversal_instruction(traversal_instruction, height);
-    if chunk_index_result.is_err() {
-        return chunk_index_from_traversal_instruction_with_recovery(
-            &traversal_instruction[0..traversal_instruction.len() - 1],
-            height,
-        );
+    if traversal_instruction.len() > max_traversal_instruction_len(height) {
+        return Err(Error::ChunkingError(BadTraversalInstruction(
+            "traversal instruction is longer than the tree is deep",
+        )));
     }
-    chunk_index_result
+
+    let mut candidate = traversal_instruction;
+    loop {
+        match chunk_index_from_traversal_instruction(candidate, height) {
+            Ok(chunk_index) => return Ok(chunk_index),
+            // nothing left to backtrack to; never reached in practice since
+            // the empty instruction is always the first chunk, but it must
+            // not underflow either way
+            Err(error) if candidate.is_empty() => return Err(error),
+            Err(_) => candidate = &candidate[..candidate.len() - 1],
+        }
+    }
 }
 
 /// Generate instruction for traversing to a given chunk index in a binary tree,
@@ -677,9 +717,92 @@ mod test {
                 .unwrap(),
             3
         );
+        // the deepest node of a height-5 tree is addressed by 4 steps;
+        // recovery from there still lands on the nearest boundary
         assert_eq!(
-            chunk_index_from_traversal_instruction_with_recovery(&[LEFT; 50], 5).unwrap(),
+            chunk_index_from_traversal_instruction_with_recovery(&[LEFT; 4], 5).unwrap(),
             2
         );
+        // anything longer walks past the leaves and is refused rather than
+        // backtracked (see `max_traversal_instruction_len`)
+        assert!(matches!(
+            chunk_index_from_traversal_instruction_with_recovery(&[LEFT; 5], 5),
+            Err(Error::ChunkingError(BadTraversalInstruction(_)))
+        ));
+        assert!(matches!(
+            chunk_index_from_traversal_instruction_with_recovery(&[LEFT; 50], 5),
+            Err(Error::ChunkingError(BadTraversalInstruction(_)))
+        ));
+    }
+
+    #[test]
+    fn test_max_traversal_instruction_len() {
+        assert_eq!(max_traversal_instruction_len(0), 0);
+        assert_eq!(max_traversal_instruction_len(1), 0);
+        assert_eq!(max_traversal_instruction_len(2), 1);
+        assert_eq!(max_traversal_instruction_len(5), 4);
+        // every chunk boundary of every height lies within the bound
+        for height in 1..=20 {
+            for chunk_index in 1..=number_of_chunks(height) {
+                let instruction = generate_traversal_instruction(height, chunk_index).unwrap();
+                assert!(instruction.len() <= max_traversal_instruction_len(height));
+                assert_eq!(
+                    chunk_index_from_traversal_instruction_with_recovery(&instruction, height)
+                        .unwrap(),
+                    chunk_index
+                );
+            }
+        }
+    }
+
+    /// Issue #883: recovery used to backtrack one recursion level per
+    /// instruction step, so a request carrying a million steps against a
+    /// tiny tree did a million levels of work (and blew the stack) before
+    /// failing. The work is now bounded by the tree's own depth.
+    #[test]
+    fn test_chunk_index_recovery_is_bounded_by_tree_depth() {
+        let handle = std::thread::Builder::new()
+            .stack_size(256 * 1024)
+            .spawn(|| {
+                let instruction = vec![LEFT; 1_000_000];
+                for height in 0..=10 {
+                    assert!(
+                        matches!(
+                            chunk_index_from_traversal_instruction_with_recovery(
+                                &instruction,
+                                height
+                            ),
+                            Err(Error::ChunkingError(BadTraversalInstruction(_)))
+                        ),
+                        "height {height}"
+                    );
+                }
+            })
+            .expect("spawn thread");
+        handle.join().expect("recovery must not overflow the stack");
+    }
+
+    /// The empty instruction is the root chunk at every height, and an
+    /// instruction that is too long for a one-node (or empty) tree is an
+    /// error rather than an arithmetic underflow.
+    #[test]
+    fn test_chunk_index_recovery_empty_and_tiny_trees() {
+        for height in 0..=10 {
+            assert_eq!(
+                chunk_index_from_traversal_instruction_with_recovery(&[], height).unwrap(),
+                1,
+                "height {height}"
+            );
+        }
+        for height in [0, 1] {
+            assert!(matches!(
+                chunk_index_from_traversal_instruction(&[LEFT], height),
+                Err(Error::ChunkingError(BadTraversalInstruction(_)))
+            ));
+            assert!(matches!(
+                chunk_index_from_traversal_instruction_with_recovery(&[LEFT], height),
+                Err(Error::ChunkingError(BadTraversalInstruction(_)))
+            ));
+        }
     }
 }


### PR DESCRIPTION
Fixes #883.

## Problem

A Merk chunk id is a traversal instruction, one `0x00`/`0x01` byte per step down from the root, and a tree of height `h` has no node deeper than `h - 1` steps. `chunk_index_from_traversal_instruction_with_recovery` handled a failed conversion by recursing on the id minus its last byte, with no length bound, so a state sync peer could make the source do work (and consume stack) proportional to its request rather than to the local tree. Reproduced on `develop`: a million-byte id against a height-4 Merk aborts the process with a stack overflow through `ChunkProducer::chunk`, and the same through `GroveDb::fetch_chunk`.

Two smaller hazards sat next to it: the recovery helper would underflow `len - 1` on an empty slice if the inner conversion ever failed, and `chunk_index_from_traversal_instruction` itself panicked on a height-0 tree (`pop().expect`) and underflowed `height - last_layer_height` on a height-1 tree when given a non-empty id.

## Fix

- `max_traversal_instruction_len(height)` (= `height - 1`, saturating) is the request bound. Both the plain converter and the recovery helper refuse a longer id with `ChunkError::BadTraversalInstruction` before any work.
- Recovery is now an iterative loop that shortens the id at most `height - 1` times. The empty id always resolves to the first chunk and cannot underflow.
- `ChunkProducer::chunk` and `multi_chunk_with_limit` apply the bound on the raw id bytes through one shared helper, so direct callers get the same protection as callers using the packed state sync transport. The limit is documented on `ChunkProducer` and in a new `replication` module doc comment, and `fetch_chunk`'s notes point at it.
- Ordinary recovery is unchanged: an id that addresses a real node off a chunk boundary still resolves to the nearest boundary above it.

## Tests

- merk: a million-byte id on a 256 KiB stack through `chunk` and `multi_chunk_with_limit`, plus the first over-depth length; the empty id at every height; height-0 and height-1 trees with a non-empty id; every chunk boundary of every height up to 20 lies within the bound and round-trips through recovery; the producer's non-boundary recovery and empty-id behaviour pinned against `chunk_with_index`.
- grovedb: the same through `fetch_chunk` with an encoded global chunk id, asserting the root id and the deepest valid id are still served and that the one-past-depth and million-byte ids are refused with a traversal-instruction error.
- One assertion in the existing `test_chunk_id_from_traversal_instruction_with_recovery` expected a 50-step id on a height-5 tree to be recovered to chunk 2; it now expects the rejection, and a 4-step id (the exact bound) covers the recovery it used to exercise.

## Versioning

No GroveVersion gate. State sync is not a consensus path, and the change only rejects identifiers that could never address a valid traversal in the local tree; every id an honest target sends was handed to it by the source in an earlier chunk.

## Verification

`cargo test -p grovedb-merk` (750 passed), `cargo test -p grovedb --features full,unsafe-dump-load` (3175 passed; the `unsafe-dump-load` feature is needed because an unrelated test file on `develop` calls `raw_storage`), `cargo fmt`, `cargo clippy --workspace --all-features -- -D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
