### PR TITLE
fix(batch): keep both segments of apply_partial_batch on one live Merk cache (#842)

### DIFF
--- a/grovedb/src/batch/batch_structure.rs
+++ b/grovedb/src/batch/batch_structure.rs
@@ -127,6 +127,7 @@ where
     ) -> CostResult<BatchStructure<C, F, SR>, Error> {
         Self::continue_from_ops(
             None,
+            None,
             ops,
             update_element_flags_function,
             split_remove_bytes_function,
@@ -136,8 +137,16 @@ where
     }
 
     /// Create batch structure from a list of ops. Returns CostResult.
+    ///
+    /// `previous_ops_by_qualified_paths` seeds the reference-resolution map
+    /// with an earlier segment's user ops, so a continuation's reference
+    /// ops resolve targets that segment wrote exactly as one combined batch
+    /// would (in-batch, from the op's own element) instead of reading a
+    /// possibly stale committed value. Ops in `ops` override seeded entries
+    /// at the same qualified path.
     pub(super) fn continue_from_ops(
         previous_ops: Option<OpsByLevelPath>,
+        previous_ops_by_qualified_paths: Option<BTreeMap<Vec<Vec<u8>>, GroveOp>>,
         ops: Vec<QualifiedGroveDbOp>,
         update_element_flags_function: F,
         split_remove_bytes_function: SR,
@@ -156,7 +165,8 @@ where
             ops_by_level_paths.iter().map(|(k, _)| k).max().unwrap_or(0);
 
         // qualified paths meaning path + key
-        let mut ops_by_qualified_paths: BTreeMap<Vec<Vec<u8>>, GroveOp> = BTreeMap::new();
+        let mut ops_by_qualified_paths: BTreeMap<Vec<Vec<u8>>, GroveOp> =
+            previous_ops_by_qualified_paths.unwrap_or_default();
 
         for (op_index, op) in ops.into_iter().enumerate() {
             let QualifiedGroveDbOp {

--- a/grovedb/src/batch/batch_structure.rs
+++ b/grovedb/src/batch/batch_structure.rs
@@ -143,7 +143,9 @@ where
     /// ops resolve targets that segment wrote exactly as one combined batch
     /// would (in-batch, from the op's own element) instead of reading a
     /// possibly stale committed value. Ops in `ops` override seeded entries
-    /// at the same qualified path.
+    /// at the same qualified path. The caller must exclude conditional
+    /// insertions that the earlier segment skipped, so their proposed
+    /// elements cannot shadow the values that actually remain stored.
     pub(super) fn continue_from_ops(
         previous_ops: Option<OpsByLevelPath>,
         previous_ops_by_qualified_paths: Option<BTreeMap<Vec<Vec<u8>>, GroveOp>>,

--- a/grovedb/src/batch/batch_structure.rs
+++ b/grovedb/src/batch/batch_structure.rs
@@ -234,6 +234,9 @@ where
                             merk_tree_cache.insert(&op_path, &key, tree_type)
                         );
                     }
+                    if element.is_indexed_tree() {
+                        merk_tree_cache.remember_indexed_element(&op_path, &key, element);
+                    }
                     Ok(())
                 }
                 GroveOp::RefreshReference { .. } | GroveOp::Delete | GroveOp::DeleteTree(..) => {

--- a/grovedb/src/batch/initial_segment_footprint.rs
+++ b/grovedb/src/batch/initial_segment_footprint.rs
@@ -1,0 +1,148 @@
+//! The cross-segment consistency gate of `apply_partial_batch` (issue #842).
+//!
+//! A partial batch applies in two segments — the caller's initial ops, then
+//! the ops its add-on closure returns — against one live Merk cache and one
+//! storage batch, with a single atomic commit at the end. The per-batch
+//! consistency check only sees one segment at a time, so the footprint
+//! recorded here is what lets the flow refuse add-on shapes that are
+//! individually consistent but incoherent across the segment boundary.
+
+use grovedb_merk::element::tree_type::ElementTreeTypeExtensions;
+
+use crate::{
+    batch::{GroveOp, QualifiedGroveDbOp},
+    Error,
+};
+
+/// What the initial segment of a partial batch wrote and deleted, for the
+/// cross-segment consistency gate (issue #842).
+///
+/// The per-batch consistency check only sees one segment at a time, so a
+/// continuation could otherwise write under a subtree the initial segment
+/// deleted, or replace / delete a subtree the initial segment wrote into.
+/// The continuation runs on the initial segment's live Merk cache, which
+/// makes writes into the same subtrees coherent — but neither of those two
+/// shapes has a coherent outcome: the first leaves rows under a deleted
+/// prefix, the second orphans the initial segment's rows behind a fresh
+/// root. Both are refused before the continuation applies.
+pub(super) struct InitialSegmentFootprint {
+    /// Qualified path (path ‖ key) of every element the segment deleted.
+    deleted: Vec<Vec<Vec<u8>>>,
+    /// Path of the Merk every op in the segment wrote into.
+    written_paths: Vec<Vec<Vec<u8>>>,
+    /// Qualified path of every non-Merk tree the segment appended into,
+    /// created, or replaced. Add-on typed appends are preprocessed against
+    /// COMMITTED state (see `preprocess_commitment_tree_ops` and friends),
+    /// so a target whose data namespace or element only exists pending in
+    /// the batch cannot be appended to coherently — and deleting or
+    /// replacing such a tree would strand the segment's pending data-row
+    /// writes behind a cleanup pass that cannot see them.
+    non_merk_tree_targets: Vec<Vec<Vec<u8>>>,
+}
+
+impl InitialSegmentFootprint {
+    pub(super) fn from_ops(ops: &[QualifiedGroveDbOp]) -> Self {
+        let mut deleted = Vec::new();
+        let mut written_paths = Vec::with_capacity(ops.len());
+        let mut non_merk_tree_targets = Vec::new();
+        for op in ops {
+            let path = op.path.to_path();
+            if matches!(op.op, GroveOp::Delete | GroveOp::DeleteTree(..))
+                && let Some(key) = op.key.as_ref()
+            {
+                let mut qualified = path.clone();
+                qualified.push(key.get_key_clone());
+                deleted.push(qualified);
+            }
+            // Typed appends were rewritten into ReplaceNonMerkTreeRoot by
+            // preprocessing before the footprint is taken; insert-family
+            // ops can create or replace a non-Merk tree element directly.
+            let non_merk_tree_target = match &op.op {
+                GroveOp::ReplaceNonMerkTreeRoot { .. } => true,
+                GroveOp::InsertOrReplace { element }
+                | GroveOp::InsertWithKnownToNotAlreadyExist { element }
+                | GroveOp::InsertIfNotExists { element, .. }
+                | GroveOp::Replace { element }
+                | GroveOp::Patch { element, .. } => element
+                    .tree_type()
+                    .is_some_and(|tree_type| tree_type.uses_non_merk_data_storage()),
+                _ => false,
+            };
+            if non_merk_tree_target && let Some(key) = op.key.as_ref() {
+                let mut qualified = path.clone();
+                qualified.push(key.get_key_clone());
+                non_merk_tree_targets.push(qualified);
+            }
+            written_paths.push(path);
+        }
+        Self {
+            deleted,
+            written_paths,
+            non_merk_tree_targets,
+        }
+    }
+
+    /// Refuse add-on ops that cannot be applied coherently after this
+    /// segment (see the type docs).
+    pub(super) fn verify_add_on_ops(&self, add_on_ops: &[QualifiedGroveDbOp]) -> Result<(), Error> {
+        for op in add_on_ops {
+            let path = op.path.to_path();
+            if self.deleted.iter().any(|deleted| path.starts_with(deleted)) {
+                return Err(Error::InvalidBatchOperation(
+                    "add-on operation writes under a path the initial segment deleted",
+                ));
+            }
+            // Add-on typed appends (keyless; the tree key is the path's
+            // last segment) are preprocessed against committed state, so a
+            // target this segment appended into, created, or replaced has
+            // no coherent committed root to append onto.
+            if matches!(
+                op.op,
+                GroveOp::CommitmentTreeInsert { .. }
+                    | GroveOp::MmrTreeAppend { .. }
+                    | GroveOp::BulkAppend { .. }
+                    | GroveOp::DenseTreeInsert { .. }
+                    | GroveOp::PrivateDocumentStoreInsert { .. }
+            ) && self.non_merk_tree_targets.contains(&path)
+            {
+                return Err(Error::InvalidBatchOperation(
+                    "add-on append targets a non-Merk tree the initial segment wrote",
+                ));
+            }
+            // Whether an op orphans what the initial segment wrote depends
+            // only on what was AT the target, never on what the new element
+            // is: overwriting a written-into subtree with a plain item
+            // strands the segment's pending child writes just as surely as
+            // overwriting it with a fresh tree.
+            let replaces_or_deletes_subtree = matches!(
+                op.op,
+                GroveOp::Delete
+                    | GroveOp::DeleteTree(..)
+                    | GroveOp::InsertOrReplace { .. }
+                    | GroveOp::InsertWithKnownToNotAlreadyExist { .. }
+                    | GroveOp::InsertIfNotExists { .. }
+                    | GroveOp::Replace { .. }
+                    | GroveOp::Patch { .. }
+            );
+            if replaces_or_deletes_subtree && let Some(key) = op.key.as_ref() {
+                let mut qualified = path;
+                qualified.push(key.get_key_clone());
+                if self
+                    .written_paths
+                    .iter()
+                    .any(|written| written.starts_with(&qualified))
+                {
+                    return Err(Error::InvalidBatchOperation(
+                        "add-on op replaces or deletes a subtree the initial segment wrote into",
+                    ));
+                }
+                if self.non_merk_tree_targets.contains(&qualified) {
+                    return Err(Error::InvalidBatchOperation(
+                        "add-on op replaces or deletes a non-Merk tree the initial segment wrote",
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/grovedb/src/batch/initial_segment_footprint.rs
+++ b/grovedb/src/batch/initial_segment_footprint.rs
@@ -7,6 +7,8 @@
 //! recorded here is what lets the flow refuse add-on shapes that are
 //! individually consistent but incoherent across the segment boundary.
 
+use std::collections::{BTreeMap, HashSet};
+
 use grovedb_merk::element::tree_type::ElementTreeTypeExtensions;
 
 use crate::{
@@ -28,7 +30,8 @@ use crate::{
 pub(super) struct InitialSegmentFootprint {
     /// Qualified path (path ‖ key) of every element the segment deleted.
     deleted: Vec<Vec<Vec<u8>>>,
-    /// Path of the Merk every op in the segment wrote into.
+    /// Paths written into, plus qualified targets of Merk trees the segment
+    /// creates or replaces, even when no child operation populated them.
     written_paths: Vec<Vec<Vec<u8>>>,
     /// Qualified path of every non-Merk tree the segment appended into,
     /// created, or replaced. Add-on typed appends are preprocessed against
@@ -41,37 +44,46 @@ pub(super) struct InitialSegmentFootprint {
 }
 
 impl InitialSegmentFootprint {
-    pub(super) fn from_ops(ops: &[QualifiedGroveDbOp]) -> Self {
+    /// Build the footprint after initial execution, retaining pending ops
+    /// above the pause height but excluding conditional insertions that
+    /// execution skipped. A skipped proposal created no pending tree state.
+    pub(super) fn from_ops(
+        ops: &BTreeMap<Vec<Vec<u8>>, GroveOp>,
+        skipped_insert_paths: &HashSet<Vec<Vec<u8>>>,
+    ) -> Self {
         let mut deleted = Vec::new();
         let mut written_paths = Vec::with_capacity(ops.len());
         let mut non_merk_tree_targets = Vec::new();
-        for op in ops {
-            let path = op.path.to_path();
-            if matches!(op.op, GroveOp::Delete | GroveOp::DeleteTree(..))
-                && let Some(key) = op.key.as_ref()
-            {
-                let mut qualified = path.clone();
-                qualified.push(key.get_key_clone());
-                deleted.push(qualified);
+        for (qualified, op) in ops {
+            if skipped_insert_paths.contains(qualified) {
+                continue;
+            }
+            let mut path = qualified.clone();
+            path.pop();
+            if matches!(op, GroveOp::Delete | GroveOp::DeleteTree(..)) {
+                deleted.push(qualified.clone());
             }
             // Typed appends were rewritten into ReplaceNonMerkTreeRoot by
-            // preprocessing before the footprint is taken; insert-family
-            // ops can create or replace a non-Merk tree element directly.
-            let non_merk_tree_target = match &op.op {
-                GroveOp::ReplaceNonMerkTreeRoot { .. } => true,
+            // preprocessing; insert-family ops can create or replace trees
+            // directly. Track the tree's own path as well as its parent:
+            // even an empty new tree exists only in pending state, which
+            // committed-state deletion checks and cleanup cannot observe.
+            let tree_type = match op {
                 GroveOp::InsertOrReplace { element }
                 | GroveOp::InsertWithKnownToNotAlreadyExist { element }
                 | GroveOp::InsertIfNotExists { element, .. }
                 | GroveOp::Replace { element }
-                | GroveOp::Patch { element, .. } => element
-                    .tree_type()
-                    .is_some_and(|tree_type| tree_type.uses_non_merk_data_storage()),
-                _ => false,
+                | GroveOp::Patch { element, .. } => element.tree_type(),
+                _ => None,
             };
-            if non_merk_tree_target && let Some(key) = op.key.as_ref() {
-                let mut qualified = path.clone();
-                qualified.push(key.get_key_clone());
-                non_merk_tree_targets.push(qualified);
+            if let Some(tree_type) = tree_type {
+                if tree_type.uses_non_merk_data_storage() {
+                    non_merk_tree_targets.push(qualified.clone());
+                } else {
+                    written_paths.push(qualified.clone());
+                }
+            } else if matches!(op, GroveOp::ReplaceNonMerkTreeRoot { .. }) {
+                non_merk_tree_targets.push(qualified.clone());
             }
             written_paths.push(path);
         }

--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -1624,6 +1624,13 @@ impl GroveDbOpConsistencyResults {
 /// Cache for Merk trees by their paths.
 struct TreeCacheMerkByPath<S, F, F2> {
     merks: HashMap<Vec<Vec<u8>>, Merk<S>>,
+    /// Empty Merks reserved while scanning tree insertions, with no path
+    /// operations applied yet. A skipped insertion must not carry its
+    /// unused placeholder into a continuation as if it were the stored tree.
+    unused_new_merks: HashSet<Vec<Vec<u8>>>,
+    /// Conditional insertions that emitted no Merk write. Their proposed
+    /// elements must not seed reference resolution in the next segment.
+    skipped_insert_paths: HashSet<Vec<Vec<u8>>>,
     /// Every axis secondary opened for an indexed primary, keyed by the
     /// primary's path, in the element's canonical axis order. A primary's
     /// secondaries are opened once and then reused for the life of the
@@ -2866,6 +2873,7 @@ where
                 cost_return_on_error!(&mut cost, (self.get_merk_fn)(&inserted_path, true));
             merk.tree_type = tree_type;
             e.insert(merk);
+            self.unused_new_merks.insert(inserted_path);
         }
 
         Ok(()).wrap_with_cost(cost)
@@ -2932,6 +2940,7 @@ where
         // todo: fix this
         let p = path.to_path();
         let path = &p;
+        self.unused_new_merks.remove(path);
 
         // This also populates Merk trees cache
         let in_tree_type = {
@@ -2977,6 +2986,21 @@ where
         let mut pending_overwrite_inspections: BTreeMap<Vec<u8>, Element> = BTreeMap::new();
         let mut pending_delete_tree_checks: BTreeMap<Vec<u8>, TreeType> = BTreeMap::new();
 
+        // Derive skipped insertions from the writes actually emitted below,
+        // covering every element variant without another existence read.
+        let mut skipped_insert_keys: HashSet<Vec<u8>> = ops_at_path_by_key
+            .iter()
+            .filter(|(_, op)| {
+                matches!(
+                    op,
+                    GroveOp::InsertIfNotExists {
+                        error_if_exists: false,
+                        ..
+                    }
+                )
+            })
+            .map(|(key, _)| key.get_key_clone())
+            .collect();
         let mut batch_operations: Vec<(Vec<u8>, Op)> = vec![];
         for (key_info, op) in ops_at_path_by_key.into_iter() {
             match op {
@@ -4409,6 +4433,16 @@ where
             }
         }
 
+        for (key, _) in &batch_operations {
+            skipped_insert_keys.remove(key);
+        }
+        self.skipped_insert_paths
+            .extend(skipped_insert_keys.into_iter().map(|key| {
+                let mut qualified_path = path.clone();
+                qualified_path.push(key);
+                qualified_path
+            }));
+
         let merk = self.merks.get_mut(path).expect("the Merk is cached");
 
         // V4 gate results collected by the old-value observer while the merk
@@ -5410,6 +5444,8 @@ impl GroveDb {
                 split_removed_bytes_function,
                 TreeCacheMerkByPath {
                     merks: Default::default(),
+                    unused_new_merks: Default::default(),
+                    skipped_insert_paths: Default::default(),
                     secondary_merks: Default::default(),
                     pending_indexed_elements: Default::default(),
                     get_merk_fn,
@@ -5442,7 +5478,7 @@ impl GroveDb {
     fn continue_partial_apply_body<'db, S, F, F2>(
         &self,
         previous_leftover_operations: Option<OpsByLevelPath>,
-        previous_ops_by_qualified_paths: BTreeMap<Vec<Vec<u8>>, GroveOp>,
+        mut previous_ops_by_qualified_paths: BTreeMap<Vec<Vec<u8>>, GroveOp>,
         additional_ops: Vec<QualifiedGroveDbOp>,
         batch_apply_options: Option<BatchApplyOptions>,
         update_element_flags_function: impl FnMut(
@@ -5458,7 +5494,7 @@ impl GroveDb {
             (StorageRemovedBytes, StorageRemovedBytes),
             Error,
         >,
-        merk_tree_cache: TreeCacheMerkByPath<S, F, F2>,
+        mut merk_tree_cache: TreeCacheMerkByPath<S, F, F2>,
         grove_version: &GroveVersion,
     ) -> CostResult<(Option<OpsByLevelPath>, BatchApplyCaptures), Error>
     where
@@ -5477,6 +5513,17 @@ impl GroveDb {
                 .apply_batch
                 .continue_partial_apply_body
         );
+        // The first segment's conditional insertions may have been skipped.
+        // Keep their actual stored values authoritative for references and
+        // discard only unused placeholders reserved for the attempted trees.
+        // Merks with applied operations still carry live pending state.
+        for path in merk_tree_cache.skipped_insert_paths.drain() {
+            previous_ops_by_qualified_paths.remove(&path);
+            merk_tree_cache.pending_indexed_elements.remove(&path);
+            if merk_tree_cache.unused_new_merks.remove(&path) {
+                merk_tree_cache.merks.remove(&path);
+            }
+        }
         let mut cost = OperationCost::default();
         let batch_structure = cost_return_on_error!(
             &mut cost,

--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -1618,6 +1618,23 @@ impl GroveDbOpConsistencyResults {
 /// Cache for Merk trees by their paths.
 struct TreeCacheMerkByPath<S, F, F2> {
     merks: HashMap<Vec<Vec<u8>>, Merk<S>>,
+    /// Every axis secondary opened for an indexed primary, keyed by the
+    /// primary's path, in the element's canonical axis order. A primary's
+    /// secondaries are opened once and then reused for the life of the
+    /// cache — a partial batch's continuation mirrors into the very Merks
+    /// the initial segment already moved rows in (their pending root keys
+    /// exist only in memory and in the initial segment's leftover
+    /// propagation op), never into a copy reopened from committed state.
+    secondary_merks: HashMap<Vec<Vec<u8>>, Vec<(grovedb_element::indexed::IndexAxis, Merk<S>)>>,
+    /// Indexed-tree elements this batch INSERTS, keyed by their qualified
+    /// path. An indexed primary created in-batch has no stored element for
+    /// the secondary opener to read, so its axes come from here. Populated
+    /// while the ops are scanned (`remember_indexed_element`), which is
+    /// what lets a partial batch's continuation populate an indexed tree
+    /// the initial segment created: the creating op is no longer among the
+    /// continuation's own ops, and the parent Merk's copy of the element is
+    /// only pending.
+    pending_indexed_elements: HashMap<Vec<Vec<u8>>, Element>,
     get_merk_fn: F,
     /// Opens EVERY configured axis secondary for an indexed primary, given
     /// the primary's path. Used when ops mutate an indexed primary so the
@@ -1661,6 +1678,82 @@ struct TreeCacheMerkByPath<S, F, F2> {
 impl<S, F, F2> fmt::Debug for TreeCacheMerkByPath<S, F, F2> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("TreeCacheMerkByPath").finish()
+    }
+}
+
+/// What the initial segment of a partial batch wrote and deleted, for the
+/// cross-segment consistency gate (issue #842).
+///
+/// The per-batch consistency check only sees one segment at a time, so a
+/// continuation could otherwise write under a subtree the initial segment
+/// deleted, or replace / delete a subtree the initial segment wrote into.
+/// The continuation runs on the initial segment's live Merk cache, which
+/// makes writes into the same subtrees coherent — but neither of those two
+/// shapes has a coherent outcome: the first leaves rows under a deleted
+/// prefix, the second orphans the initial segment's rows behind a fresh
+/// root. Both are refused before the continuation applies.
+struct InitialSegmentFootprint {
+    /// Qualified path (path ‖ key) of every element the segment deleted.
+    deleted: Vec<Vec<Vec<u8>>>,
+    /// Path of the Merk every op in the segment wrote into.
+    written_paths: Vec<Vec<Vec<u8>>>,
+}
+
+impl InitialSegmentFootprint {
+    fn from_ops(ops: &[QualifiedGroveDbOp]) -> Self {
+        let mut deleted = Vec::new();
+        let mut written_paths = Vec::with_capacity(ops.len());
+        for op in ops {
+            let path = op.path.to_path();
+            if matches!(op.op, GroveOp::Delete | GroveOp::DeleteTree(..))
+                && let Some(key) = op.key.as_ref()
+            {
+                let mut qualified = path.clone();
+                qualified.push(key.get_key_clone());
+                deleted.push(qualified);
+            }
+            written_paths.push(path);
+        }
+        Self {
+            deleted,
+            written_paths,
+        }
+    }
+
+    /// Refuse add-on ops that cannot be applied coherently after this
+    /// segment (see the type docs).
+    fn verify_add_on_ops(&self, add_on_ops: &[QualifiedGroveDbOp]) -> Result<(), Error> {
+        for op in add_on_ops {
+            let path = op.path.to_path();
+            if self.deleted.iter().any(|deleted| path.starts_with(deleted)) {
+                return Err(Error::InvalidBatchOperation(
+                    "add-on operation writes under a path the initial segment deleted",
+                ));
+            }
+            let replaces_or_deletes_subtree = match &op.op {
+                GroveOp::Delete | GroveOp::DeleteTree(..) => true,
+                GroveOp::InsertOrReplace { element }
+                | GroveOp::InsertWithKnownToNotAlreadyExist { element }
+                | GroveOp::InsertIfNotExists { element, .. }
+                | GroveOp::Replace { element }
+                | GroveOp::Patch { element, .. } => element.tree_type().is_some(),
+                _ => false,
+            };
+            if replaces_or_deletes_subtree && let Some(key) = op.key.as_ref() {
+                let mut qualified = path;
+                qualified.push(key.get_key_clone());
+                if self
+                    .written_paths
+                    .iter()
+                    .any(|written| written.starts_with(&qualified))
+                {
+                    return Err(Error::InvalidBatchOperation(
+                        "add-on op replaces or deletes a subtree the initial segment wrote into",
+                    ));
+                }
+            }
+        }
+        Ok(())
     }
 }
 
@@ -1846,6 +1939,17 @@ trait TreeCache<G, SR> {
     ) -> CostResult<(), Error>;
 
     fn get_batch_run_mode(&self) -> BatchRunMode;
+
+    /// Called for every indexed-tree element the batch inserts, before any
+    /// level executes. Caches that open secondaries keep the element so the
+    /// primary's axes are known even when no stored element exists yet.
+    fn remember_indexed_element(
+        &mut self,
+        _path: &KeyInfoPath,
+        _key: &KeyInfo,
+        _element: &Element,
+    ) {
+    }
 
     /// We will also be returning an op mode, this is to be used in propagation
     fn execute_ops_on_path(
@@ -2842,6 +2946,13 @@ where
         path: &[Vec<u8>],
     ) -> Option<Vec<(u8, CryptoHash, Option<Vec<u8>>)>> {
         self.indexed_secondary_after_apply.remove(path)
+    }
+
+    fn remember_indexed_element(&mut self, path: &KeyInfoPath, key: &KeyInfo, element: &Element) {
+        let mut qualified_path = path.to_path();
+        qualified_path.push(key.get_key_clone());
+        self.pending_indexed_elements
+            .insert(qualified_path, element.clone());
     }
 
     fn take_cidx_overwrite_cleanup_paths(&mut self) -> Vec<Vec<Vec<u8>>> {
@@ -4607,22 +4718,30 @@ where
             // the read-from-parent path. Overwrite-with-descendants is
             // rejected in preflight, so an in-batch insert op at this exact
             // path means the element is fresh.
-            let fresh_indexed_element = ops_by_qualified_paths.get(path).and_then(|op| match op {
-                GroveOp::InsertOrReplace { element }
-                | GroveOp::InsertWithKnownToNotAlreadyExist { element }
-                | GroveOp::InsertIfNotExists { element, .. }
-                | GroveOp::Replace { element }
-                | GroveOp::Patch { element, .. }
-                    if element.is_indexed_tree() =>
-                {
-                    Some(element)
-                }
-                _ => None,
-            });
-            let secondaries = cost_return_on_error!(
-                &mut cost,
-                (self.get_secondary_merks_fn)(path, fresh_indexed_element)
-            );
+            let fresh_indexed_element = ops_by_qualified_paths
+                .get(path)
+                .and_then(|op| match op {
+                    GroveOp::InsertOrReplace { element }
+                    | GroveOp::InsertWithKnownToNotAlreadyExist { element }
+                    | GroveOp::InsertIfNotExists { element, .. }
+                    | GroveOp::Replace { element }
+                    | GroveOp::Patch { element, .. }
+                        if element.is_indexed_tree() =>
+                    {
+                        Some(element)
+                    }
+                    _ => None,
+                })
+                // The creating op may belong to an earlier segment of a
+                // partial batch (see `pending_indexed_elements`).
+                .or_else(|| self.pending_indexed_elements.get(path));
+            let secondaries = match self.secondary_merks.entry(path.to_vec()) {
+                HashMapEntry::Occupied(o) => o.into_mut(),
+                HashMapEntry::Vacant(v) => v.insert(cost_return_on_error!(
+                    &mut cost,
+                    (self.get_secondary_merks_fn)(path, fresh_indexed_element)
+                )),
+            };
             let primary_merk = self.merks.get(path).expect("the Merk is cached");
             // One post-state read per captured key, shared by every axis: the
             // (count, sum) transitions are axis-independent, only the sort-key
@@ -4633,13 +4752,13 @@ where
                 indexed_tree::read_post_apply_transitions(primary_merk, &pre, grove_version)
             );
             let mut per_axis = Vec::with_capacity(secondaries.len());
-            for (axis, mut secondary_merk) in secondaries {
+            for (axis, secondary_merk) in secondaries.iter_mut() {
                 let (sec_hash, sec_root_key, rekey_churn_bytes) = cost_return_on_error!(
                     &mut cost,
                     indexed_tree::apply_indexed_secondary_mirror_post_apply(
                         &transitions,
-                        axis,
-                        &mut secondary_merk,
+                        *axis,
+                        secondary_merk,
                         grove_version,
                     )
                 );
@@ -4669,9 +4788,12 @@ impl GroveDb {
     /// are returned
     /// Runs the level-by-level batch propagation.
     ///
-    /// Returns `(leftover_ops, captures)`:
+    /// Returns `(leftover_ops, captures, merk_tree_cache)`:
     ///   - `leftover_ops` is `Some(...)` only if a `batch_pause_height`
     ///     was set and pruning paused before reaching the root.
+    ///   - `merk_tree_cache` is the cache the body ran against, handed back
+    ///     so a paused apply can be continued on the same live Merks (see
+    ///     `continue_partial_apply_body`).
     ///   - `captures` is the [`BatchApplyCaptures`] collected while the
     ///     body applied, for the caller's post-apply cleanup passes:
     ///     `cidx_overwrite_cleanup_paths` lists the cidx primary paths
@@ -4685,7 +4807,7 @@ impl GroveDb {
         batch_structure: BatchStructure<C, F, SR>,
         batch_apply_options: Option<BatchApplyOptions>,
         grove_version: &GroveVersion,
-    ) -> CostResult<(Option<OpsByLevelPath>, BatchApplyCaptures), Error>
+    ) -> CostResult<(Option<OpsByLevelPath>, BatchApplyCaptures, C), Error>
     where
         F: FnMut(&StorageCost, Option<ElementFlags>, &mut ElementFlags) -> Result<bool, Error>,
         SR: FnMut(
@@ -5272,7 +5394,8 @@ impl GroveDb {
                     indexed_mirror_rekey_churn_bytes: merk_tree_cache
                         .take_indexed_mirror_rekey_churn_bytes(),
                 };
-                return Ok((Some(ops_by_level_paths), captures)).wrap_with_cost(cost);
+                return Ok((Some(ops_by_level_paths), captures, merk_tree_cache))
+                    .wrap_with_cost(cost);
             }
             current_level = current_level.saturating_sub(1);
         }
@@ -5282,13 +5405,14 @@ impl GroveDb {
             indexed_mirror_rekey_churn_bytes: merk_tree_cache
                 .take_indexed_mirror_rekey_churn_bytes(),
         };
-        Ok((None, captures)).wrap_with_cost(cost)
+        Ok((None, captures, merk_tree_cache)).wrap_with_cost(cost)
     }
 
     /// Method to propagate updated subtree root hashes up to GroveDB root
     /// If the pause height is set in the batch apply options
-    /// Then return the list of leftover operations
-    fn apply_body<'db, S: StorageContext<'db>>(
+    /// Then return the list of leftover operations, together with the live
+    /// Merk cache the body ran against so the apply can be continued on it.
+    fn apply_body<'db, S, F, F2>(
         &self,
         ops: Vec<QualifiedGroveDbOp>,
         batch_apply_options: Option<BatchApplyOptions>,
@@ -5305,16 +5429,26 @@ impl GroveDb {
             (StorageRemovedBytes, StorageRemovedBytes),
             Error,
         >,
-        get_merk_fn: impl FnMut(&[Vec<u8>], bool) -> CostResult<Merk<S>, Error>,
-        get_secondary_merks_fn: impl FnMut(
+        get_merk_fn: F,
+        get_secondary_merks_fn: F2,
+        grove_version: &GroveVersion,
+    ) -> CostResult<
+        (
+            Option<OpsByLevelPath>,
+            BatchApplyCaptures,
+            TreeCacheMerkByPath<S, F, F2>,
+        ),
+        Error,
+    >
+    where
+        S: StorageContext<'db>,
+        F: FnMut(&[Vec<u8>], bool) -> CostResult<Merk<S>, Error>,
+        F2: FnMut(
             &[Vec<u8>],
             Option<&Element>,
-        ) -> CostResult<
-            Vec<(grovedb_element::indexed::IndexAxis, Merk<S>)>,
-            Error,
-        >,
-        grove_version: &GroveVersion,
-    ) -> CostResult<(Option<OpsByLevelPath>, BatchApplyCaptures), Error> {
+        )
+            -> CostResult<Vec<(grovedb_element::indexed::IndexAxis, Merk<S>)>, Error>,
+    {
         check_grovedb_v0_with_cost!(
             "apply_body",
             grove_version.grovedb_versions.apply_batch.apply_body
@@ -5328,6 +5462,8 @@ impl GroveDb {
                 split_removed_bytes_function,
                 TreeCacheMerkByPath {
                     merks: Default::default(),
+                    secondary_merks: Default::default(),
+                    pending_indexed_elements: Default::default(),
                     get_merk_fn,
                     get_secondary_merks_fn,
                     indexed_secondary_after_apply: Default::default(),
@@ -5342,10 +5478,17 @@ impl GroveDb {
             .add_cost(cost)
     }
 
-    /// Method to propagate updated subtree root hashes up to GroveDB root
-    /// If the pause height is set in the batch apply options
-    /// Then return the list of leftover operations
-    fn continue_partial_apply_body<'db, S: StorageContext<'db>>(
+    /// Continue a paused `apply_body` on the SAME live Merk cache it ran
+    /// against, folding `additional_ops` into its leftover operations.
+    ///
+    /// The cache is what keeps the two segments of a partial batch
+    /// coherent (issue #842): every primary and secondary Merk the initial
+    /// segment touched is still open here with its pending in-memory state
+    /// — including root keys that exist nowhere in storage yet because the
+    /// op carrying them is still a leftover — so the continuation applies
+    /// on top of that state instead of reopening stale copies from
+    /// committed storage and rewriting nodes the initial segment deleted.
+    fn continue_partial_apply_body<'db, S, F, F2>(
         &self,
         previous_leftover_operations: Option<OpsByLevelPath>,
         additional_ops: Vec<QualifiedGroveDbOp>,
@@ -5363,16 +5506,18 @@ impl GroveDb {
             (StorageRemovedBytes, StorageRemovedBytes),
             Error,
         >,
-        get_merk_fn: impl FnMut(&[Vec<u8>], bool) -> CostResult<Merk<S>, Error>,
-        get_secondary_merks_fn: impl FnMut(
+        merk_tree_cache: TreeCacheMerkByPath<S, F, F2>,
+        grove_version: &GroveVersion,
+    ) -> CostResult<(Option<OpsByLevelPath>, BatchApplyCaptures), Error>
+    where
+        S: StorageContext<'db>,
+        F: FnMut(&[Vec<u8>], bool) -> CostResult<Merk<S>, Error>,
+        F2: FnMut(
             &[Vec<u8>],
             Option<&Element>,
-        ) -> CostResult<
-            Vec<(grovedb_element::indexed::IndexAxis, Merk<S>)>,
-            Error,
-        >,
-        grove_version: &GroveVersion,
-    ) -> CostResult<(Option<OpsByLevelPath>, BatchApplyCaptures), Error> {
+        )
+            -> CostResult<Vec<(grovedb_element::indexed::IndexAxis, Merk<S>)>, Error>,
+    {
         check_grovedb_v0_with_cost!(
             "continue_partial_apply_body",
             grove_version
@@ -5388,20 +5533,17 @@ impl GroveDb {
                 additional_ops,
                 update_element_flags_function,
                 split_removed_bytes_function,
-                TreeCacheMerkByPath {
-                    merks: Default::default(),
-                    get_merk_fn,
-                    get_secondary_merks_fn,
-                    indexed_secondary_after_apply: Default::default(),
-                    cidx_overwrite_cleanup_paths: Default::default(),
-                    deleted_tree_actual_types: Default::default(),
-                    indexed_mirror_rekey_churn_bytes: 0,
-                },
+                merk_tree_cache,
                 grove_version
             )
         );
-        Self::apply_batch_structure(batch_structure, batch_apply_options, grove_version)
-            .add_cost(cost)
+        // The cache is dropped here: its Merks borrow the storage batch,
+        // which the caller drains and consumes next.
+        let (leftover, captures, _merk_tree_cache) = cost_return_on_error!(
+            &mut cost,
+            Self::apply_batch_structure(batch_structure, batch_apply_options, grove_version)
+        );
+        Ok((leftover, captures)).wrap_with_cost(cost)
     }
 
     /// Applies operations on GroveDB one at a time, without batching.
@@ -6617,7 +6759,7 @@ impl GroveDb {
         // 5. Remove operation from the tree, repeat until there are operations to do;
         // 6. Add root leaves save operation to the batch
         // 7. Apply storage_cost batch
-        let (_leftover, batch_apply_captures) = cost_return_on_error!(
+        let (_leftover, batch_apply_captures, _) = cost_return_on_error!(
             &mut cost,
             self.apply_body(
                 ops,
@@ -7065,6 +7207,21 @@ impl GroveDb {
             batch_apply_options.batch_pause_height = Some(1);
         }
 
+        let initial_segment_footprint =
+            check_batch_operation_consistency.then(|| InitialSegmentFootprint::from_ops(&ops));
+
+        // Both segments run against ONE storage batch and ONE live Merk
+        // cache (issue #842). The initial segment's writes are only pending
+        // in the batch, so a continuation that reopened Merks from the
+        // transaction would apply on top of stale trees — re-writing nodes
+        // the initial segment deleted (an indexed secondary's old
+        // `(count ‖ key)` row came back that way) and opening pause-level
+        // Merks at root keys that are still only in the leftover ops. The
+        // cache carries every touched Merk, primaries and secondaries, with
+        // its pending state into the continuation. Nothing reaches the
+        // transaction before the single commit below, so a failing
+        // continuation still leaves it untouched.
+        //
         // With the only one difference (if there is a transaction) do the following:
         // 2. If nothing left to do and we were on a non-leaf subtree or we're done with
         //    one subtree and moved to another then add propagation operation to the
@@ -7075,7 +7232,7 @@ impl GroveDb {
         // 5. Remove operation from the tree, repeat until there are operations to do;
         // 6. Add root leaves save operation to the batch
         // 7. Apply storage_cost batch
-        let (left_over_operations, partial_captures) = cost_return_on_error!(
+        let (left_over_operations, partial_captures, merk_tree_cache) = cost_return_on_error!(
             &mut cost,
             self.apply_body(
                 ops,
@@ -7109,11 +7266,13 @@ impl GroveDb {
         // if we paused at the root height, the left over operations would be to replace
         // a lot of leaf nodes in the root tree
 
-        // let's build the write batch
+        // Drain the initial segment's pending writes into the write batch
+        // so their cost can be reported to the caller. The batch object
+        // stays alive (and empty): the cached Merks keep writing into it.
         let (mut write_batch, mut pending_costs) = cost_return_on_error!(
             &mut cost,
             self.db
-                .build_write_batch(storage_batch)
+                .build_write_batch(storage_batch.take_pending())
                 .map_err(|e| e.into())
         );
 
@@ -7154,6 +7313,24 @@ impl GroveDb {
                 .wrap_with_cost(cost);
             }
         }
+        // Cross-segment gate: the two shapes the live cache cannot make
+        // coherent (see `InitialSegmentFootprint`).
+        if let Some(footprint) = initial_segment_footprint.as_ref() {
+            cost_return_on_error_no_add!(cost, footprint.verify_add_on_ops(&new_operations));
+        }
+        // Add-on ops get the same indexed-overwrite preflight as the initial
+        // batch. It reads committed state, so it covers committed
+        // descendants; descendants the initial segment wrote are covered by
+        // the cross-segment gate above.
+        cost_return_on_error!(
+            &mut cost,
+            indexed_tree::reject_indexed_overwrite_with_descendants(
+                self,
+                &new_operations,
+                tx.as_ref(),
+                grove_version,
+            )
+        );
 
         // The callback is caller-provided, so add-on ops get the same
         // backward-references gate the initial ops got — otherwise an op
@@ -7166,8 +7343,6 @@ impl GroveDb {
         // we are trying to finalize
         batch_apply_options.batch_pause_height = None;
 
-        let continue_storage_batch = StorageBatch::new();
-
         let (_leftover_unused, continue_captures) = cost_return_on_error!(
             &mut cost,
             self.continue_partial_apply_body(
@@ -7176,27 +7351,7 @@ impl GroveDb {
                 Some(batch_apply_options),
                 update_element_flags_function,
                 split_removal_bytes_function,
-                |path, new_merk| {
-                    self.open_batch_transactional_merk_at_path(
-                        &continue_storage_batch,
-                        path.into(),
-                        tx.as_ref(),
-                        new_merk,
-                        grove_version,
-                    )
-                },
-                |primary_path: &[Vec<u8>], fresh_element: Option<&Element>| {
-                    let primary_refs: Vec<&[u8]> =
-                        primary_path.iter().map(|v| v.as_slice()).collect();
-                    let cidx_path: SubtreePath<&[u8]> = primary_refs.as_slice().into();
-                    self.open_indexed_secondaries_for_batch(
-                        cidx_path,
-                        fresh_element,
-                        &continue_storage_batch,
-                        tx.as_ref(),
-                        grove_version,
-                    )
-                },
+                merk_tree_cache,
                 grove_version
             )
         );
@@ -7233,7 +7388,7 @@ impl GroveDb {
             cost,
             self.stage_flat_drop_records(
                 &flat_drop_records,
-                &continue_storage_batch,
+                &storage_batch,
                 tx.as_ref(),
                 &mut cost,
             )
@@ -7246,7 +7401,7 @@ impl GroveDb {
                 .db
                 .get_transactional_storage_context(
                     child_subtree_path,
-                    Some(&continue_storage_batch),
+                    Some(&storage_batch),
                     tx.as_ref(),
                 )
                 .unwrap_add_cost(&mut cost);
@@ -7281,11 +7436,7 @@ impl GroveDb {
                 let p: SubtreePath<_> = subtree_path.as_slice().into();
                 let mut storage = self
                     .db
-                    .get_transactional_storage_context(
-                        p,
-                        Some(&continue_storage_batch),
-                        tx.as_ref(),
-                    )
+                    .get_transactional_storage_context(p, Some(&storage_batch), tx.as_ref())
                     .unwrap_add_cost(&mut cost);
                 cost_return_on_error!(
                     &mut cost,
@@ -7321,7 +7472,7 @@ impl GroveDb {
                     .db
                     .get_transactional_storage_context_by_subtree_prefix(
                         secondary_prefix,
-                        Some(&continue_storage_batch),
+                        Some(&storage_batch),
                         tx.as_ref(),
                     )
                     .unwrap_add_cost(&mut cost);
@@ -7356,11 +7507,7 @@ impl GroveDb {
                 let p: SubtreePath<_> = subtree_path.as_slice().into();
                 let mut storage = self
                     .db
-                    .get_transactional_storage_context(
-                        p,
-                        Some(&continue_storage_batch),
-                        tx.as_ref(),
-                    )
+                    .get_transactional_storage_context(p, Some(&storage_batch), tx.as_ref())
                     .unwrap_add_cost(&mut cost);
                 cost_return_on_error!(
                     &mut cost,
@@ -7391,7 +7538,7 @@ impl GroveDb {
                     .db
                     .get_transactional_storage_context_by_subtree_prefix(
                         secondary_prefix,
-                        Some(&continue_storage_batch),
+                        Some(&storage_batch),
                         tx.as_ref(),
                     )
                     .unwrap_add_cost(&mut cost);
@@ -7412,7 +7559,7 @@ impl GroveDb {
         let continued_pending_costs = cost_return_on_error!(
             &mut cost,
             self.db
-                .continue_write_batch(&mut write_batch, continue_storage_batch)
+                .continue_write_batch(&mut write_batch, storage_batch)
                 .map_err(|e| e.into())
         );
 

--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -7063,10 +7063,12 @@ impl GroveDb {
         Ok(()).wrap_with_cost(cost)
     }
 
-    /// Applies a partial batch of operations on GroveDB
-    /// The batch is not committed
-    /// Clients should set the Batch Apply Options batch pause height
-    /// If it is not set we default to pausing at the root tree
+    /// Apply the initial segment, pass its pending cost to the add-on
+    /// callback, then apply the continuation before one atomic commit.
+    ///
+    /// The initial segment pauses at `batch_pause_height` (default: 1).
+    /// Cross-segment safety checks are always enforced, even when
+    /// `disable_operation_consistency_check` skips per-segment validation.
     pub fn apply_partial_batch_with_element_flags_update(
         &self,
         ops: Vec<QualifiedGroveDbOp>,
@@ -7227,9 +7229,6 @@ impl GroveDb {
             batch_apply_options.batch_pause_height = Some(1);
         }
 
-        let initial_segment_footprint =
-            check_batch_operation_consistency.then(|| InitialSegmentFootprint::from_ops(&ops));
-
         // Both segments run against ONE storage batch and ONE live Merk
         // cache (issue #842). The initial segment's writes are only pending
         // in the batch, so a continuation that reopened Merks from the
@@ -7327,11 +7326,18 @@ impl GroveDb {
                 .wrap_with_cost(cost);
             }
         }
-        // Cross-segment gate: the shapes the live cache cannot make
-        // coherent (see `InitialSegmentFootprint`).
-        if let Some(footprint) = initial_segment_footprint.as_ref() {
-            cost_return_on_error_no_add!(cost, footprint.verify_add_on_ops(&new_operations));
-        }
+        // Cross-segment safety is mandatory even when callers disable
+        // per-segment consistency checks: the live cache cannot make these
+        // operation combinations coherent. Build from the initial op map
+        // after execution so skipped conditional insertions add no footprint.
+        let initial_segment_footprint = InitialSegmentFootprint::from_ops(
+            &initial_ops_by_qualified_paths,
+            &merk_tree_cache.skipped_insert_paths,
+        );
+        cost_return_on_error_no_add!(
+            cost,
+            initial_segment_footprint.verify_add_on_ops(&new_operations)
+        );
         // A continuation write under an indexed primary the initial segment
         // safe-subset-OVERWROTE would land in the very storage prefixes the
         // post-apply sweep below clears (the old element's primary subtree
@@ -7438,9 +7444,7 @@ impl GroveDb {
         // path / behavior collection the post-apply passes below run on.
         // The scan reads committed state, which is coherent here because
         // the cross-segment gate refused deletes of anything the initial
-        // segment wrote into; a target the initial segment CREATED has no
-        // committed element yet, so an Error / Skip emptiness check on it
-        // fails closed before the continuation applies anything.
+        // segment wrote into, created, or replaced, including empty trees.
         let DeleteTreePreScan {
             non_merk_delete_paths: add_on_non_merk_delete_paths,
             merk_delete_paths: add_on_merk_delete_paths,

--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -3,6 +3,11 @@
 mod backward_references;
 mod batch_structure;
 
+/// The cross-segment consistency gate of `apply_partial_batch`: what the
+/// initial segment wrote and deleted, so add-on ops that cannot be applied
+/// coherently after it are refused (issue #842).
+mod initial_segment_footprint;
+
 /// Indexed-tree helpers for the batch apply pipeline (pre-apply
 /// aggregate capture + post-apply secondary mirror) — covers
 /// `ProvableCountIndexedTree`, `ProvableSumIndexedTree`, and
@@ -82,6 +87,7 @@ use grovedb_storage::{
 };
 use grovedb_version::{check_grovedb_v0_with_cost, version::GroveVersion};
 use grovedb_visualize::{Drawer, Visualize};
+use initial_segment_footprint::InitialSegmentFootprint;
 use integer_encoding::VarInt;
 use itertools::Itertools;
 use key_info::{KeyInfo, KeyInfo::KnownKey};
@@ -1678,139 +1684,6 @@ struct TreeCacheMerkByPath<S, F, F2> {
 impl<S, F, F2> fmt::Debug for TreeCacheMerkByPath<S, F, F2> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("TreeCacheMerkByPath").finish()
-    }
-}
-
-/// What the initial segment of a partial batch wrote and deleted, for the
-/// cross-segment consistency gate (issue #842).
-///
-/// The per-batch consistency check only sees one segment at a time, so a
-/// continuation could otherwise write under a subtree the initial segment
-/// deleted, or replace / delete a subtree the initial segment wrote into.
-/// The continuation runs on the initial segment's live Merk cache, which
-/// makes writes into the same subtrees coherent — but neither of those two
-/// shapes has a coherent outcome: the first leaves rows under a deleted
-/// prefix, the second orphans the initial segment's rows behind a fresh
-/// root. Both are refused before the continuation applies.
-struct InitialSegmentFootprint {
-    /// Qualified path (path ‖ key) of every element the segment deleted.
-    deleted: Vec<Vec<Vec<u8>>>,
-    /// Path of the Merk every op in the segment wrote into.
-    written_paths: Vec<Vec<Vec<u8>>>,
-    /// Qualified path of every non-Merk tree the segment appended into,
-    /// created, or replaced. Add-on typed appends are preprocessed against
-    /// COMMITTED state (see `preprocess_commitment_tree_ops` and friends),
-    /// so a target whose data namespace or element only exists pending in
-    /// the batch cannot be appended to coherently — and deleting or
-    /// replacing such a tree would strand the segment's pending data-row
-    /// writes behind a cleanup pass that cannot see them.
-    non_merk_tree_targets: Vec<Vec<Vec<u8>>>,
-}
-
-impl InitialSegmentFootprint {
-    fn from_ops(ops: &[QualifiedGroveDbOp]) -> Self {
-        let mut deleted = Vec::new();
-        let mut written_paths = Vec::with_capacity(ops.len());
-        let mut non_merk_tree_targets = Vec::new();
-        for op in ops {
-            let path = op.path.to_path();
-            if matches!(op.op, GroveOp::Delete | GroveOp::DeleteTree(..))
-                && let Some(key) = op.key.as_ref()
-            {
-                let mut qualified = path.clone();
-                qualified.push(key.get_key_clone());
-                deleted.push(qualified);
-            }
-            // Typed appends were rewritten into ReplaceNonMerkTreeRoot by
-            // preprocessing before the footprint is taken; insert-family
-            // ops can create or replace a non-Merk tree element directly.
-            let non_merk_tree_target = match &op.op {
-                GroveOp::ReplaceNonMerkTreeRoot { .. } => true,
-                GroveOp::InsertOrReplace { element }
-                | GroveOp::InsertWithKnownToNotAlreadyExist { element }
-                | GroveOp::InsertIfNotExists { element, .. }
-                | GroveOp::Replace { element }
-                | GroveOp::Patch { element, .. } => element
-                    .tree_type()
-                    .is_some_and(|tree_type| tree_type.uses_non_merk_data_storage()),
-                _ => false,
-            };
-            if non_merk_tree_target && let Some(key) = op.key.as_ref() {
-                let mut qualified = path.clone();
-                qualified.push(key.get_key_clone());
-                non_merk_tree_targets.push(qualified);
-            }
-            written_paths.push(path);
-        }
-        Self {
-            deleted,
-            written_paths,
-            non_merk_tree_targets,
-        }
-    }
-
-    /// Refuse add-on ops that cannot be applied coherently after this
-    /// segment (see the type docs).
-    fn verify_add_on_ops(&self, add_on_ops: &[QualifiedGroveDbOp]) -> Result<(), Error> {
-        for op in add_on_ops {
-            let path = op.path.to_path();
-            if self.deleted.iter().any(|deleted| path.starts_with(deleted)) {
-                return Err(Error::InvalidBatchOperation(
-                    "add-on operation writes under a path the initial segment deleted",
-                ));
-            }
-            // Add-on typed appends (keyless; the tree key is the path's
-            // last segment) are preprocessed against committed state, so a
-            // target this segment appended into, created, or replaced has
-            // no coherent committed root to append onto.
-            if matches!(
-                op.op,
-                GroveOp::CommitmentTreeInsert { .. }
-                    | GroveOp::MmrTreeAppend { .. }
-                    | GroveOp::BulkAppend { .. }
-                    | GroveOp::DenseTreeInsert { .. }
-                    | GroveOp::PrivateDocumentStoreInsert { .. }
-            ) && self.non_merk_tree_targets.contains(&path)
-            {
-                return Err(Error::InvalidBatchOperation(
-                    "add-on append targets a non-Merk tree the initial segment wrote",
-                ));
-            }
-            // Whether an op orphans what the initial segment wrote depends
-            // only on what was AT the target, never on what the new element
-            // is: overwriting a written-into subtree with a plain item
-            // strands the segment's pending child writes just as surely as
-            // overwriting it with a fresh tree.
-            let replaces_or_deletes_subtree = matches!(
-                op.op,
-                GroveOp::Delete
-                    | GroveOp::DeleteTree(..)
-                    | GroveOp::InsertOrReplace { .. }
-                    | GroveOp::InsertWithKnownToNotAlreadyExist { .. }
-                    | GroveOp::InsertIfNotExists { .. }
-                    | GroveOp::Replace { .. }
-                    | GroveOp::Patch { .. }
-            );
-            if replaces_or_deletes_subtree && let Some(key) = op.key.as_ref() {
-                let mut qualified = path;
-                qualified.push(key.get_key_clone());
-                if self
-                    .written_paths
-                    .iter()
-                    .any(|written| written.starts_with(&qualified))
-                {
-                    return Err(Error::InvalidBatchOperation(
-                        "add-on op replaces or deletes a subtree the initial segment wrote into",
-                    ));
-                }
-                if self.non_merk_tree_targets.contains(&qualified) {
-                    return Err(Error::InvalidBatchOperation(
-                        "add-on op replaces or deletes a non-Merk tree the initial segment wrote",
-                    ));
-                }
-            }
-        }
-        Ok(())
     }
 }
 

--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -1697,12 +1697,21 @@ struct InitialSegmentFootprint {
     deleted: Vec<Vec<Vec<u8>>>,
     /// Path of the Merk every op in the segment wrote into.
     written_paths: Vec<Vec<Vec<u8>>>,
+    /// Qualified path of every non-Merk tree the segment appended into,
+    /// created, or replaced. Add-on typed appends are preprocessed against
+    /// COMMITTED state (see `preprocess_commitment_tree_ops` and friends),
+    /// so a target whose data namespace or element only exists pending in
+    /// the batch cannot be appended to coherently — and deleting or
+    /// replacing such a tree would strand the segment's pending data-row
+    /// writes behind a cleanup pass that cannot see them.
+    non_merk_tree_targets: Vec<Vec<Vec<u8>>>,
 }
 
 impl InitialSegmentFootprint {
     fn from_ops(ops: &[QualifiedGroveDbOp]) -> Self {
         let mut deleted = Vec::new();
         let mut written_paths = Vec::with_capacity(ops.len());
+        let mut non_merk_tree_targets = Vec::new();
         for op in ops {
             let path = op.path.to_path();
             if matches!(op.op, GroveOp::Delete | GroveOp::DeleteTree(..))
@@ -1712,11 +1721,31 @@ impl InitialSegmentFootprint {
                 qualified.push(key.get_key_clone());
                 deleted.push(qualified);
             }
+            // Typed appends were rewritten into ReplaceNonMerkTreeRoot by
+            // preprocessing before the footprint is taken; insert-family
+            // ops can create or replace a non-Merk tree element directly.
+            let non_merk_tree_target = match &op.op {
+                GroveOp::ReplaceNonMerkTreeRoot { .. } => true,
+                GroveOp::InsertOrReplace { element }
+                | GroveOp::InsertWithKnownToNotAlreadyExist { element }
+                | GroveOp::InsertIfNotExists { element, .. }
+                | GroveOp::Replace { element }
+                | GroveOp::Patch { element, .. } => element
+                    .tree_type()
+                    .is_some_and(|tree_type| tree_type.uses_non_merk_data_storage()),
+                _ => false,
+            };
+            if non_merk_tree_target && let Some(key) = op.key.as_ref() {
+                let mut qualified = path.clone();
+                qualified.push(key.get_key_clone());
+                non_merk_tree_targets.push(qualified);
+            }
             written_paths.push(path);
         }
         Self {
             deleted,
             written_paths,
+            non_merk_tree_targets,
         }
     }
 
@@ -1730,15 +1759,38 @@ impl InitialSegmentFootprint {
                     "add-on operation writes under a path the initial segment deleted",
                 ));
             }
-            let replaces_or_deletes_subtree = match &op.op {
-                GroveOp::Delete | GroveOp::DeleteTree(..) => true,
-                GroveOp::InsertOrReplace { element }
-                | GroveOp::InsertWithKnownToNotAlreadyExist { element }
-                | GroveOp::InsertIfNotExists { element, .. }
-                | GroveOp::Replace { element }
-                | GroveOp::Patch { element, .. } => element.tree_type().is_some(),
-                _ => false,
-            };
+            // Add-on typed appends (keyless; the tree key is the path's
+            // last segment) are preprocessed against committed state, so a
+            // target this segment appended into, created, or replaced has
+            // no coherent committed root to append onto.
+            if matches!(
+                op.op,
+                GroveOp::CommitmentTreeInsert { .. }
+                    | GroveOp::MmrTreeAppend { .. }
+                    | GroveOp::BulkAppend { .. }
+                    | GroveOp::DenseTreeInsert { .. }
+                    | GroveOp::PrivateDocumentStoreInsert { .. }
+            ) && self.non_merk_tree_targets.contains(&path)
+            {
+                return Err(Error::InvalidBatchOperation(
+                    "add-on append targets a non-Merk tree the initial segment wrote",
+                ));
+            }
+            // Whether an op orphans what the initial segment wrote depends
+            // only on what was AT the target, never on what the new element
+            // is: overwriting a written-into subtree with a plain item
+            // strands the segment's pending child writes just as surely as
+            // overwriting it with a fresh tree.
+            let replaces_or_deletes_subtree = matches!(
+                op.op,
+                GroveOp::Delete
+                    | GroveOp::DeleteTree(..)
+                    | GroveOp::InsertOrReplace { .. }
+                    | GroveOp::InsertWithKnownToNotAlreadyExist { .. }
+                    | GroveOp::InsertIfNotExists { .. }
+                    | GroveOp::Replace { .. }
+                    | GroveOp::Patch { .. }
+            );
             if replaces_or_deletes_subtree && let Some(key) = op.key.as_ref() {
                 let mut qualified = path;
                 qualified.push(key.get_key_clone());
@@ -1749,6 +1801,11 @@ impl InitialSegmentFootprint {
                 {
                     return Err(Error::InvalidBatchOperation(
                         "add-on op replaces or deletes a subtree the initial segment wrote into",
+                    ));
+                }
+                if self.non_merk_tree_targets.contains(&qualified) {
+                    return Err(Error::InvalidBatchOperation(
+                        "add-on op replaces or deletes a non-Merk tree the initial segment wrote",
                     ));
                 }
             }
@@ -4788,12 +4845,16 @@ impl GroveDb {
     /// are returned
     /// Runs the level-by-level batch propagation.
     ///
-    /// Returns `(leftover_ops, captures, merk_tree_cache)`:
+    /// Returns `(leftover_ops, captures, merk_tree_cache,
+    /// ops_by_qualified_paths)`:
     ///   - `leftover_ops` is `Some(...)` only if a `batch_pause_height`
     ///     was set and pruning paused before reaching the root.
     ///   - `merk_tree_cache` is the cache the body ran against, handed back
     ///     so a paused apply can be continued on the same live Merks (see
     ///     `continue_partial_apply_body`).
+    ///   - `ops_by_qualified_paths` is the reference-resolution map the body
+    ///     ran against, handed back so a continuation's reference ops can
+    ///     resolve this body's in-batch targets like one combined batch.
     ///   - `captures` is the [`BatchApplyCaptures`] collected while the
     ///     body applied, for the caller's post-apply cleanup passes:
     ///     `cidx_overwrite_cleanup_paths` lists the cidx primary paths
@@ -4807,7 +4868,15 @@ impl GroveDb {
         batch_structure: BatchStructure<C, F, SR>,
         batch_apply_options: Option<BatchApplyOptions>,
         grove_version: &GroveVersion,
-    ) -> CostResult<(Option<OpsByLevelPath>, BatchApplyCaptures, C), Error>
+    ) -> CostResult<
+        (
+            Option<OpsByLevelPath>,
+            BatchApplyCaptures,
+            C,
+            BTreeMap<Vec<Vec<u8>>, GroveOp>,
+        ),
+        Error,
+    >
     where
         F: FnMut(&StorageCost, Option<ElementFlags>, &mut ElementFlags) -> Result<bool, Error>,
         SR: FnMut(
@@ -5394,8 +5463,13 @@ impl GroveDb {
                     indexed_mirror_rekey_churn_bytes: merk_tree_cache
                         .take_indexed_mirror_rekey_churn_bytes(),
                 };
-                return Ok((Some(ops_by_level_paths), captures, merk_tree_cache))
-                    .wrap_with_cost(cost);
+                return Ok((
+                    Some(ops_by_level_paths),
+                    captures,
+                    merk_tree_cache,
+                    ops_by_qualified_paths,
+                ))
+                .wrap_with_cost(cost);
             }
             current_level = current_level.saturating_sub(1);
         }
@@ -5405,7 +5479,7 @@ impl GroveDb {
             indexed_mirror_rekey_churn_bytes: merk_tree_cache
                 .take_indexed_mirror_rekey_churn_bytes(),
         };
-        Ok((None, captures, merk_tree_cache)).wrap_with_cost(cost)
+        Ok((None, captures, merk_tree_cache, ops_by_qualified_paths)).wrap_with_cost(cost)
     }
 
     /// Method to propagate updated subtree root hashes up to GroveDB root
@@ -5437,6 +5511,7 @@ impl GroveDb {
             Option<OpsByLevelPath>,
             BatchApplyCaptures,
             TreeCacheMerkByPath<S, F, F2>,
+            BTreeMap<Vec<Vec<u8>>, GroveOp>,
         ),
         Error,
     >
@@ -5479,7 +5554,10 @@ impl GroveDb {
     }
 
     /// Continue a paused `apply_body` on the SAME live Merk cache it ran
-    /// against, folding `additional_ops` into its leftover operations.
+    /// against, folding `additional_ops` into its leftover operations and
+    /// seeding reference resolution with the paused body's
+    /// `ops_by_qualified_paths`, so `additional_ops` references resolve
+    /// the initial segment's in-batch targets like one combined batch.
     ///
     /// The cache is what keeps the two segments of a partial batch
     /// coherent (issue #842): every primary and secondary Merk the initial
@@ -5491,6 +5569,7 @@ impl GroveDb {
     fn continue_partial_apply_body<'db, S, F, F2>(
         &self,
         previous_leftover_operations: Option<OpsByLevelPath>,
+        previous_ops_by_qualified_paths: BTreeMap<Vec<Vec<u8>>, GroveOp>,
         additional_ops: Vec<QualifiedGroveDbOp>,
         batch_apply_options: Option<BatchApplyOptions>,
         update_element_flags_function: impl FnMut(
@@ -5530,6 +5609,7 @@ impl GroveDb {
             &mut cost,
             BatchStructure::continue_from_ops(
                 previous_leftover_operations,
+                Some(previous_ops_by_qualified_paths),
                 additional_ops,
                 update_element_flags_function,
                 split_removed_bytes_function,
@@ -5539,7 +5619,7 @@ impl GroveDb {
         );
         // The cache is dropped here: its Merks borrow the storage batch,
         // which the caller drains and consumes next.
-        let (leftover, captures, _merk_tree_cache) = cost_return_on_error!(
+        let (leftover, captures, _merk_tree_cache, _ops_by_qualified_paths) = cost_return_on_error!(
             &mut cost,
             Self::apply_batch_structure(batch_structure, batch_apply_options, grove_version)
         );
@@ -6591,6 +6671,26 @@ impl GroveDb {
             return Ok(()).wrap_with_cost(cost);
         }
 
+        // An ordinary batch must fully propagate. A nonzero
+        // `batch_pause_height` would make `apply_body` pause mid-propagation
+        // and hand back leftover ancestor ops — which this entry point has
+        // no continuation for, so it would commit the paused result and
+        // silently discard them, leaving child state inconsistent with
+        // retained ancestor commitments (issue #889). Only
+        // `apply_partial_batch*` may pause. A pause height of 0 is complete
+        // propagation (level 0 is processed, base root key included, before
+        // the pause check fires) and stays accepted.
+        if batch_apply_options
+            .as_ref()
+            .and_then(|options| options.batch_pause_height)
+            .is_some_and(|pause_height| pause_height > 0)
+        {
+            return Err(Error::InvalidBatchOperation(
+                "a nonzero batch_pause_height is only supported by apply_partial_batch",
+            ))
+            .wrap_with_cost(cost);
+        }
+
         // Check batch operation consistency BEFORE preprocessing so that
         // conflicting ops (e.g., CommitmentTreeInsert + Delete on the same
         // path/key) are caught before any work is done.
@@ -6759,7 +6859,7 @@ impl GroveDb {
         // 5. Remove operation from the tree, repeat until there are operations to do;
         // 6. Add root leaves save operation to the batch
         // 7. Apply storage_cost batch
-        let (_leftover, batch_apply_captures, _) = cost_return_on_error!(
+        let (_leftover, batch_apply_captures, _, _) = cost_return_on_error!(
             &mut cost,
             self.apply_body(
                 ops,
@@ -7178,7 +7278,7 @@ impl GroveDb {
             mut merk_delete_paths,
             mut cidx_primary_delete_paths,
             skipped_delete_paths,
-            delete_tree_behaviors,
+            mut delete_tree_behaviors,
         } = cost_return_on_error!(
             &mut cost,
             self.scan_delete_tree_ops(&ops, &storage_batch, tx.as_ref(), grove_version)
@@ -7232,7 +7332,12 @@ impl GroveDb {
         // 5. Remove operation from the tree, repeat until there are operations to do;
         // 6. Add root leaves save operation to the batch
         // 7. Apply storage_cost batch
-        let (left_over_operations, partial_captures, merk_tree_cache) = cost_return_on_error!(
+        let (
+            left_over_operations,
+            partial_captures,
+            merk_tree_cache,
+            initial_ops_by_qualified_paths,
+        ) = cost_return_on_error!(
             &mut cost,
             self.apply_body(
                 ops,
@@ -7292,17 +7397,6 @@ impl GroveDb {
         // caller-provided, so the returned operations could contain duplicates,
         // internal-only ops, or inserts under paths being deleted. Apply the
         // same consistency gate used for the initial batch.
-        //
-        // Limitation: add-on DeleteTree ops bypass the
-        // SubelementsDeletionBehavior preflight (emptiness check, Skip
-        // filtering, cleanup path collection) that runs on the initial
-        // batch.  They go straight into continue_partial_apply_body →
-        // apply_body, where DeleteTree is a simple layered Merk delete
-        // with no emptiness enforcement.  In practice this is safe because
-        // partial-batch callers (Platform) control the callback and only
-        // return root-level propagation ops, not new DeleteTree ops.  If
-        // add-on DeleteTree support is needed in the future, the preflight
-        // must be extended to cover new_operations as well.
         if check_batch_operation_consistency && !new_operations.is_empty() {
             let consistency_result =
                 QualifiedGroveDbOp::verify_consistency_of_operations(&new_operations);
@@ -7313,7 +7407,7 @@ impl GroveDb {
                 .wrap_with_cost(cost);
             }
         }
-        // Cross-segment gate: the two shapes the live cache cannot make
+        // Cross-segment gate: the shapes the live cache cannot make
         // coherent (see `InitialSegmentFootprint`).
         if let Some(footprint) = initial_segment_footprint.as_ref() {
             cost_return_on_error_no_add!(cost, footprint.verify_add_on_ops(&new_operations));
@@ -7340,6 +7434,106 @@ impl GroveDb {
             Self::reject_backward_references_elements_in_batch(&new_operations, false)
         );
 
+        // Add-on typed appends (CommitmentTreeInsert, MmrTreeAppend,
+        // BulkAppend, DenseTreeInsert, PrivateDocumentStoreInsert) get the
+        // same preprocessing as the initial segment (issue #895): without
+        // it they are keyless, so ordinary batch construction either drops
+        // them silently (V1..V3) or execution refuses them loudly.
+        // Preprocessing reads committed state, which is coherent here
+        // because the cross-segment gate above refused any append whose
+        // target tree the initial segment appended into, created, replaced,
+        // or deleted.
+        let new_operations = cost_return_on_error!(
+            &mut cost,
+            self.preprocess_commitment_tree_ops(
+                new_operations,
+                tx.as_ref(),
+                &storage_batch,
+                grove_version
+            )
+        );
+        let new_operations = cost_return_on_error!(
+            &mut cost,
+            self.preprocess_mmr_tree_ops(
+                new_operations,
+                tx.as_ref(),
+                &storage_batch,
+                grove_version
+            )
+        );
+        let new_operations = cost_return_on_error!(
+            &mut cost,
+            self.preprocess_bulk_append_ops(
+                new_operations,
+                tx.as_ref(),
+                &storage_batch,
+                grove_version
+            )
+        );
+        let new_operations = cost_return_on_error!(
+            &mut cost,
+            self.preprocess_dense_tree_ops(
+                new_operations,
+                tx.as_ref(),
+                &storage_batch,
+                grove_version
+            )
+        );
+        let new_operations = cost_return_on_error!(
+            &mut cost,
+            self.preprocess_private_document_store_ops(
+                new_operations,
+                tx.as_ref(),
+                &storage_batch,
+                grove_version
+            )
+        );
+
+        // Add-on DeleteTree ops get the same SubelementsDeletionBehavior
+        // preflight as the initial segment (issue #709): the emptiness
+        // check behind Error / Skip, Skip filtering, and the cleanup
+        // path / behavior collection the post-apply passes below run on.
+        // The scan reads committed state, which is coherent here because
+        // the cross-segment gate refused deletes of anything the initial
+        // segment wrote into; a target the initial segment CREATED has no
+        // committed element yet, so an Error / Skip emptiness check on it
+        // fails closed before the continuation applies anything.
+        let DeleteTreePreScan {
+            non_merk_delete_paths: add_on_non_merk_delete_paths,
+            merk_delete_paths: add_on_merk_delete_paths,
+            cidx_primary_delete_paths: add_on_cidx_primary_delete_paths,
+            skipped_delete_paths: add_on_skipped_delete_paths,
+            delete_tree_behaviors: add_on_delete_tree_behaviors,
+        } = cost_return_on_error!(
+            &mut cost,
+            self.scan_delete_tree_ops(&new_operations, &storage_batch, tx.as_ref(), grove_version)
+        );
+        non_merk_delete_paths.extend(add_on_non_merk_delete_paths);
+        merk_delete_paths.extend(add_on_merk_delete_paths);
+        cidx_primary_delete_paths.extend(add_on_cidx_primary_delete_paths);
+        delete_tree_behaviors.extend(add_on_delete_tree_behaviors);
+
+        // Filter out add-on DeleteTree ops skipped by
+        // SubelementsDeletionBehavior::Skip on non-empty trees, exactly
+        // like the initial segment's filtering above.
+        let new_operations = if !add_on_skipped_delete_paths.is_empty() {
+            new_operations
+                .into_iter()
+                .filter(|op| {
+                    if let GroveOp::DeleteTree(..) = &op.op
+                        && let Some(key) = op.key.as_ref()
+                    {
+                        let mut child_path = op.path.to_path();
+                        child_path.push(key.as_slice().to_vec());
+                        return !add_on_skipped_delete_paths.contains(&child_path);
+                    }
+                    true
+                })
+                .collect()
+        } else {
+            new_operations
+        };
+
         // we are trying to finalize
         batch_apply_options.batch_pause_height = None;
 
@@ -7347,6 +7541,7 @@ impl GroveDb {
             &mut cost,
             self.continue_partial_apply_body(
                 left_over_operations,
+                initial_ops_by_qualified_paths,
                 new_operations,
                 Some(batch_apply_options),
                 update_element_flags_function,

--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -7412,6 +7412,29 @@ impl GroveDb {
         if let Some(footprint) = initial_segment_footprint.as_ref() {
             cost_return_on_error_no_add!(cost, footprint.verify_add_on_ops(&new_operations));
         }
+        // A continuation write under an indexed primary the initial segment
+        // safe-subset-OVERWROTE would land in the very storage prefixes the
+        // post-apply sweep below clears (the old element's primary subtree
+        // and secondary namespaces). The ordinary batch refuses this shape
+        // in one batch for the same reason — see the NotSupported arm of
+        // `reject_indexed_overwrite_with_descendants` — so refuse it here
+        // before the continuation applies. `cidx_overwrite_cleanup_paths`
+        // is exactly the list of primaries the initial segment overwrote.
+        for op in &new_operations {
+            let path = op.path.to_path();
+            if partial_captures
+                .cidx_overwrite_cleanup_paths
+                .iter()
+                .any(|overwritten| path.starts_with(overwritten))
+            {
+                return Err(Error::InvalidBatchOperation(
+                    "add-on operation writes under an indexed tree the initial segment \
+                     overwrote; the old element's storage is swept at commit and would \
+                     clear the new writes",
+                ))
+                .wrap_with_cost(cost);
+            }
+        }
         // Add-on ops get the same indexed-overwrite preflight as the initial
         // batch. It reads committed state, so it covers committed
         // descendants; descendants the initial segment wrote are covered by

--- a/grovedb/src/batch/options.rs
+++ b/grovedb/src/batch/options.rs
@@ -67,6 +67,10 @@ pub struct BatchApplyOptions {
     /// such conflicting batches are rejected before the emptiness check runs.
     /// When this flag is `true`, the caller must ensure no batch contains
     /// both inserts into a subtree and a `DeleteTree` of that subtree.
+    ///
+    /// Partial batches always validate conflicts between the initial and
+    /// continuation segments. This flag disables only per-segment checks;
+    /// it cannot make pending state safe for committed-state cleanup.
     pub disable_operation_consistency_check: bool,
     /// Base root storage is free
     pub base_root_storage_is_free: bool,

--- a/grovedb/src/tests/indexed_secondary_rekey_cost_tests.rs
+++ b/grovedb/src/tests/indexed_secondary_rekey_cost_tests.rs
@@ -34,7 +34,7 @@ mod tests {
             reclassify_indexed_mirror_rekey_churn, QualifiedGroveDbOp, SubelementsDeletionBehavior,
         },
         tests::{make_test_grovedb, TEST_LEAF},
-        Element,
+        Element, IndexedAxisEntrySliceExt,
     };
 
     fn total_removed(cost: &OperationCost) -> u64 {
@@ -191,12 +191,10 @@ mod tests {
         // each segment: if either segment's churn were dropped, its old
         // row's removal would survive into the final cost.
         //
-        // Scoped to the COST LANES only: apply_partial_batch has a
-        // pre-existing state bug when both segments touch the same
-        // secondary (the initial segment's row deletion is resurrected by
-        // the continuation's rotation writes — see
-        // https://github.com/dashpay/grovedb/issues/842), so state-level
-        // assertions belong to that fix, not this accounting change.
+        // State-level coverage of two segments sharing one secondary
+        // (issue #842) lives in `partial_batch_coherence_tests`; the final
+        // rows are pinned here too so the cost assertions are known to
+        // describe a correct end state.
         let grove_version = GroveVersion::latest();
 
         let db = setup_pcit_with_group(grove_version, 2);
@@ -246,6 +244,15 @@ mod tests {
             "both segments' re-key churn must be rebilled at the one commit"
         );
         assert!(cost.storage_cost.replaced_bytes > 0);
+        let top = db
+            .indexed_count_top_k([TEST_LEAF, b"cidx"].as_ref(), 10, true, None, grove_version)
+            .unwrap()
+            .expect("top-k");
+        assert_eq!(
+            top.key_pairs(),
+            vec![(3, b"q".to_vec()), (3, b"p".to_vec())],
+            "both re-keyed rows, and neither old row"
+        );
     }
 
     // -----------------------------------------------------------------

--- a/grovedb/src/tests/mod.rs
+++ b/grovedb/src/tests/mod.rs
@@ -5081,8 +5081,8 @@ mod general_tests {
         }
     }
 
-    /// Fail-closed: batches perform no backward-references bookkeeping, so
-    /// every batch entry point rejects ops carrying the element family.
+    /// Without opt-in bookkeeping, every batch entry point rejects the
+    /// backward-references family and leaves preceding valid writes uncommitted.
     #[test]
     fn backward_references_elements_rejected_in_batches() {
         let grove_version = GroveVersion::latest();
@@ -5103,18 +5103,64 @@ mod general_tests {
         ];
 
         for element in elements {
-            let ops = vec![QualifiedGroveDbOp::insert_or_replace_op(
+            let valid_op = |key: &[u8]| {
+                QualifiedGroveDbOp::insert_or_replace_op(
+                    vec![TEST_LEAF.to_vec()],
+                    key.to_vec(),
+                    Element::new_item(b"valid".to_vec()),
+                )
+            };
+            let rejected_op = QualifiedGroveDbOp::insert_or_replace_op(
                 vec![TEST_LEAF.to_vec()],
                 b"k".to_vec(),
                 element.clone(),
-            )];
-            assert!(
-                matches!(
-                    db.apply_batch(ops, None, None, grove_version).unwrap(),
-                    Err(Error::NotSupported(_))
-                ),
-                "expected NotSupported in batch for {element:?}"
             );
+            // Exercise ordinary batch rejection, initial partial rejection,
+            // and rejection after a successful initial partial segment.
+            for phase in ["ordinary", "initial", "continuation"] {
+                let before = db.root_hash(None, grove_version).unwrap().unwrap();
+                let ops = vec![valid_op(b"a_valid"), rejected_op.clone()];
+                let result = match phase {
+                    "ordinary" => db.apply_batch(ops, None, None, grove_version).unwrap(),
+                    "initial" => db
+                        .apply_partial_batch(
+                            ops,
+                            None,
+                            |_, _| {
+                                panic!("rejected initial segment must not call the add-on closure")
+                            },
+                            None,
+                            grove_version,
+                        )
+                        .unwrap(),
+                    _ => db
+                        .apply_partial_batch(
+                            vec![valid_op(b"initial_valid")],
+                            None,
+                            |_, _| Ok(ops.clone()),
+                            None,
+                            grove_version,
+                        )
+                        .unwrap(),
+                };
+                assert!(
+                    matches!(result, Err(Error::NotSupported(_))),
+                    "expected NotSupported in {phase} batch for {element:?}: {result:?}"
+                );
+                assert_eq!(db.root_hash(None, grove_version).unwrap().unwrap(), before);
+                for key in [b"a_valid".as_slice(), b"initial_valid", b"k"] {
+                    assert!(
+                        db.get([TEST_LEAF].as_ref(), key, None, grove_version)
+                            .unwrap()
+                            .is_err(),
+                        "{phase} rejection committed {key:?}"
+                    );
+                }
+                assert!(db
+                    .verify_grovedb(None, true, true, grove_version)
+                    .unwrap()
+                    .is_empty());
+            }
         }
     }
 }

--- a/grovedb/src/tests/mod.rs
+++ b/grovedb/src/tests/mod.rs
@@ -96,6 +96,7 @@ mod non_counted_tests;
 mod not_counted_or_summed_tests;
 mod not_summed_tests;
 mod operations_coverage_tests;
+mod partial_batch_coherence_tests;
 mod partial_batch_consistency_tests;
 mod proof_advanced_tests;
 mod proof_coverage_tests;

--- a/grovedb/src/tests/partial_batch_coherence_tests.rs
+++ b/grovedb/src/tests/partial_batch_coherence_tests.rs
@@ -430,6 +430,94 @@ mod tests {
     }
 
     #[test]
+    fn new_pcit_via_insert_if_not_exists_populated_by_continuation() {
+        // Same shape as above, but the indexed tree is created with
+        // InsertIfNotExists: the continuation's secondary opener must find
+        // the pending element through that op variant too.
+        let grove_version = GroveVersion::latest();
+        let cidx_path = vec![TEST_LEAF.to_vec(), b"cidx".to_vec()];
+        let mut second = vec![count_child_op(cidx_path.clone(), b"a")];
+        second.extend((0..3u64).map(|k| bump(b"cidx", b"a", k)));
+        let rows = assert_three_flows_agree(
+            make_test_grovedb,
+            vec![QualifiedGroveDbOp::insert_if_not_exists_op(
+                vec![TEST_LEAF.to_vec()],
+                b"cidx".to_vec(),
+                Element::empty_provable_count_indexed_tree(),
+            )],
+            second,
+            Some(BatchApplyOptions::default()),
+            |db, gv| top_k(db, b"cidx", gv),
+            grove_version,
+        );
+        assert_eq!(rows, vec![(3, b"a".to_vec())]);
+    }
+
+    #[test]
+    fn continuation_write_under_pcit_overwritten_by_initial_segment_is_refused() {
+        // The initial segment safe-subset-OVERWRITES a committed indexed
+        // tree; the continuation writes under it. The old element's storage
+        // is swept at commit, which would clear the continuation's writes —
+        // the same shape one combined batch refuses with NotSupported — so
+        // the partial flow must refuse it too, committing nothing.
+        let grove_version = GroveVersion::latest();
+        let db = two_group_pcit(grove_version);
+        let before = root_hash(&db, grove_version);
+
+        let overwrite = QualifiedGroveDbOp::replace_op(
+            vec![TEST_LEAF.to_vec()],
+            b"cidx".to_vec(),
+            Element::empty_provable_count_indexed_tree(),
+        );
+        let populate = count_child_op(vec![TEST_LEAF.to_vec(), b"cidx".to_vec()], b"a");
+
+        let combined = db.apply_batch(
+            vec![overwrite.clone(), populate.clone()],
+            Some(BatchApplyOptions::default()),
+            None,
+            grove_version,
+        );
+        assert!(
+            matches!(combined.unwrap(), Err(Error::NotSupported(_))),
+            "the combined batch must refuse overwrite-then-populate"
+        );
+
+        let result = apply_partial(
+            &db,
+            vec![overwrite],
+            vec![populate],
+            Some(BatchApplyOptions::default()),
+            grove_version,
+        );
+        assert!(
+            matches!(result, Err(Error::InvalidBatchOperation(_))),
+            "{result:?}"
+        );
+        assert_untouched(&db, before, grove_version);
+    }
+
+    #[test]
+    fn continuation_replace_overwrite_of_committed_pcit_with_empty_one_cleans_up() {
+        // The Replace-op variant of the safe-subset overwrite from the
+        // continuation (no writes under it afterwards): allowed, and the
+        // old rows are swept exactly like the InsertOrReplace variant.
+        let grove_version = GroveVersion::latest();
+        let rows = assert_three_flows_agree(
+            two_group_pcit,
+            vec![item_op(vec![TEST_LEAF.to_vec()], 1)],
+            vec![QualifiedGroveDbOp::replace_op(
+                vec![TEST_LEAF.to_vec()],
+                b"cidx".to_vec(),
+                Element::empty_provable_count_indexed_tree(),
+            )],
+            Some(BatchApplyOptions::default()),
+            |db, gv| top_k(db, b"cidx", gv),
+            grove_version,
+        );
+        assert!(rows.is_empty(), "{rows:?}");
+    }
+
+    #[test]
     fn new_pcit_from_initial_segment_populated_by_continuation() {
         // The initial segment creates an EMPTY indexed tree under
         // TEST_LEAF (its element is written into the cached TEST_LEAF

--- a/grovedb/src/tests/partial_batch_coherence_tests.rs
+++ b/grovedb/src/tests/partial_batch_coherence_tests.rs
@@ -1,0 +1,710 @@
+//! `apply_partial_batch` coherence between its two segments (issue #842).
+//!
+//! The partial flow applies the initial segment, hands its pending cost
+//! to the caller's add-on closure, then applies the closure's ops as a
+//! continuation before one atomic commit. Both segments must observe one
+//! coherent logical state: the continuation has to see every node write,
+//! row delete, pending root key and root-metadata change the initial
+//! segment made, and a failing continuation must leave nothing behind.
+//!
+//! Each case applies the same two op sets three ways — one combined
+//! `apply_batch`, two sequential `apply_batch` calls, and one
+//! `apply_partial_batch` — and pins that the partial flow lands on the
+//! sequential flow's exact state (root hash included: each segment is one
+//! Merk apply on the same tree, exactly like two sequential batches), that
+//! every flow reads the same rows, and that `verify_grovedb` stays clean.
+
+#[cfg(test)]
+mod tests {
+    use grovedb_merk::tree_type::TreeType;
+    use grovedb_version::version::GroveVersion;
+
+    use crate::{
+        batch::{BatchApplyOptions, QualifiedGroveDbOp, SubelementsDeletionBehavior},
+        tests::{make_test_grovedb, TempGroveDb, TEST_LEAF},
+        Element, Error, GroveDb, IndexedAxisEntrySliceExt,
+    };
+
+    fn assert_verify_clean(db: &GroveDb, grove_version: &GroveVersion) {
+        let issues = db
+            .verify_grovedb(None, true, true, grove_version)
+            .expect("verify_grovedb must not hard-error");
+        assert!(issues.is_empty(), "verify_grovedb reported: {issues:?}");
+    }
+
+    fn root_hash(db: &GroveDb, grove_version: &GroveVersion) -> [u8; 32] {
+        db.root_hash(None, grove_version)
+            .unwrap()
+            .expect("root hash")
+    }
+
+    /// A PCIT at `[TEST_LEAF, "cidx"]` with count-tree groups, each holding
+    /// `count` items keyed `0..count`.
+    fn insert_pcit_with_groups(
+        db: &GroveDb,
+        cidx: &[u8],
+        groups: &[(&[u8], u64)],
+        grove_version: &GroveVersion,
+    ) {
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            cidx,
+            Element::empty_provable_count_indexed_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert PCIT");
+        for (group, count) in groups {
+            db.insert_into_count_indexed_tree(
+                [TEST_LEAF, cidx].as_ref(),
+                group,
+                Element::empty_count_tree(),
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("insert group");
+            for i in 0..*count {
+                db.insert(
+                    [TEST_LEAF, cidx, group].as_ref(),
+                    &i.to_be_bytes(),
+                    Element::new_item(vec![]),
+                    None,
+                    None,
+                    grove_version,
+                )
+                .unwrap()
+                .expect("populate group");
+            }
+        }
+    }
+
+    fn two_group_pcit(grove_version: &GroveVersion) -> TempGroveDb {
+        let db = make_test_grovedb(grove_version);
+        insert_pcit_with_groups(&db, b"cidx", &[(b"p", 2), (b"q", 2)], grove_version);
+        db
+    }
+
+    fn item_op(path: Vec<Vec<u8>>, key: u64) -> QualifiedGroveDbOp {
+        QualifiedGroveDbOp::insert_or_replace_op(
+            path,
+            key.to_be_bytes().to_vec(),
+            Element::new_item(vec![]),
+        )
+    }
+
+    /// Insert one more item into a PCIT group: its count bumps and the
+    /// mirror row moves from `(old ‖ group)` to `(new ‖ group)`.
+    fn bump(cidx: &[u8], group: &[u8], key: u64) -> QualifiedGroveDbOp {
+        item_op(vec![TEST_LEAF.to_vec(), cidx.to_vec(), group.to_vec()], key)
+    }
+
+    fn top_k(db: &GroveDb, cidx: &[u8], grove_version: &GroveVersion) -> Vec<(u64, Vec<u8>)> {
+        db.indexed_count_top_k([TEST_LEAF, cidx].as_ref(), 10, true, None, grove_version)
+            .unwrap()
+            .expect("top-k")
+            .key_pairs()
+    }
+
+    fn apply_partial(
+        db: &GroveDb,
+        first: Vec<QualifiedGroveDbOp>,
+        second: Vec<QualifiedGroveDbOp>,
+        options: Option<BatchApplyOptions>,
+        grove_version: &GroveVersion,
+    ) -> Result<(), Error> {
+        db.apply_partial_batch(
+            first,
+            options,
+            move |_cost, _left_over| Ok(second.clone()),
+            None,
+            grove_version,
+        )
+        .unwrap()
+    }
+
+    /// Apply `first` then `second` three ways on identically prepared
+    /// databases and pin the equivalence described in the module docs.
+    /// `read` snapshots whatever rows the case cares about.
+    fn assert_three_flows_agree<R: PartialEq + std::fmt::Debug>(
+        setup: impl Fn(&GroveVersion) -> TempGroveDb,
+        first: Vec<QualifiedGroveDbOp>,
+        second: Vec<QualifiedGroveDbOp>,
+        options: Option<BatchApplyOptions>,
+        read: impl Fn(&GroveDb, &GroveVersion) -> R,
+        grove_version: &GroveVersion,
+    ) -> R {
+        let combined = setup(grove_version);
+        combined
+            .apply_batch(
+                first.iter().chain(second.iter()).cloned().collect(),
+                options.clone(),
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("combined batch applies");
+
+        let sequential = setup(grove_version);
+        sequential
+            .apply_batch(first.clone(), options.clone(), None, grove_version)
+            .unwrap()
+            .expect("first batch applies");
+        sequential
+            .apply_batch(second.clone(), options.clone(), None, grove_version)
+            .unwrap()
+            .expect("second batch applies");
+
+        let partial = setup(grove_version);
+        apply_partial(&partial, first, second, options, grove_version)
+            .expect("partial batch applies");
+
+        assert_verify_clean(&combined, grove_version);
+        assert_verify_clean(&sequential, grove_version);
+        assert_verify_clean(&partial, grove_version);
+
+        let rows = read(&combined, grove_version);
+        assert_eq!(
+            read(&sequential, grove_version),
+            rows,
+            "sequential flow reads differ from the combined batch"
+        );
+        assert_eq!(
+            read(&partial, grove_version),
+            rows,
+            "partial flow reads differ from the combined batch"
+        );
+        assert_eq!(
+            root_hash(&partial, grove_version),
+            root_hash(&sequential, grove_version),
+            "partial flow must land on the sequential flow's root hash"
+        );
+        rows
+    }
+
+    // -----------------------------------------------------------------
+    // Overlapping secondaries (the issue's reproduction)
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn same_secondary_rekeyed_in_both_segments() {
+        // Issue #842: the initial segment re-keys `p` (2 → 3), the
+        // continuation re-keys `q` (2 → 3) in the SAME secondary. The old
+        // `(2 ‖ p)` row must not survive.
+        let grove_version = GroveVersion::latest();
+        let rows = assert_three_flows_agree(
+            two_group_pcit,
+            vec![bump(b"cidx", b"p", 2)],
+            vec![bump(b"cidx", b"q", 2)],
+            Some(BatchApplyOptions::default()),
+            |db, gv| top_k(db, b"cidx", gv),
+            grove_version,
+        );
+        assert_eq!(rows, vec![(3, b"q".to_vec()), (3, b"p".to_vec())]);
+    }
+
+    #[test]
+    fn same_group_rekeyed_in_both_segments() {
+        // Both segments bump the SAME group: the continuation must start
+        // from the initial segment's count (3), not the committed one (2),
+        // or the mirror lands on `(3 ‖ p)` with a stale pre-state.
+        let grove_version = GroveVersion::latest();
+        let rows = assert_three_flows_agree(
+            two_group_pcit,
+            vec![bump(b"cidx", b"p", 2)],
+            vec![bump(b"cidx", b"p", 3)],
+            Some(BatchApplyOptions::default()),
+            |db, gv| top_k(db, b"cidx", gv),
+            grove_version,
+        );
+        assert_eq!(rows, vec![(4, b"p".to_vec()), (2, b"q".to_vec())]);
+    }
+
+    #[test]
+    fn disjoint_secondaries_in_both_segments() {
+        // Two PCITs: each segment re-keys a row in its own secondary.
+        let grove_version = GroveVersion::latest();
+        let setup = |gv: &GroveVersion| {
+            let db = make_test_grovedb(gv);
+            insert_pcit_with_groups(&db, b"cidx1", &[(b"p", 2), (b"q", 2)], gv);
+            insert_pcit_with_groups(&db, b"cidx2", &[(b"p", 2), (b"q", 2)], gv);
+            db
+        };
+        let rows = assert_three_flows_agree(
+            setup,
+            vec![bump(b"cidx1", b"p", 2)],
+            vec![bump(b"cidx2", b"q", 2)],
+            Some(BatchApplyOptions::default()),
+            |db, gv| (top_k(db, b"cidx1", gv), top_k(db, b"cidx2", gv)),
+            grove_version,
+        );
+        assert_eq!(
+            rows,
+            (
+                vec![(3, b"p".to_vec()), (2, b"q".to_vec())],
+                vec![(3, b"q".to_vec()), (2, b"p".to_vec())],
+            )
+        );
+    }
+
+    // -----------------------------------------------------------------
+    // Deletes in the initial segment
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn primary_row_delete_then_continuation_insert_into_same_group() {
+        // Initial segment deletes an item from `p` (2 → 1, mirror row
+        // moves down); the continuation inserts a new item into `p`
+        // (1 → 2, mirror row moves back). The continuation must see the
+        // delete: group `p` ends with exactly {1, 7}.
+        let grove_version = GroveVersion::latest();
+        let rows = assert_three_flows_agree(
+            two_group_pcit,
+            vec![QualifiedGroveDbOp::delete_op(
+                vec![TEST_LEAF.to_vec(), b"cidx".to_vec(), b"p".to_vec()],
+                0u64.to_be_bytes().to_vec(),
+            )],
+            vec![bump(b"cidx", b"p", 7)],
+            Some(BatchApplyOptions::default()),
+            |db, gv| {
+                let present: Vec<u64> = [0u64, 1, 7]
+                    .into_iter()
+                    .filter(|k| {
+                        db.get_raw(
+                            [TEST_LEAF, b"cidx", b"p"].as_ref().into(),
+                            &k.to_be_bytes(),
+                            None,
+                            gv,
+                        )
+                        .unwrap()
+                        .is_ok()
+                    })
+                    .collect();
+                (top_k(db, b"cidx", gv), present)
+            },
+            grove_version,
+        );
+        assert_eq!(
+            rows,
+            (vec![(2, b"q".to_vec()), (2, b"p".to_vec())], vec![1, 7])
+        );
+    }
+
+    #[test]
+    fn group_delete_then_continuation_inserts_sibling_group() {
+        // Initial segment drops the whole `p` group (its mirror row goes
+        // away); the continuation bumps `q` in the same secondary. The
+        // drained row must not come back.
+        let grove_version = GroveVersion::latest();
+        let rows = assert_three_flows_agree(
+            two_group_pcit,
+            vec![QualifiedGroveDbOp::delete_tree_op(
+                vec![TEST_LEAF.to_vec(), b"cidx".to_vec()],
+                b"p".to_vec(),
+                TreeType::CountTree,
+                SubelementsDeletionBehavior::DeleteChildren,
+            )],
+            vec![bump(b"cidx", b"q", 2)],
+            Some(BatchApplyOptions::default()),
+            |db, gv| top_k(db, b"cidx", gv),
+            grove_version,
+        );
+        assert_eq!(rows, vec![(3, b"q".to_vec())]);
+    }
+
+    // -----------------------------------------------------------------
+    // Ordinary (non-indexed) subtrees shared between segments
+    // -----------------------------------------------------------------
+
+    fn ordinary_subtree(grove_version: &GroveVersion) -> TempGroveDb {
+        let db = make_test_grovedb(grove_version);
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"sub",
+            Element::empty_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert subtree");
+        for i in 0..8u64 {
+            db.insert(
+                [TEST_LEAF, b"sub"].as_ref(),
+                &i.to_be_bytes(),
+                Element::new_item(vec![i as u8]),
+                None,
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("populate subtree");
+        }
+        db
+    }
+
+    fn present_keys(db: &GroveDb, path: &[&[u8]], grove_version: &GroveVersion) -> Vec<u64> {
+        (0..40u64)
+            .filter(|k| {
+                db.get_raw(path.into(), &k.to_be_bytes(), None, grove_version)
+                    .unwrap()
+                    .is_ok()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn same_ordinary_subtree_in_both_segments() {
+        // Both segments write into `[TEST_LEAF, "sub"]`, a subtree below
+        // the pause height whose parent element the initial segment
+        // already rewrote. Every key from both segments must survive.
+        let grove_version = GroveVersion::latest();
+        let sub = vec![TEST_LEAF.to_vec(), b"sub".to_vec()];
+        let rows = assert_three_flows_agree(
+            ordinary_subtree,
+            (10..20u64).map(|k| item_op(sub.clone(), k)).collect(),
+            (20..30u64).map(|k| item_op(sub.clone(), k)).collect(),
+            Some(BatchApplyOptions::default()),
+            |db, gv| present_keys(db, &[TEST_LEAF, b"sub"], gv),
+            grove_version,
+        );
+        assert_eq!(
+            rows,
+            (0..8u64).chain(10..30).collect::<Vec<_>>(),
+            "the setup's 0..8 plus both segments' 10..30"
+        );
+    }
+
+    #[test]
+    fn pause_level_subtree_shared_between_segments() {
+        // Both segments write into `[TEST_LEAF]` itself — the Merk AT the
+        // pause height, whose new root key lives only in the initial
+        // segment's leftover root-level op. The continuation must reuse
+        // that live Merk rather than reopen it from the committed root
+        // key.
+        let grove_version = GroveVersion::latest();
+        let leaf = vec![TEST_LEAF.to_vec()];
+        let rows = assert_three_flows_agree(
+            make_test_grovedb,
+            (10..20u64).map(|k| item_op(leaf.clone(), k)).collect(),
+            (20..30u64).map(|k| item_op(leaf.clone(), k)).collect(),
+            Some(BatchApplyOptions::default()),
+            |db, gv| present_keys(db, &[TEST_LEAF], gv),
+            grove_version,
+        );
+        assert_eq!(rows, (10..30u64).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn new_tree_from_initial_segment_populated_by_continuation() {
+        // The initial segment creates an empty subtree at the pause
+        // height (a root-level leftover op); the continuation writes into
+        // it. The continuation must find the pending empty Merk.
+        let grove_version = GroveVersion::latest();
+        let rows = assert_three_flows_agree(
+            make_test_grovedb,
+            vec![QualifiedGroveDbOp::insert_or_replace_op(
+                vec![],
+                b"fresh".to_vec(),
+                Element::empty_tree(),
+            )],
+            (0..5u64)
+                .map(|k| item_op(vec![b"fresh".to_vec()], k))
+                .collect(),
+            Some(BatchApplyOptions::default()),
+            |db, gv| present_keys(db, &[b"fresh"], gv),
+            grove_version,
+        );
+        assert_eq!(rows, (0..5u64).collect::<Vec<_>>());
+    }
+
+    fn count_child_op(cidx_path: Vec<Vec<u8>>, group: &[u8]) -> QualifiedGroveDbOp {
+        QualifiedGroveDbOp::insert_or_replace_op(
+            cidx_path,
+            group.to_vec(),
+            Element::empty_provable_count_tree(),
+        )
+    }
+
+    #[test]
+    fn new_pcit_from_initial_segment_populated_by_continuation() {
+        // The initial segment creates an EMPTY indexed tree under
+        // TEST_LEAF (its element is written into the cached TEST_LEAF
+        // Merk, nowhere in storage); the continuation adds a group and
+        // fills it. The continuation must find the primary AND open its
+        // secondaries from the in-batch element, then mirror the derived
+        // count.
+        let grove_version = GroveVersion::latest();
+        let cidx_path = vec![TEST_LEAF.to_vec(), b"cidx".to_vec()];
+        let mut second = vec![count_child_op(cidx_path.clone(), b"a")];
+        second.extend((0..3u64).map(|k| bump(b"cidx", b"a", k)));
+        let rows = assert_three_flows_agree(
+            make_test_grovedb,
+            vec![QualifiedGroveDbOp::insert_or_replace_op(
+                vec![TEST_LEAF.to_vec()],
+                b"cidx".to_vec(),
+                Element::empty_provable_count_indexed_tree(),
+            )],
+            second,
+            Some(BatchApplyOptions::default()),
+            |db, gv| top_k(db, b"cidx", gv),
+            grove_version,
+        );
+        assert_eq!(rows, vec![(3, b"a".to_vec())]);
+    }
+
+    #[test]
+    fn new_root_level_pcit_from_initial_segment_populated_by_continuation() {
+        // Same shape, but the indexed tree sits at the ROOT: its creating
+        // op is a root-level leftover the initial segment never executed,
+        // so the element exists only in that pending op.
+        let grove_version = GroveVersion::latest();
+        let cidx_path = vec![b"cidx".to_vec()];
+        let mut second = vec![count_child_op(cidx_path.clone(), b"a")];
+        second.extend((0..3u64).map(|k| item_op(vec![b"cidx".to_vec(), b"a".to_vec()], k)));
+        let rows = assert_three_flows_agree(
+            make_test_grovedb,
+            vec![QualifiedGroveDbOp::insert_or_replace_op(
+                vec![],
+                b"cidx".to_vec(),
+                Element::empty_provable_count_indexed_tree(),
+            )],
+            second,
+            Some(BatchApplyOptions::default()),
+            |db, gv| {
+                db.indexed_count_top_k([b"cidx"].as_ref(), 10, true, None, gv)
+                    .unwrap()
+                    .expect("top-k")
+                    .key_pairs()
+            },
+            grove_version,
+        );
+        assert_eq!(rows, vec![(3, b"a".to_vec())]);
+    }
+
+    // -----------------------------------------------------------------
+    // Cross-segment gate: shapes no cache can make coherent are refused
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn continuation_write_under_path_deleted_by_initial_segment_is_refused() {
+        let grove_version = GroveVersion::latest();
+        let db = two_group_pcit(grove_version);
+        let before = root_hash(&db, grove_version);
+
+        let result = apply_partial(
+            &db,
+            vec![QualifiedGroveDbOp::delete_tree_op(
+                vec![TEST_LEAF.to_vec(), b"cidx".to_vec()],
+                b"p".to_vec(),
+                TreeType::CountTree,
+                SubelementsDeletionBehavior::DeleteChildren,
+            )],
+            vec![bump(b"cidx", b"p", 7)],
+            Some(BatchApplyOptions::default()),
+            grove_version,
+        );
+        assert!(
+            matches!(result, Err(Error::InvalidBatchOperation(_))),
+            "{result:?}"
+        );
+        assert_untouched(&db, before, grove_version);
+    }
+
+    #[test]
+    fn continuation_delete_of_subtree_initial_segment_wrote_into_is_refused() {
+        let grove_version = GroveVersion::latest();
+        let db = two_group_pcit(grove_version);
+        let before = root_hash(&db, grove_version);
+
+        let result = apply_partial(
+            &db,
+            vec![bump(b"cidx", b"p", 2)],
+            vec![QualifiedGroveDbOp::delete_tree_op(
+                vec![TEST_LEAF.to_vec(), b"cidx".to_vec()],
+                b"p".to_vec(),
+                TreeType::CountTree,
+                SubelementsDeletionBehavior::DeleteChildren,
+            )],
+            Some(BatchApplyOptions::default()),
+            grove_version,
+        );
+        assert!(
+            matches!(result, Err(Error::InvalidBatchOperation(_))),
+            "{result:?}"
+        );
+        assert_untouched(&db, before, grove_version);
+    }
+
+    #[test]
+    fn continuation_replace_of_subtree_initial_segment_wrote_into_is_refused() {
+        let grove_version = GroveVersion::latest();
+        let db = two_group_pcit(grove_version);
+        let before = root_hash(&db, grove_version);
+
+        let result = apply_partial(
+            &db,
+            vec![bump(b"cidx", b"p", 2)],
+            vec![QualifiedGroveDbOp::insert_or_replace_op(
+                vec![TEST_LEAF.to_vec()],
+                b"cidx".to_vec(),
+                Element::empty_provable_count_indexed_tree(),
+            )],
+            Some(BatchApplyOptions::default()),
+            grove_version,
+        );
+        assert!(
+            matches!(result, Err(Error::InvalidBatchOperation(_))),
+            "{result:?}"
+        );
+        assert_untouched(&db, before, grove_version);
+    }
+
+    // -----------------------------------------------------------------
+    // Root metadata (pause height 0: the initial segment writes the base
+    // root key itself)
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn root_metadata_written_by_both_segments() {
+        let grove_version = GroveVersion::latest();
+        let options = Some(BatchApplyOptions {
+            batch_pause_height: Some(0),
+            ..Default::default()
+        });
+        let rows = assert_three_flows_agree(
+            make_test_grovedb,
+            (10..20u64).map(|k| item_op(vec![], k)).collect(),
+            (20..30u64).map(|k| item_op(vec![], k)).collect(),
+            options,
+            |db, gv| present_keys(db, &[], gv),
+            grove_version,
+        );
+        assert_eq!(rows, (10..30u64).collect::<Vec<_>>());
+    }
+
+    // -----------------------------------------------------------------
+    // Rollback: a failing continuation commits nothing
+    // -----------------------------------------------------------------
+
+    fn assert_untouched(db: &GroveDb, before: [u8; 32], grove_version: &GroveVersion) {
+        assert_eq!(root_hash(db, grove_version), before, "root hash changed");
+        assert_eq!(
+            top_k(db, b"cidx", grove_version),
+            vec![(2, b"q".to_vec()), (2, b"p".to_vec())],
+            "rows changed"
+        );
+        assert_verify_clean(db, grove_version);
+    }
+
+    #[test]
+    fn continuation_closure_error_commits_nothing() {
+        let grove_version = GroveVersion::latest();
+        let db = two_group_pcit(grove_version);
+        let before = root_hash(&db, grove_version);
+
+        let result = db
+            .apply_partial_batch(
+                vec![bump(b"cidx", b"p", 2)],
+                Some(BatchApplyOptions::default()),
+                |_cost, _left_over| Err(Error::InvalidInput("caller aborted")),
+                None,
+                grove_version,
+            )
+            .unwrap();
+        assert!(matches!(result, Err(Error::InvalidInput(_))), "{result:?}");
+        assert_untouched(&db, before, grove_version);
+    }
+
+    #[test]
+    fn continuation_apply_error_commits_nothing() {
+        // The add-on ops themselves fail mid-apply (a write under a path
+        // that does not exist): the initial segment must roll back too.
+        let grove_version = GroveVersion::latest();
+        let db = two_group_pcit(grove_version);
+        let before = root_hash(&db, grove_version);
+
+        let result = apply_partial(
+            &db,
+            vec![bump(b"cidx", b"p", 2)],
+            vec![item_op(vec![TEST_LEAF.to_vec(), b"missing".to_vec()], 1)],
+            Some(BatchApplyOptions::default()),
+            grove_version,
+        );
+        assert!(result.is_err(), "continuation must fail");
+        assert_untouched(&db, before, grove_version);
+    }
+
+    #[test]
+    fn continuation_error_inside_caller_transaction_leaves_it_clean() {
+        // With a caller-owned transaction the failed partial batch must
+        // not leave its initial segment staged in the transaction: the
+        // caller committing afterwards must commit nothing from it.
+        let grove_version = GroveVersion::latest();
+        let db = two_group_pcit(grove_version);
+        let before = root_hash(&db, grove_version);
+
+        let tx = db.start_transaction();
+        let result = db
+            .apply_partial_batch(
+                vec![bump(b"cidx", b"p", 2)],
+                Some(BatchApplyOptions::default()),
+                |_cost, _left_over| Err(Error::InvalidInput("caller aborted")),
+                Some(&tx),
+                grove_version,
+            )
+            .unwrap();
+        assert!(result.is_err());
+        assert_eq!(
+            db.root_hash(Some(&tx), grove_version).unwrap().unwrap(),
+            before,
+            "the transaction must not carry the initial segment"
+        );
+        db.commit_transaction(tx).unwrap().expect("commit");
+        assert_untouched(&db, before, grove_version);
+    }
+
+    #[test]
+    fn success_inside_caller_transaction_is_visible_only_after_commit() {
+        let grove_version = GroveVersion::latest();
+        let db = two_group_pcit(grove_version);
+        let before = root_hash(&db, grove_version);
+
+        let tx = db.start_transaction();
+        db.apply_partial_batch(
+            vec![bump(b"cidx", b"p", 2)],
+            Some(BatchApplyOptions::default()),
+            |_cost, _left_over| Ok(vec![bump(b"cidx", b"q", 2)]),
+            Some(&tx),
+            grove_version,
+        )
+        .unwrap()
+        .expect("partial batch applies");
+        assert_eq!(
+            root_hash(&db, grove_version),
+            before,
+            "nothing committed yet"
+        );
+        assert_eq!(
+            db.indexed_count_top_k(
+                [TEST_LEAF, b"cidx"].as_ref(),
+                10,
+                true,
+                Some(&tx),
+                grove_version
+            )
+            .unwrap()
+            .expect("top-k in tx")
+            .key_pairs(),
+            vec![(3, b"q".to_vec()), (3, b"p".to_vec())]
+        );
+        db.commit_transaction(tx).unwrap().expect("commit");
+        assert_eq!(
+            top_k(&db, b"cidx", grove_version),
+            vec![(3, b"q".to_vec()), (3, b"p".to_vec())]
+        );
+        assert_verify_clean(&db, grove_version);
+    }
+}

--- a/grovedb/src/tests/partial_batch_coherence_tests.rs
+++ b/grovedb/src/tests/partial_batch_coherence_tests.rs
@@ -1357,4 +1357,185 @@ mod tests {
         assert_eq!(root_hash(&db, gv), root_hash(&sequential, gv));
         assert_verify_clean(&db, gv);
     }
+
+    /// Fresh empty trees need the same rejection as trees with child writes,
+    /// before the deletion preflight attempts to read committed state.
+    #[test]
+    fn cross_segment_gate_rejects_deleting_or_overwriting_fresh_merk_tree() {
+        for gv in grovedb_version::version::GROVE_VERSIONS {
+            let path = vec![TEST_LEAF.to_vec()];
+            let key = b"fresh".to_vec();
+            let add_ons = [
+                QualifiedGroveDbOp::delete_tree_op(
+                    path.clone(),
+                    key.clone(),
+                    TreeType::NormalTree,
+                    SubelementsDeletionBehavior::Error,
+                ),
+                QualifiedGroveDbOp::delete_tree_op(
+                    path.clone(),
+                    key.clone(),
+                    TreeType::NormalTree,
+                    SubelementsDeletionBehavior::Skip,
+                ),
+                QualifiedGroveDbOp::delete_tree_op(
+                    path.clone(),
+                    key.clone(),
+                    TreeType::NormalTree,
+                    SubelementsDeletionBehavior::DeleteChildren,
+                ),
+                QualifiedGroveDbOp::insert_or_replace_op(
+                    path.clone(),
+                    key.clone(),
+                    Element::new_item(vec![9]),
+                ),
+            ];
+            for disable_operation_consistency_check in [false, true] {
+                for add_on in &add_ons {
+                    let db = ordinary_subtree(gv);
+                    let before = root_hash(&db, gv);
+                    let result = apply_partial(
+                        &db,
+                        vec![QualifiedGroveDbOp::insert_or_replace_op(
+                            path.clone(),
+                            key.clone(),
+                            Element::empty_tree(),
+                        )],
+                        vec![add_on.clone()],
+                        Some(BatchApplyOptions {
+                            disable_operation_consistency_check,
+                            ..Default::default()
+                        }),
+                        gv,
+                    );
+                    assert!(
+                        matches!(result, Err(Error::InvalidBatchOperation(_))),
+                        "{result:?}"
+                    );
+                    assert_eq!(root_hash(&db, gv), before);
+                    assert!(db
+                        .get([TEST_LEAF].as_ref(), b"fresh", None, gv)
+                        .unwrap()
+                        .is_err());
+                    assert_verify_clean(&db, gv);
+                }
+            }
+        }
+    }
+
+    /// Disabling per-segment checks must not permit cleanup or overwrites
+    /// that strand the other segment's pending data.
+    #[test]
+    fn cross_segment_gate_cannot_be_disabled() {
+        let gv = GroveVersion::latest();
+        let sub_path = vec![TEST_LEAF.to_vec(), b"sub".to_vec()];
+        let mmr_path = vec![TEST_LEAF.to_vec(), b"mmr".to_vec()];
+        let cases = [
+            (
+                item_op(sub_path.clone(), 20),
+                QualifiedGroveDbOp::insert_or_replace_op(
+                    vec![TEST_LEAF.to_vec()],
+                    b"sub".to_vec(),
+                    Element::new_item(vec![9]),
+                ),
+            ),
+            (
+                QualifiedGroveDbOp::delete_tree_op(
+                    vec![TEST_LEAF.to_vec()],
+                    b"sub".to_vec(),
+                    TreeType::NormalTree,
+                    SubelementsDeletionBehavior::DeleteChildren,
+                ),
+                item_op(sub_path.clone(), 20),
+            ),
+            (
+                item_op(sub_path, 20),
+                QualifiedGroveDbOp::delete_tree_op(
+                    vec![TEST_LEAF.to_vec()],
+                    b"sub".to_vec(),
+                    TreeType::NormalTree,
+                    SubelementsDeletionBehavior::DeleteChildren,
+                ),
+            ),
+            (
+                QualifiedGroveDbOp::mmr_tree_append_op(mmr_path.clone(), b"a".to_vec()),
+                QualifiedGroveDbOp::mmr_tree_append_op(mmr_path, b"b".to_vec()),
+            ),
+        ];
+        for (first, second) in cases {
+            let db = ordinary_subtree_with_mmr(gv);
+            let before = root_hash(&db, gv);
+            let result = apply_partial(
+                &db,
+                vec![first],
+                vec![second],
+                Some(BatchApplyOptions {
+                    disable_operation_consistency_check: true,
+                    ..Default::default()
+                }),
+                gv,
+            );
+            assert!(
+                matches!(result, Err(Error::InvalidBatchOperation(_))),
+                "{result:?}"
+            );
+            assert_eq!(root_hash(&db, gv), before);
+            assert_eq!(
+                present_keys(&db, &[TEST_LEAF, b"sub"], gv),
+                (0..8u64).collect::<Vec<_>>()
+            );
+            assert_eq!(
+                db.mmr_tree_leaf_count([TEST_LEAF].as_ref(), b"mmr", None, gv)
+                    .unwrap()
+                    .unwrap(),
+                0
+            );
+            assert_verify_clean(&db, gv);
+        }
+    }
+
+    /// A skipped tree insertion did not create pending state at the target
+    /// and must not prevent the continuation from deleting the stored tree.
+    #[test]
+    fn cross_segment_gate_excludes_skipped_tree_insertions() {
+        for gv in grovedb_version::version::GROVE_VERSIONS {
+            let db = ordinary_subtree(gv);
+            db.insert(
+                [TEST_LEAF].as_ref(),
+                b"empty",
+                Element::empty_tree(),
+                None,
+                None,
+                gv,
+            )
+            .unwrap()
+            .unwrap();
+            apply_partial(
+                &db,
+                vec![QualifiedGroveDbOp::insert_if_not_exists_or_skip_op(
+                    vec![TEST_LEAF.to_vec()],
+                    b"empty".to_vec(),
+                    Element::empty_tree(),
+                )],
+                vec![QualifiedGroveDbOp::delete_tree_op(
+                    vec![TEST_LEAF.to_vec()],
+                    b"empty".to_vec(),
+                    TreeType::NormalTree,
+                    SubelementsDeletionBehavior::Error,
+                )],
+                None,
+                gv,
+            )
+            .unwrap();
+            assert!(db
+                .get([TEST_LEAF].as_ref(), b"empty", None, gv)
+                .unwrap()
+                .is_err());
+            assert_eq!(
+                present_keys(&db, &[TEST_LEAF, b"sub"], gv),
+                (0..8u64).collect::<Vec<_>>()
+            );
+            assert_verify_clean(&db, gv);
+        }
+    }
 }

--- a/grovedb/src/tests/partial_batch_coherence_tests.rs
+++ b/grovedb/src/tests/partial_batch_coherence_tests.rs
@@ -562,6 +562,29 @@ mod tests {
         assert_untouched(&db, before, grove_version);
     }
 
+    #[test]
+    fn continuation_overwrite_of_committed_pcit_with_empty_one_cleans_up() {
+        // Add-on ops get the indexed-overwrite preflight too. Overwriting
+        // a committed, populated indexed tree with an EMPTY one is the
+        // safe-subset overwrite it allows (the old primary subtrees and
+        // secondaries are swept at commit), so the partial flow must land
+        // on the same clean, empty tree as the other flows.
+        let grove_version = GroveVersion::latest();
+        let rows = assert_three_flows_agree(
+            two_group_pcit,
+            vec![item_op(vec![TEST_LEAF.to_vec()], 1)],
+            vec![QualifiedGroveDbOp::insert_or_replace_op(
+                vec![TEST_LEAF.to_vec()],
+                b"cidx".to_vec(),
+                Element::empty_provable_count_indexed_tree(),
+            )],
+            Some(BatchApplyOptions::default()),
+            |db, gv| top_k(db, b"cidx", gv),
+            grove_version,
+        );
+        assert!(rows.is_empty(), "{rows:?}");
+    }
+
     // -----------------------------------------------------------------
     // Root metadata (pause height 0: the initial segment writes the base
     // root key itself)

--- a/grovedb/src/tests/partial_batch_coherence_tests.rs
+++ b/grovedb/src/tests/partial_batch_coherence_tests.rs
@@ -1205,4 +1205,156 @@ mod tests {
         );
         assert_verify_clean(&db, grove_version);
     }
+
+    // Skipped conditional inserts must carry neither their proposed value
+    // nor an empty subtree placeholder across the segment boundary.
+    #[test]
+    fn skipped_tree_insertion_preserves_existing_children() {
+        for gv in grovedb_version::version::GROVE_VERSIONS {
+            for proposed_tree in [Element::empty_tree(), Element::empty_sum_tree()] {
+                for pause_height in [0, 1] {
+                    let db = ordinary_subtree(gv);
+                    let sequential = ordinary_subtree(gv);
+                    let first = vec![QualifiedGroveDbOp::insert_if_not_exists_or_skip_op(
+                        vec![TEST_LEAF.to_vec()],
+                        b"sub".to_vec(),
+                        proposed_tree.clone(),
+                    )];
+                    let second = vec![item_op(vec![TEST_LEAF.to_vec(), b"sub".to_vec()], 20)];
+                    sequential
+                        .apply_batch(first.clone(), None, None, gv)
+                        .unwrap()
+                        .unwrap();
+                    sequential
+                        .apply_batch(second.clone(), None, None, gv)
+                        .unwrap()
+                        .unwrap();
+                    let options = BatchApplyOptions {
+                        batch_pause_height: Some(pause_height),
+                        ..Default::default()
+                    };
+                    apply_partial(&db, first, second, Some(options), gv)
+                        .expect("skipped creation followed by child insertion should succeed");
+                    let mut expected: Vec<u64> = (0..8).collect();
+                    expected.push(20);
+                    assert_eq!(present_keys(&db, &[TEST_LEAF, b"sub"], gv), expected);
+                    assert_eq!(root_hash(&db, gv), root_hash(&sequential, gv));
+                    assert_verify_clean(&db, gv);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn continuation_reference_to_conditional_item_uses_actual_value() {
+        for gv in grovedb_version::version::GROVE_VERSIONS {
+            // The existing key skips the proposed value; the missing key
+            // really inserts it. Both must resolve to the final stored value.
+            for (key, expected_value) in [(0u64, 0), (20, 99)] {
+                for pause_height in [0, 1] {
+                    let db = ordinary_subtree(gv);
+                    let first = vec![QualifiedGroveDbOp::insert_if_not_exists_or_skip_op(
+                        vec![TEST_LEAF.to_vec(), b"sub".to_vec()],
+                        key.to_be_bytes().to_vec(),
+                        Element::new_item(vec![99]),
+                    )];
+                    let second = vec![reference_op_to(
+                        vec![TEST_LEAF.to_vec()],
+                        b"ref",
+                        vec![
+                            TEST_LEAF.to_vec(),
+                            b"sub".to_vec(),
+                            key.to_be_bytes().to_vec(),
+                        ],
+                    )];
+                    let options = BatchApplyOptions {
+                        batch_pause_height: Some(pause_height),
+                        ..Default::default()
+                    };
+                    apply_partial(&db, first, second, Some(options), gv)
+                        .expect("reference to conditional insertion should succeed");
+                    assert_eq!(
+                        db.get([TEST_LEAF].as_ref(), b"ref", None, gv)
+                            .unwrap()
+                            .unwrap(),
+                        Element::new_item(vec![expected_value])
+                    );
+                    assert_verify_clean(&db, gv);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn continuation_reference_to_skipped_reference_uses_stored_target() {
+        let gv = GroveVersion::latest();
+        let db = ordinary_subtree(gv);
+        let target = |key: u64| {
+            vec![
+                TEST_LEAF.to_vec(),
+                b"sub".to_vec(),
+                key.to_be_bytes().to_vec(),
+            ]
+        };
+        db.insert(
+            [TEST_LEAF, b"sub"].as_ref(),
+            b"existing_ref",
+            Element::new_reference(ReferencePathType::AbsolutePathReference(target(0))),
+            None,
+            None,
+            gv,
+        )
+        .unwrap()
+        .unwrap();
+        let first = vec![QualifiedGroveDbOp::insert_if_not_exists_or_skip_op(
+            vec![TEST_LEAF.to_vec(), b"sub".to_vec()],
+            b"existing_ref".to_vec(),
+            Element::new_reference(ReferencePathType::AbsolutePathReference(target(1))),
+        )];
+        let second = vec![reference_op_to(
+            vec![TEST_LEAF.to_vec()],
+            b"ref",
+            vec![
+                TEST_LEAF.to_vec(),
+                b"sub".to_vec(),
+                b"existing_ref".to_vec(),
+            ],
+        )];
+        apply_partial(&db, first, second, None, gv).unwrap();
+        assert_eq!(
+            db.get([TEST_LEAF].as_ref(), b"ref", None, gv)
+                .unwrap()
+                .unwrap(),
+            Element::new_item(vec![0])
+        );
+        assert_verify_clean(&db, gv);
+    }
+
+    #[test]
+    fn skipped_indexed_tree_insertion_preserves_primary_and_secondary() {
+        let gv = GroveVersion::latest();
+        let db = two_group_pcit(gv);
+        let sequential = two_group_pcit(gv);
+        let first = vec![QualifiedGroveDbOp::insert_if_not_exists_or_skip_op(
+            vec![TEST_LEAF.to_vec()],
+            b"cidx".to_vec(),
+            Element::empty_provable_count_indexed_tree(),
+        )];
+        let second = vec![bump(b"cidx", b"p", 2)];
+        sequential
+            .apply_batch(first.clone(), None, None, gv)
+            .unwrap()
+            .unwrap();
+        sequential
+            .apply_batch(second.clone(), None, None, gv)
+            .unwrap()
+            .unwrap();
+        apply_partial(&db, first, second, None, gv).unwrap();
+        assert_eq!(
+            top_k(&db, b"cidx", gv),
+            vec![(3, b"p".to_vec()), (2, b"q".to_vec())]
+        );
+        assert_eq!(root_hash(&db, gv), root_hash(&sequential, gv));
+        assert_verify_clean(&db, gv);
+    }
 }

--- a/grovedb/src/tests/partial_batch_coherence_tests.rs
+++ b/grovedb/src/tests/partial_batch_coherence_tests.rs
@@ -21,6 +21,7 @@ mod tests {
 
     use crate::{
         batch::{BatchApplyOptions, QualifiedGroveDbOp, SubelementsDeletionBehavior},
+        reference_path::ReferencePathType,
         tests::{make_test_grovedb, TempGroveDb, TEST_LEAF},
         Element, Error, GroveDb, IndexedAxisEntrySliceExt,
     };
@@ -727,6 +728,392 @@ mod tests {
         assert_eq!(
             top_k(&db, b"cidx", grove_version),
             vec![(3, b"q".to_vec()), (3, b"p".to_vec())]
+        );
+        assert_verify_clean(&db, grove_version);
+    }
+
+    // -----------------------------------------------------------------
+    // Cross-segment gate: overwrites are refused whatever the new element
+    // is — a plain item over a written-into subtree orphans its pending
+    // child writes just like a fresh tree would
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn continuation_nontree_overwrite_of_subtree_initial_segment_wrote_into_is_refused() {
+        let grove_version = GroveVersion::latest();
+        let db = two_group_pcit(grove_version);
+        let before = root_hash(&db, grove_version);
+
+        let result = apply_partial(
+            &db,
+            vec![bump(b"cidx", b"p", 2)],
+            vec![QualifiedGroveDbOp::insert_or_replace_op(
+                vec![TEST_LEAF.to_vec()],
+                b"cidx".to_vec(),
+                Element::new_item(vec![]),
+            )],
+            Some(BatchApplyOptions::default()),
+            grove_version,
+        );
+        assert!(
+            matches!(result, Err(Error::InvalidBatchOperation(_))),
+            "{result:?}"
+        );
+        assert_untouched(&db, before, grove_version);
+    }
+
+    // -----------------------------------------------------------------
+    // Ordinary apply_batch has no continuation, so it must not pause
+    // (issue #889: it used to commit the paused result and silently
+    // discard the leftover ancestor propagation ops)
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn ordinary_batch_with_nonzero_pause_height_is_refused() {
+        let grove_version = GroveVersion::latest();
+        let db = two_group_pcit(grove_version);
+        let before = root_hash(&db, grove_version);
+
+        let result = db
+            .apply_batch(
+                vec![bump(b"cidx", b"p", 2)],
+                Some(BatchApplyOptions {
+                    batch_pause_height: Some(1),
+                    ..Default::default()
+                }),
+                None,
+                grove_version,
+            )
+            .unwrap();
+        assert!(
+            matches!(result, Err(Error::InvalidBatchOperation(_))),
+            "{result:?}"
+        );
+        assert_untouched(&db, before, grove_version);
+    }
+
+    // -----------------------------------------------------------------
+    // Add-on DeleteTree ops get the SubelementsDeletionBehavior preflight
+    // (issue #709): the Error emptiness check, Skip filtering, and the
+    // descendant storage cleanup all apply to the continuation too
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn continuation_delete_tree_error_behavior_on_nonempty_tree_is_refused() {
+        let grove_version = GroveVersion::latest();
+        let db = ordinary_subtree(grove_version);
+        let before = root_hash(&db, grove_version);
+
+        let result = apply_partial(
+            &db,
+            vec![item_op(vec![TEST_LEAF.to_vec()], 10)],
+            vec![QualifiedGroveDbOp::delete_tree_op(
+                vec![TEST_LEAF.to_vec()],
+                b"sub".to_vec(),
+                TreeType::NormalTree,
+                SubelementsDeletionBehavior::Error,
+            )],
+            Some(BatchApplyOptions::default()),
+            grove_version,
+        );
+        assert!(
+            matches!(result, Err(Error::DeletingNonEmptyTree(_))),
+            "{result:?}"
+        );
+        assert_eq!(root_hash(&db, grove_version), before, "root hash changed");
+        assert_eq!(
+            present_keys(&db, &[TEST_LEAF, b"sub"], grove_version),
+            (0..8u64).collect::<Vec<_>>(),
+            "the non-empty tree must survive intact"
+        );
+        assert_verify_clean(&db, grove_version);
+    }
+
+    #[test]
+    fn continuation_delete_tree_skip_behavior_on_nonempty_tree_skips() {
+        // A Skip DeleteTree in the continuation of a non-empty tree is
+        // filtered out, exactly like in the initial segment: the tree
+        // survives and the rest of the continuation still applies.
+        let grove_version = GroveVersion::latest();
+        let rows = assert_three_flows_agree(
+            ordinary_subtree,
+            vec![item_op(vec![TEST_LEAF.to_vec()], 10)],
+            vec![
+                QualifiedGroveDbOp::delete_tree_op(
+                    vec![TEST_LEAF.to_vec()],
+                    b"sub".to_vec(),
+                    TreeType::NormalTree,
+                    SubelementsDeletionBehavior::Skip,
+                ),
+                item_op(vec![TEST_LEAF.to_vec()], 11),
+            ],
+            Some(BatchApplyOptions::default()),
+            |db, gv| {
+                (
+                    present_keys(db, &[TEST_LEAF, b"sub"], gv),
+                    present_keys(db, &[TEST_LEAF], gv),
+                )
+            },
+            grove_version,
+        );
+        assert_eq!(rows, ((0..8u64).collect::<Vec<_>>(), vec![10, 11]));
+    }
+
+    #[test]
+    fn continuation_delete_tree_delete_children_cleans_descendants() {
+        let grove_version = GroveVersion::latest();
+        let rows = assert_three_flows_agree(
+            ordinary_subtree,
+            vec![item_op(vec![TEST_LEAF.to_vec()], 10)],
+            vec![QualifiedGroveDbOp::delete_tree_op(
+                vec![TEST_LEAF.to_vec()],
+                b"sub".to_vec(),
+                TreeType::NormalTree,
+                SubelementsDeletionBehavior::DeleteChildren,
+            )],
+            Some(BatchApplyOptions::default()),
+            |db, gv| {
+                (
+                    db.get_raw([TEST_LEAF].as_ref().into(), b"sub", None, gv)
+                        .unwrap()
+                        .is_ok(),
+                    present_keys(db, &[TEST_LEAF], gv),
+                )
+            },
+            grove_version,
+        );
+        assert_eq!(rows, (false, vec![10]));
+    }
+
+    #[test]
+    fn continuation_delete_tree_delete_children_reinsert_produces_clean_tree() {
+        // Pin the descendant STORAGE cleanup the behavior map drives: after
+        // the continuation's DeleteChildren, re-creating the same tree must
+        // produce a genuinely empty one with none of the old rows.
+        let grove_version = GroveVersion::latest();
+        let db = ordinary_subtree(grove_version);
+
+        apply_partial(
+            &db,
+            vec![item_op(vec![TEST_LEAF.to_vec()], 10)],
+            vec![QualifiedGroveDbOp::delete_tree_op(
+                vec![TEST_LEAF.to_vec()],
+                b"sub".to_vec(),
+                TreeType::NormalTree,
+                SubelementsDeletionBehavior::DeleteChildren,
+            )],
+            Some(BatchApplyOptions::default()),
+            grove_version,
+        )
+        .expect("partial batch applies");
+
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"sub",
+            Element::empty_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("re-insert tree at the same path");
+        assert!(
+            present_keys(&db, &[TEST_LEAF, b"sub"], grove_version).is_empty(),
+            "old rows must not survive into the re-created tree"
+        );
+        assert_verify_clean(&db, grove_version);
+    }
+
+    // -----------------------------------------------------------------
+    // Add-on typed appends are preprocessed like the initial segment's
+    // (issue #895: they used to be silently dropped), and appends whose
+    // target the initial segment wrote are refused — their preprocessing
+    // reads committed state no cache can make coherent
+    // -----------------------------------------------------------------
+
+    fn ordinary_subtree_with_mmr(grove_version: &GroveVersion) -> TempGroveDb {
+        let db = ordinary_subtree(grove_version);
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"mmr",
+            Element::empty_mmr_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert mmr tree");
+        db
+    }
+
+    #[test]
+    fn continuation_typed_append_is_executed() {
+        let grove_version = GroveVersion::latest();
+        let rows = assert_three_flows_agree(
+            ordinary_subtree_with_mmr,
+            vec![item_op(vec![TEST_LEAF.to_vec()], 10)],
+            vec![QualifiedGroveDbOp::mmr_tree_append_op(
+                vec![TEST_LEAF.to_vec(), b"mmr".to_vec()],
+                b"leaf-0".to_vec(),
+            )],
+            Some(BatchApplyOptions::default()),
+            |db, gv| {
+                (
+                    db.mmr_tree_leaf_count([TEST_LEAF].as_ref(), b"mmr", None, gv)
+                        .unwrap()
+                        .expect("leaf count"),
+                    db.mmr_tree_get_value([TEST_LEAF].as_ref(), b"mmr", 0, None, gv)
+                        .unwrap()
+                        .expect("leaf value"),
+                )
+            },
+            grove_version,
+        );
+        assert_eq!(rows, (1, Some(b"leaf-0".to_vec())));
+    }
+
+    #[test]
+    fn continuation_typed_append_to_tree_initial_segment_appended_is_refused() {
+        let grove_version = GroveVersion::latest();
+        let db = ordinary_subtree_with_mmr(grove_version);
+        let before = root_hash(&db, grove_version);
+
+        let result = apply_partial(
+            &db,
+            vec![QualifiedGroveDbOp::mmr_tree_append_op(
+                vec![TEST_LEAF.to_vec(), b"mmr".to_vec()],
+                b"a".to_vec(),
+            )],
+            vec![QualifiedGroveDbOp::mmr_tree_append_op(
+                vec![TEST_LEAF.to_vec(), b"mmr".to_vec()],
+                b"b".to_vec(),
+            )],
+            Some(BatchApplyOptions::default()),
+            grove_version,
+        );
+        assert!(
+            matches!(result, Err(Error::InvalidBatchOperation(_))),
+            "{result:?}"
+        );
+        assert_eq!(root_hash(&db, grove_version), before, "root hash changed");
+        assert_eq!(
+            db.mmr_tree_leaf_count([TEST_LEAF].as_ref(), b"mmr", None, grove_version)
+                .unwrap()
+                .expect("leaf count"),
+            0,
+            "neither append may land"
+        );
+        assert_verify_clean(&db, grove_version);
+    }
+
+    #[test]
+    fn continuation_delete_of_non_merk_tree_initial_segment_appended_to_is_refused() {
+        let grove_version = GroveVersion::latest();
+        let db = ordinary_subtree_with_mmr(grove_version);
+        let before = root_hash(&db, grove_version);
+
+        let result = apply_partial(
+            &db,
+            vec![QualifiedGroveDbOp::mmr_tree_append_op(
+                vec![TEST_LEAF.to_vec(), b"mmr".to_vec()],
+                b"a".to_vec(),
+            )],
+            vec![QualifiedGroveDbOp::delete_op(
+                vec![TEST_LEAF.to_vec()],
+                b"mmr".to_vec(),
+            )],
+            Some(BatchApplyOptions::default()),
+            grove_version,
+        );
+        assert!(
+            matches!(result, Err(Error::InvalidBatchOperation(_))),
+            "{result:?}"
+        );
+        assert_eq!(root_hash(&db, grove_version), before, "root hash changed");
+        assert_verify_clean(&db, grove_version);
+    }
+
+    // -----------------------------------------------------------------
+    // Add-on reference ops resolve targets the initial segment wrote the
+    // way one combined batch would: through the segment's in-batch op
+    // -----------------------------------------------------------------
+
+    fn reference_op_to(path: Vec<Vec<u8>>, key: &[u8], target: Vec<Vec<u8>>) -> QualifiedGroveDbOp {
+        QualifiedGroveDbOp::insert_or_replace_op(
+            path,
+            key.to_vec(),
+            Element::new_reference(ReferencePathType::AbsolutePathReference(target)),
+        )
+    }
+
+    #[test]
+    fn continuation_reference_to_item_rewritten_by_initial_segment() {
+        // The initial segment rewrites `sub/0`; the continuation inserts a
+        // reference to it. The reference must commit to the segment's NEW
+        // value, exactly as a combined batch would.
+        let grove_version = GroveVersion::latest();
+        let sub = vec![TEST_LEAF.to_vec(), b"sub".to_vec()];
+        let target = vec![
+            TEST_LEAF.to_vec(),
+            b"sub".to_vec(),
+            0u64.to_be_bytes().to_vec(),
+        ];
+        let rows = assert_three_flows_agree(
+            ordinary_subtree,
+            vec![QualifiedGroveDbOp::insert_or_replace_op(
+                sub,
+                0u64.to_be_bytes().to_vec(),
+                Element::new_item(vec![9]),
+            )],
+            vec![reference_op_to(
+                vec![TEST_LEAF.to_vec()],
+                b"ref",
+                target.clone(),
+            )],
+            Some(BatchApplyOptions::default()),
+            |db, gv| {
+                db.get([TEST_LEAF].as_ref(), b"ref", None, gv)
+                    .unwrap()
+                    .expect("follow reference")
+            },
+            grove_version,
+        );
+        assert_eq!(rows, Element::new_item(vec![9]));
+    }
+
+    #[test]
+    fn continuation_reference_to_item_deleted_by_initial_segment_fails() {
+        // The reference target was deleted by the initial segment: the
+        // continuation must fail (as one combined batch would) and commit
+        // nothing.
+        let grove_version = GroveVersion::latest();
+        let db = ordinary_subtree(grove_version);
+        let before = root_hash(&db, grove_version);
+
+        let result = apply_partial(
+            &db,
+            vec![QualifiedGroveDbOp::delete_op(
+                vec![TEST_LEAF.to_vec(), b"sub".to_vec()],
+                0u64.to_be_bytes().to_vec(),
+            )],
+            vec![reference_op_to(
+                vec![TEST_LEAF.to_vec()],
+                b"ref",
+                vec![
+                    TEST_LEAF.to_vec(),
+                    b"sub".to_vec(),
+                    0u64.to_be_bytes().to_vec(),
+                ],
+            )],
+            Some(BatchApplyOptions::default()),
+            grove_version,
+        );
+        assert!(result.is_err(), "reference to a deleted target must fail");
+        assert_eq!(root_hash(&db, grove_version), before, "root hash changed");
+        assert_eq!(
+            present_keys(&db, &[TEST_LEAF, b"sub"], grove_version),
+            (0..8u64).collect::<Vec<_>>(),
+            "the failed partial batch must not commit its delete"
         );
         assert_verify_clean(&db, grove_version);
     }

--- a/storage/src/storage.rs
+++ b/storage/src/storage.rs
@@ -412,6 +412,21 @@ impl StorageBatch {
         self.len() == 0
     }
 
+    /// Move every pending operation out into a new batch, leaving this one
+    /// empty but alive.
+    ///
+    /// Storage contexts hold a shared reference to the batch they write
+    /// into, so a batch cannot be consumed while any of them is still open.
+    /// A caller that needs to flush part-way (the partial batch apply
+    /// reports the initial segment's pending cost to its caller before the
+    /// continuation runs) drains the batch here and keeps writing into the
+    /// same object afterwards.
+    pub fn take_pending(&self) -> StorageBatch {
+        StorageBatch {
+            operations: RefCell::new(std::mem::take(&mut *self.operations.borrow_mut())),
+        }
+    }
+
     /// Add deferred `put` operation
     pub(crate) fn put(
         &self,


### PR DESCRIPTION
Fixes #842 (September 2026 audit group M006). Also fixes #709 (M008), #895 (M017) and #889 (M010): with the coherence fix in place, this PR builds out the rest of the partial-batch machinery so the add-on path enforces the same contracts as the initial batch.

## Problem

`apply_partial_batch` ran its continuation against a **second** storage batch whose Merks were opened over committed state. Segment 1's pending node writes, row deletes and root keys were invisible to it:

- A continuation that rebalanced the same indexed secondary re-wrote nodes segment 1 had deleted. The old `(count ‖ key)` mirror row came back and `verify_grovedb` returned a hard `Err` (the issue's reproduction).
- Any Merk **at the pause height** was reopened at its committed root key, because the new one exists only in segment 1's leftover propagation op. This is why even the "disjoint secondaries" case was broken: two PCITs under the same `TEST_LEAF` share that pause-level Merk.
- With pause height 0, the root Merk itself was reopened stale.

Beyond coherence, the add-on path was never built out to the initial batch's contracts:

- **#709 / M008** — add-on `DeleteTree` ops skipped the `SubelementsDeletionBehavior` preflight entirely: `Error` didn't error, `Skip` didn't skip, and no cleanup paths were collected, so descendant storage survived the delete.
- **#895 / M017** — add-on typed appends (`CommitmentTreeInsert`, `MmrTreeAppend`, `BulkAppend`, `DenseTreeInsert`, `PrivateDocumentStoreInsert`) bypassed preprocessing; being keyless they were then silently dropped by batch construction, so a "successful" partial batch simply didn't perform them.
- **#889 / M010** — the ordinary `apply_batch*` entry points accepted `batch_pause_height`, applied up to the pause, committed the paused result and silently discarded the leftover ancestor propagation ops.
- Add-on reference ops resolved targets through committed state instead of segment 1's in-batch ops.

## Fix

### Coherence (issue #842)

Both segments now run against **one** storage batch and segment 1's **live `TreeCacheMerkByPath`**, which is what the audit asked for ("retain the first segment's live caches"):

- `apply_batch_structure` / `apply_body` hand the cache back; `continue_partial_apply_body` takes it instead of fresh opener closures.
- The cache now also holds each indexed primary's **secondary Merks**, so the continuation mirrors into the very Merks segment 1 moved rows in.
- The cache **remembers in-batch indexed elements** (`remember_indexed_element`, a default no-op on the `TreeCache` trait), so a continuation can populate an indexed tree segment 1 created, whose element is only pending.
- `StorageBatch::take_pending` drains segment 1's writes into the write batch (to report their cost to the add-on closure) without consuming the batch the cached Merks keep writing into.
- Conditional inserts that segment 1 skipped are excluded from the continuation's reference map and pending indexed-element metadata. Unused empty Merk placeholders reserved for those attempted tree inserts are discarded; live Merks with applied operations are retained. This preserves existing children and makes references commit to the actual stored value, with no additional existence reads.
- Nothing reaches the transaction before the single final commit, so a failing continuation (closure `Err`, or an add-on op failing mid-apply) still leaves the transaction untouched. This is why I did **not** stage segment 1 into the transaction behind a savepoint: the RocksDB C API has no pop-savepoint, so a leftover savepoint would corrupt a caller's own savepoint stack.

### Add-on ops get the initial batch's contracts

- **DeleteTree preflight (#709):** `scan_delete_tree_ops` now also runs on the add-on ops — the `Error` emptiness check refuses, `Skip` filters the op out, and the cleanup paths / behavior map feed the same post-apply storage sweeps as the initial segment's deletes (`DeleteChildren` clears descendant storage, indexed primaries queue the all-axis secondary sweep, V4 actual-type classification covers add-on paths).
- **Typed appends (#895):** the five preprocessing passes now also run on the add-on ops, so callback appends execute instead of being dropped. Preprocessing reads committed state, so the cross-segment gate (below) refuses appends whose target tree segment 1 appended into, created, replaced, or deleted — the one shape no cache can make coherent, since append preprocessing reads storage rather than Merks.
- **References:** `apply_batch_structure` hands back segment 1's `ops_by_qualified_paths` and the continuation seeds its own map with it, so an add-on reference to a target segment 1 wrote resolves in-batch — committing to the segment's new value exactly as one combined batch would, and failing cleanly on a target segment 1 deleted.

### Ordinary batch may not pause (#889)

`apply_batch_with_element_flags_update` refuses a **nonzero** `batch_pause_height` with `InvalidBatchOperation` before any work: it has no continuation, so pausing committed a partial application and silently dropped the leftover ancestor ops. A pause height of 0 stays accepted — level 0 is processed (base root key included) before the pause check fires, so it is complete propagation. The estimated-cost paths are untouched (replay-critical, and they commit nothing).

### Fail-closed gate for the shapes no cache can make coherent

Refused with `InvalidBatchOperation` before the continuation applies. These checks are mandatory: `disable_operation_consistency_check` controls only per-segment validation, and cannot bypass safeguards between segments:

- add-on ops writing under a path segment 1 deleted;
- add-on ops replacing or deleting a subtree segment 1 wrote into — now **regardless of the new element's type** (CodeRabbit's review finding): overwriting a written-into subtree with a plain item orphans segment 1's pending child writes just like a fresh tree would;
- add-on deletes or overwrites of a Merk tree segment 1 created or replaced, including empty trees with no child writes; these are rejected before committed-state deletion preflight. The footprint is built after initial execution and excludes conditional inserts that were skipped;
- add-on typed appends targeting, and add-on deletes/overwrites of, a non-Merk tree segment 1 appended into, created, or replaced;
- add-on ops writing under an indexed primary segment 1 safe-subset-**overwrote**: the old element's storage (primary subtree + secondary namespaces) is swept at commit, which would clear the new writes — the exact shape one combined batch already refuses with `NotSupported` in `reject_indexed_overwrite_with_descendants`, now refused across segments too (keyed off segment 1's `cidx_overwrite_cleanup_paths` captures).

Add-on ops also get the same `reject_indexed_overwrite_with_descendants` preflight as the initial batch.

### Version gating

None. `apply_partial_batch` is not used by Platform, and every outcome this changes was previously corrupt (orphan rows), silently dropped (typed appends), or already erroring. The one change to an ordinary-batch entry point (#889) only affects callers that set a nonzero `batch_pause_height` — a shape that previously committed a partial application, which Platform never does; flagging this explicitly for review.

## Tests

`grovedb/src/tests/partial_batch_coherence_tests.rs` (40 tests). Core coherence cases compare one combined `apply_batch`, two sequential `apply_batch` calls, and one `apply_partial_batch`: identical rows across all three, the partial flow's root hash equal to the sequential flow's, and `verify_grovedb` clean. Additional cases check errors, rollback, and conditional-insert outcomes.

Covered: the issue's reproduction, same group re-keyed twice, disjoint secondaries, primary-row delete then continuation insert into the same group, group delete then continuation into the sibling group, ordinary subtree shared between segments, the pause-level Merk shared between segments, a tree created by segment 1 and populated by the continuation (ordinary, PCIT under a leaf, PCIT at the root), root metadata with pause height 0, rollback on closure error and on apply error (owned and caller-provided transaction), success visible only after the caller commits, and the refused shapes (including the non-tree overwrite).

New for the build-out: add-on `DeleteTree` with `Error` refused on a non-empty tree, `Skip` filtered with the rest of the continuation still applying, `DeleteChildren` cleaning descendant storage (re-insert produces a genuinely clean tree); an add-on MMR append executing and matching the sequential flow; add-on appends to (and deletes of) a segment-1-written non-Merk tree refused; an add-on reference committing to the value segment 1 wrote; an add-on reference to a segment-1-deleted target failing with nothing committed; ordinary `apply_batch` refusing a nonzero pause height; a segment-1 indexed overwrite followed by a continuation write under it refused in parity with the combined flow's `NotSupported` (nothing committed); an indexed tree created via `InsertIfNotExists` in segment 1 and populated by the continuation; and the `Replace`-op variant of the safe-subset overwrite from a continuation, sweeping the old rows.

Regression coverage for skipped conditional inserts includes ordinary-tree preservation (including a different proposed tree type), skipped and successful item insertions followed by references, a skipped reference replacement followed by another reference, and indexed-tree preservation across primary and secondary updates. The ordinary-tree and item-reference cases run across GroveDB versions 1–4 and pause heights 0 and 1. The two original skipped-insert reproductions failed on the previous PR head and pass with the fix.

Review follow-up coverage checks rejection of deletes/overwrites of freshly created empty Merk trees across versions 1–4, rejects conflicting writes/deletes/typed appends even with per-segment checks disabled, and preserves deletion of an existing tree after a skipped conditional insertion. Mixed-batch backward-reference rejection tests also verify that preceding valid writes remain uncommitted in ordinary batches, initial partial segments, and continuations.

Before the fix, 10 of the 13 original state/rollback cases failed on `develop`, including the issue's reproduction. The older `partial_batch_combines_both_segments_churn` cost test now also asserts the end state.

`cargo test -p grovedb --all-features`, `cargo test -p grovedb-storage`, `cargo fmt --check`, `cargo clippy --workspace --all-features -- -D warnings` all clean.

## Remaining limits (unchanged, fail closed)

- Add-on deletes or overwrites of trees segment 1 created or replaced are refused with `InvalidBatchOperation`, including empty trees. Deletion preflight and cleanup read committed state, so the cross-segment gate rejects these operations before those reads; nothing commits.
- Add-on typed appends to a non-Merk tree segment 1 touched are refused rather than made coherent — append preprocessing reads storage, not Merks.
- Add-on ops colliding with leftover propagation ops at the pause level are #708, fixed separately in PR #925.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to flush pending storage operations while keeping the batch usable.
* **Bug Fixes**
  * Improved partial batch processing so continuations maintain consistent state across indexed data, shared trees, references, and typed appends.
  * Added safeguards that reject conflicting cross-segment operations and invalid pause configurations without modifying the database.
  * Improved rollback behavior when continuation operations fail.
  * Corrected continuation handling for tree deletion options, indexed updates, and reference resolution.
* **Tests**
  * Added comprehensive coverage for partial batch consistency, rollback, validation, indexed re-keying, and typed appends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->