### PR TITLE
fix: reject keyed batch ops under non-Merk append-family parents (#900)

### DIFF
--- a/grovedb-version/src/version/grovedb_versions.rs
+++ b/grovedb-version/src/version/grovedb_versions.rs
@@ -176,6 +176,26 @@ pub struct GroveDBApplyBatchVersions {
     /// rewrites keyless ops into keyed ops before the batch structure is
     /// built.
     pub keyless_op_cost_dispatch: FeatureVersion,
+    /// Whether batch execution rejects ordinary keyed ops at a level whose
+    /// parent is a non-Merk data tree (`CommitmentTree`, `MmrTree`,
+    /// `BulkAppendTree`, `DenseAppendOnlyFixedSizeTree`,
+    /// `PrivateDocumentStore`).
+    ///
+    /// - `0` (V1..V3): such ops execute through ordinary Merk dispatch
+    ///   against the parent's (empty) Merk namespace. The level's Merk root
+    ///   then propagates into the parent element's committed hash while the
+    ///   element keeps its typed metadata (e.g. `mmr_size: 0`) and no root
+    ///   key — the batch acknowledges a write that typed readers never see,
+    ///   the rows are unreachable, and `verify_grovedb` reports the subtree
+    ///   corrupted (issue #900). Preserved for replay only.
+    /// - `1` (V4+): the level is refused before any write, for parents that
+    ///   already exist and for parents created in the same batch alike
+    ///   (the batch structure registers a same-batch parent's real tree
+    ///   type in the Merk cache, so both reach the same check). Typed
+    ///   append operations are unaffected: preprocessing rewrites them into
+    ///   `ReplaceNonMerkTreeRoot` ops at the PARENT level, which never
+    ///   dispatches into the non-Merk tree's own path.
+    pub non_merk_parent_keyed_ops_rejection: FeatureVersion,
 }
 
 #[derive(Clone, Debug, Default)]

--- a/grovedb-version/src/version/v1.rs
+++ b/grovedb-version/src/version/v1.rs
@@ -39,6 +39,7 @@ pub const GROVE_V1: GroveVersion = GroveVersion {
             delete_tree_cleanup_type_source: 0,
             overwrite_indexed_cleanup_inspection: 0,
             keyless_op_cost_dispatch: 0,
+            non_merk_parent_keyed_ops_rejection: 0,
         },
         element: GroveDBElementMethodVersions {
             delete: 0,

--- a/grovedb-version/src/version/v2.rs
+++ b/grovedb-version/src/version/v2.rs
@@ -39,6 +39,7 @@ pub const GROVE_V2: GroveVersion = GroveVersion {
             delete_tree_cleanup_type_source: 0,
             overwrite_indexed_cleanup_inspection: 0,
             keyless_op_cost_dispatch: 0,
+            non_merk_parent_keyed_ops_rejection: 0,
         },
         element: GroveDBElementMethodVersions {
             delete: 0,

--- a/grovedb-version/src/version/v3.rs
+++ b/grovedb-version/src/version/v3.rs
@@ -39,6 +39,7 @@ pub const GROVE_V3: GroveVersion = GroveVersion {
             delete_tree_cleanup_type_source: 0,
             overwrite_indexed_cleanup_inspection: 0,
             keyless_op_cost_dispatch: 0,
+            non_merk_parent_keyed_ops_rejection: 0,
         },
         element: GroveDBElementMethodVersions {
             delete: 0,

--- a/grovedb-version/src/version/v4.rs
+++ b/grovedb-version/src/version/v4.rs
@@ -140,6 +140,19 @@
 //!   apply path is unaffected on every version (preprocessing rewrites
 //!   keyless ops before the batch structure is built).
 //!
+//! - `apply_batch.non_merk_parent_keyed_ops_rejection: 1` — batch execution
+//!   refuses ordinary keyed ops at a level whose parent is a non-Merk data
+//!   tree (`CommitmentTree`, `MmrTree`, `BulkAppendTree`, `DenseTree`,
+//!   `PrivateDocumentStore`), whether the parent already exists or is
+//!   created in the same batch. V1..V3 let such ops run through ordinary
+//!   Merk dispatch: the level's Merk root is committed into the parent
+//!   element's hash while the element keeps its typed metadata, so the
+//!   acknowledged write is unreachable through typed readers and
+//!   `verify_grovedb` reports the subtree corrupted (issue #900). Gated
+//!   because it flips an accepted batch into a refused one. Typed append
+//!   ops are unaffected on every version (preprocessing rewrites them at
+//!   the parent level).
+//!
 //! - `operations.average_case.average_case_commitment_tree_insert: 1` and
 //!   `operations.worst_case.worst_case_commitment_tree_insert: 1` — the
 //!   `CommitmentTreeInsert` estimation arms charge the depth-derived
@@ -305,6 +318,7 @@ pub const GROVE_V4: GroveVersion = GroveVersion {
             delete_tree_cleanup_type_source: 1,
             overwrite_indexed_cleanup_inspection: 1,
             keyless_op_cost_dispatch: 1,
+            non_merk_parent_keyed_ops_rejection: 1,
         },
         element: GroveDBElementMethodVersions {
             delete: 0,

--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -2904,6 +2904,33 @@ where
             merk.tree_type
         };
 
+        // Every op at this level executes through Merk dispatch against the
+        // parent's Merk namespace. Non-Merk data trees keep their state in
+        // the data namespace and commit a typed root instead: letting a Merk
+        // root form here would propagate it into the parent element's hash
+        // while the element keeps its typed metadata and no root key — an
+        // acknowledged write that typed readers never see, unreachable rows,
+        // and a verify_grovedb failure (issue #900). This catches parents
+        // that already exist (the open above derives the tree type from the
+        // stored element) and parents created in this same batch (the batch
+        // structure registers them in the cache with their real tree type).
+        // Typed appends never reach this path: preprocessing rewrites them
+        // into ReplaceNonMerkTreeRoot ops at the PARENT level.
+        if in_tree_type.uses_non_merk_data_storage()
+            && grove_version
+                .grovedb_versions
+                .apply_batch
+                .non_merk_parent_keyed_ops_rejection
+                >= 1
+        {
+            return Err(Error::InvalidBatchOperation(
+                "non-Merk trees (CommitmentTree, MmrTree, BulkAppendTree, DenseTree, \
+                 PrivateDocumentStore) cannot hold keyed child elements; entries are added \
+                 through their typed operations",
+            ))
+            .wrap_with_cost(cost);
+        }
+
         // For cidx primaries, capture the pre-apply count value of every
         // key that this level's ops will mutate. After
         // `merk.apply_with_specialized_costs` runs we re-read each

--- a/grovedb/src/tests/batch_rejection_tests.rs
+++ b/grovedb/src/tests/batch_rejection_tests.rs
@@ -497,3 +497,265 @@ fn test_commitment_tree_insert_debug_format() {
         debug_str
     );
 }
+
+// ===========================================================================
+// Keyed child writes under non-Merk (append-family) parents — issue #900
+// ===========================================================================
+//
+// Non-Merk data trees (CommitmentTree, MmrTree, BulkAppendTree, DenseTree,
+// PrivateDocumentStore) keep their state in the data namespace and commit a
+// typed root. Before the V4 gate `non_merk_parent_keyed_ops_rejection`,
+// ordinary keyed batch ops beneath such a parent executed through Merk
+// dispatch against the parent's (empty) Merk namespace: the batch returned
+// Ok, the level's Merk root was committed into the parent element's hash
+// while the element kept its typed metadata (e.g. `mmr_size: 0`) and no
+// root key — so the acknowledged rows were unreachable, typed readers saw
+// an empty tree, and verify_grovedb reported the subtree corrupted. These
+// tests pin the V4+ rejection for parents created in the same batch and
+// for pre-existing parents, and that valid typed usage is unaffected.
+
+/// The four append-family elements (PrivateDocumentStore has its own
+/// dedicated rejection tests in private_document_store_tests.rs).
+fn append_family_elements() -> Vec<(&'static [u8], Element)> {
+    vec![
+        (
+            b"ct".as_slice(),
+            Element::empty_commitment_tree(10).expect("valid chunk_power"),
+        ),
+        (b"mmr".as_slice(), Element::empty_mmr_tree()),
+        (
+            b"bulk".as_slice(),
+            Element::empty_bulk_append_tree(2).expect("valid chunk_power"),
+        ),
+        (b"dense".as_slice(), Element::empty_dense_tree(3)),
+    ]
+}
+
+#[test]
+fn test_batch_rejects_keyed_child_under_same_batch_created_append_tree() {
+    let grove_version = GroveVersion::latest();
+    for (key, element) in append_family_elements() {
+        let db = make_empty_grovedb();
+        let root_before = db
+            .root_hash(None, grove_version)
+            .unwrap()
+            .expect("root hash before");
+
+        let ops = vec![
+            QualifiedGroveDbOp::insert_or_replace_op(vec![], key.to_vec(), element),
+            QualifiedGroveDbOp::insert_or_replace_op(
+                vec![key.to_vec()],
+                b"child".to_vec(),
+                Element::new_item(b"data".to_vec()),
+            ),
+        ];
+        let result = db.apply_batch(ops, None, None, grove_version).value;
+        assert!(
+            matches!(result, Err(Error::InvalidBatchOperation(_))),
+            "keyed child under same-batch {} parent must be rejected, got {:?}",
+            String::from_utf8_lossy(key),
+            result
+        );
+
+        // The whole batch must roll back: no parent element, unchanged root.
+        assert!(
+            db.get(EMPTY_PATH, key, None, grove_version)
+                .unwrap()
+                .is_err(),
+            "rejected batch must not have created the {} parent",
+            String::from_utf8_lossy(key)
+        );
+        let root_after = db
+            .root_hash(None, grove_version)
+            .unwrap()
+            .expect("root hash after");
+        assert_eq!(root_before, root_after, "root hash must be unchanged");
+        let issues = db
+            .verify_grovedb(None, true, false, grove_version)
+            .expect("verify_grovedb should not fail");
+        assert!(issues.is_empty(), "expected no issues, got: {:?}", issues);
+    }
+}
+
+#[test]
+fn test_batch_rejects_keyed_child_under_existing_append_tree() {
+    let grove_version = GroveVersion::latest();
+    for (key, element) in append_family_elements() {
+        let db = make_empty_grovedb();
+        db.insert(EMPTY_PATH, key, element.clone(), None, None, grove_version)
+            .unwrap()
+            .expect("insert append-family tree");
+        let root_before = db
+            .root_hash(None, grove_version)
+            .unwrap()
+            .expect("root hash before");
+
+        let ops = vec![QualifiedGroveDbOp::insert_or_replace_op(
+            vec![key.to_vec()],
+            b"child".to_vec(),
+            Element::new_item(b"data".to_vec()),
+        )];
+        let result = db.apply_batch(ops, None, None, grove_version).value;
+        assert!(
+            matches!(result, Err(Error::InvalidBatchOperation(_))),
+            "keyed child under existing {} parent must be rejected, got {:?}",
+            String::from_utf8_lossy(key),
+            result
+        );
+
+        // State must be untouched: same root, same stored element, clean
+        // verification.
+        let root_after = db
+            .root_hash(None, grove_version)
+            .unwrap()
+            .expect("root hash after");
+        assert_eq!(root_before, root_after, "root hash must be unchanged");
+        let stored = db
+            .get(EMPTY_PATH, key, None, grove_version)
+            .unwrap()
+            .expect("parent element still readable");
+        assert_eq!(stored, element, "parent element must be unchanged");
+        let issues = db
+            .verify_grovedb(None, true, false, grove_version)
+            .expect("verify_grovedb should not fail");
+        assert!(issues.is_empty(), "expected no issues, got: {:?}", issues);
+    }
+}
+
+#[test]
+fn test_batch_rejects_keyed_delete_under_existing_append_tree() {
+    // Not just inserts: EVERY keyed op family dispatching into the non-Merk
+    // tree's own path is refused.
+    let grove_version = GroveVersion::latest();
+    let db = make_empty_grovedb();
+    db.insert(
+        EMPTY_PATH,
+        b"mmr",
+        Element::empty_mmr_tree(),
+        None,
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("insert mmr tree");
+
+    let ops = vec![QualifiedGroveDbOp::delete_op(
+        vec![b"mmr".to_vec()],
+        b"child".to_vec(),
+    )];
+    let result = db.apply_batch(ops, None, None, grove_version).value;
+    assert!(
+        matches!(result, Err(Error::InvalidBatchOperation(_))),
+        "keyed delete under an MmrTree parent must be rejected, got {:?}",
+        result
+    );
+}
+
+#[test]
+fn test_batch_rejects_subtree_created_below_append_tree() {
+    // A grandchild level executes before its parents (deepest level first),
+    // so the ordinary Tree level applies cleanly — the rejection fires when
+    // its root propagates into the MmrTree's own path, and the whole batch
+    // must roll back, including the already-executed grandchild level.
+    let grove_version = GroveVersion::latest();
+    let db = make_empty_grovedb();
+    let root_before = db
+        .root_hash(None, grove_version)
+        .unwrap()
+        .expect("root hash before");
+
+    let ops = vec![
+        QualifiedGroveDbOp::insert_or_replace_op(
+            vec![],
+            b"mmr".to_vec(),
+            Element::empty_mmr_tree(),
+        ),
+        QualifiedGroveDbOp::insert_or_replace_op(
+            vec![b"mmr".to_vec()],
+            b"sub".to_vec(),
+            Element::empty_tree(),
+        ),
+        QualifiedGroveDbOp::insert_or_replace_op(
+            vec![b"mmr".to_vec(), b"sub".to_vec()],
+            b"child".to_vec(),
+            Element::new_item(b"data".to_vec()),
+        ),
+    ];
+    let result = db.apply_batch(ops, None, None, grove_version).value;
+    assert!(
+        matches!(result, Err(Error::InvalidBatchOperation(_))),
+        "subtree nested below an MmrTree parent must be rejected, got {:?}",
+        result
+    );
+    let root_after = db
+        .root_hash(None, grove_version)
+        .unwrap()
+        .expect("root hash after");
+    assert_eq!(root_before, root_after, "root hash must be unchanged");
+    assert!(
+        db.get(EMPTY_PATH, b"mmr", None, grove_version)
+            .unwrap()
+            .is_err(),
+        "rejected batch must not have created the mmr parent"
+    );
+}
+
+#[test]
+fn test_batch_creating_empty_append_trees_still_succeeds() {
+    // Valid fresh-parent creation (no keyed descendants) is unaffected by
+    // the rejection, and the created trees agree with typed readers and
+    // integrity checks.
+    let grove_version = GroveVersion::latest();
+    let db = make_empty_grovedb();
+
+    let ops = append_family_elements()
+        .into_iter()
+        .map(|(key, element)| {
+            QualifiedGroveDbOp::insert_or_replace_op(vec![], key.to_vec(), element)
+        })
+        .collect::<Vec<_>>();
+    db.apply_batch(ops, None, None, grove_version)
+        .unwrap()
+        .expect("creating empty append-family trees in a batch must succeed");
+
+    // Typed appends into the freshly created trees work.
+    db.mmr_tree_append(EMPTY_PATH, b"mmr", b"value".to_vec(), None, grove_version)
+        .unwrap()
+        .expect("typed append into fresh mmr tree");
+    assert_eq!(
+        db.mmr_tree_leaf_count(EMPTY_PATH, b"mmr", None, grove_version)
+            .unwrap()
+            .expect("leaf count"),
+        1
+    );
+
+    let issues = db
+        .verify_grovedb(None, true, false, grove_version)
+        .expect("verify_grovedb should not fail");
+    assert!(issues.is_empty(), "expected no issues, got: {:?}", issues);
+}
+
+#[test]
+fn test_batch_keyed_child_under_append_tree_accepted_on_grove_v3_for_replay() {
+    // GROVE_V3 must keep the released accepted/rejected outcome: the gate
+    // `non_merk_parent_keyed_ops_rejection` is 0, so the (corrupting) keyed
+    // child write under a CommitmentTree parent still returns Ok. This
+    // documents that the V4 fix does not alter V1..V3 replay.
+    use grovedb_version::version::v3::GROVE_V3;
+    let db = make_empty_grovedb();
+    let ops = vec![
+        QualifiedGroveDbOp::insert_or_replace_op(
+            vec![],
+            b"ct".to_vec(),
+            Element::empty_commitment_tree(10).expect("valid chunk_power"),
+        ),
+        QualifiedGroveDbOp::insert_or_replace_op(
+            vec![b"ct".to_vec()],
+            b"child".to_vec(),
+            Element::new_item(b"data".to_vec()),
+        ),
+    ];
+    db.apply_batch(ops, None, None, &GROVE_V3)
+        .unwrap()
+        .expect("GROVE_V3 must preserve the released (accepting) behavior");
+}

--- a/grovedb/src/tests/batch_unit_tests.rs
+++ b/grovedb/src/tests/batch_unit_tests.rs
@@ -17,7 +17,7 @@ mod tests {
     };
     use crate::reference_path::ReferencePathType;
     use crate::tests::{common::EMPTY_PATH, make_empty_grovedb, make_test_grovedb, TEST_LEAF};
-    use crate::Element;
+    use crate::{Element, Error};
 
     // ===================================================================
     // Group 1: NonMerkTreeMeta::to_tree_type() and count()
@@ -820,149 +820,89 @@ mod tests {
     // ===================================================================
     // Group 7: Non-Merk tree propagation in apply_batch
     //
-    // Exercises the propagation branches at L2400-2469 where a non-Merk
-    // tree element in an Occupied entry is converted to InsertNonMerkTree.
     // Pattern: batch-insert the non-Merk tree AND an item under it so
-    // the root hash propagates to the parent's occupied InsertOrReplace.
+    // the root hash propagates to the parent's occupied InsertOrReplace,
+    // converting it to InsertNonMerkTree.
+    //
+    // That propagation is exactly the representation corruption of issue
+    // #900 — the parent element commits a Merk root over keyed children
+    // that typed readers never see — so on V4+
+    // (`non_merk_parent_keyed_ops_rejection`) the batch is refused before
+    // any write. GROVE_V3 preserves the released accepting behavior, which
+    // these tests still run to keep the Occupied-entry →
+    // InsertNonMerkTree conversion branches covered.
     // ===================================================================
+
+    fn assert_batch_propagation_non_merk_tree(key: &[u8], element: Element) {
+        let latest = GroveVersion::latest();
+        for grove_version in [&GROVE_V3, latest] {
+            let db = make_empty_grovedb();
+
+            // Insert a parent tree so the non-Merk tree is at level 1
+            db.insert(
+                EMPTY_PATH,
+                b"parent",
+                Element::empty_tree(),
+                None,
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("insert parent");
+
+            // Batch: create the non-Merk tree under parent AND insert an
+            // item under it. The item triggers propagation back to the
+            // tree's entry.
+            let ops = vec![
+                QualifiedGroveDbOp::insert_or_replace_op(
+                    vec![b"parent".to_vec()],
+                    key.to_vec(),
+                    element.clone(),
+                ),
+                QualifiedGroveDbOp::insert_or_replace_op(
+                    vec![b"parent".to_vec(), key.to_vec()],
+                    b"item".to_vec(),
+                    Element::new_item(b"value".to_vec()),
+                ),
+            ];
+
+            let result = db.apply_batch(ops, None, None, grove_version).value;
+            if grove_version.protocol_version >= 4 {
+                assert!(
+                    matches!(result, Err(Error::InvalidBatchOperation(_))),
+                    "V4+ must reject the keyed child under the non-Merk parent, got {:?}",
+                    result
+                );
+            } else {
+                result.expect("V3 must preserve the released (accepting) propagation");
+            }
+        }
+    }
 
     #[test]
     fn test_batch_propagation_commitment_tree() {
-        let grove_version = GroveVersion::latest();
-        let db = make_empty_grovedb();
-
-        // Insert a parent tree so the CommitmentTree is at level 1
-        db.insert(
-            EMPTY_PATH,
-            b"parent",
-            Element::empty_tree(),
-            None,
-            None,
-            grove_version,
-        )
-        .unwrap()
-        .expect("insert parent");
-
-        // Batch: create CommitmentTree under parent AND insert an item under it.
-        // The item triggers propagation back to the CommitmentTree entry.
-        let ops = vec![
-            QualifiedGroveDbOp::insert_or_replace_op(
-                vec![b"parent".to_vec()],
-                b"ct".to_vec(),
-                Element::empty_commitment_tree(10).expect("valid chunk_power"),
-            ),
-            QualifiedGroveDbOp::insert_or_replace_op(
-                vec![b"parent".to_vec(), b"ct".to_vec()],
-                b"item".to_vec(),
-                Element::new_item(b"value".to_vec()),
-            ),
-        ];
-
-        db.apply_batch(ops, None, None, grove_version)
-            .unwrap()
-            .expect("batch propagation through CommitmentTree");
+        assert_batch_propagation_non_merk_tree(
+            b"ct",
+            Element::empty_commitment_tree(10).expect("valid chunk_power"),
+        );
     }
 
     #[test]
     fn test_batch_propagation_mmr_tree() {
-        let grove_version = GroveVersion::latest();
-        let db = make_empty_grovedb();
-
-        db.insert(
-            EMPTY_PATH,
-            b"parent",
-            Element::empty_tree(),
-            None,
-            None,
-            grove_version,
-        )
-        .unwrap()
-        .expect("insert parent");
-
-        let ops = vec![
-            QualifiedGroveDbOp::insert_or_replace_op(
-                vec![b"parent".to_vec()],
-                b"mmr".to_vec(),
-                Element::empty_mmr_tree(),
-            ),
-            QualifiedGroveDbOp::insert_or_replace_op(
-                vec![b"parent".to_vec(), b"mmr".to_vec()],
-                b"item".to_vec(),
-                Element::new_item(b"value".to_vec()),
-            ),
-        ];
-
-        db.apply_batch(ops, None, None, grove_version)
-            .unwrap()
-            .expect("batch propagation through MmrTree");
+        assert_batch_propagation_non_merk_tree(b"mmr", Element::empty_mmr_tree());
     }
 
     #[test]
     fn test_batch_propagation_bulk_append_tree() {
-        let grove_version = GroveVersion::latest();
-        let db = make_empty_grovedb();
-
-        db.insert(
-            EMPTY_PATH,
-            b"parent",
-            Element::empty_tree(),
-            None,
-            None,
-            grove_version,
-        )
-        .unwrap()
-        .expect("insert parent");
-
-        let ops = vec![
-            QualifiedGroveDbOp::insert_or_replace_op(
-                vec![b"parent".to_vec()],
-                b"bulk".to_vec(),
-                Element::empty_bulk_append_tree(10).expect("valid chunk_power"),
-            ),
-            QualifiedGroveDbOp::insert_or_replace_op(
-                vec![b"parent".to_vec(), b"bulk".to_vec()],
-                b"item".to_vec(),
-                Element::new_item(b"value".to_vec()),
-            ),
-        ];
-
-        db.apply_batch(ops, None, None, grove_version)
-            .unwrap()
-            .expect("batch propagation through BulkAppendTree");
+        assert_batch_propagation_non_merk_tree(
+            b"bulk",
+            Element::empty_bulk_append_tree(10).expect("valid chunk_power"),
+        );
     }
 
     #[test]
     fn test_batch_propagation_dense_tree() {
-        let grove_version = GroveVersion::latest();
-        let db = make_empty_grovedb();
-
-        db.insert(
-            EMPTY_PATH,
-            b"parent",
-            Element::empty_tree(),
-            None,
-            None,
-            grove_version,
-        )
-        .unwrap()
-        .expect("insert parent");
-
-        let ops = vec![
-            QualifiedGroveDbOp::insert_or_replace_op(
-                vec![b"parent".to_vec()],
-                b"dense".to_vec(),
-                Element::empty_dense_tree(4),
-            ),
-            QualifiedGroveDbOp::insert_or_replace_op(
-                vec![b"parent".to_vec(), b"dense".to_vec()],
-                b"item".to_vec(),
-                Element::new_item(b"value".to_vec()),
-            ),
-        ];
-
-        db.apply_batch(ops, None, None, grove_version)
-            .unwrap()
-            .expect("batch propagation through DenseTree");
+        assert_batch_propagation_non_merk_tree(b"dense", Element::empty_dense_tree(4));
     }
 
     // ===================================================================


### PR DESCRIPTION
Fixes #900 (audit M022).

## Problem

A batch could place ordinary keyed ops (inserts, deletes, whole subtrees) at a path whose parent is a non-Merk data tree — `CommitmentTree`, `MmrTree`, `BulkAppendTree`, `DenseAppendOnlyFixedSizeTree`, or `PrivateDocumentStore`. The level executed through ordinary Merk dispatch against the parent's (empty) Merk namespace, and propagation then committed that Merk root into the parent element's hash while `reconstruct_with_root_key` returned the non-Merk element verbatim, keeping its typed metadata and no root key.

Reproduced on `develop` for both shapes the issue names:

- **Parent created in the same batch** (`InsertOrReplace(MmrTree)` + `InsertOrReplace(Item)` under it): `apply_batch` returns `Ok(())`, the stored element is `MmrTree(mmr_size: 0)`, the committed hash covers the keyed rows, the child readback fails (`root key [None]`), typed readers return the empty-MMR root of zeros, and `verify_grovedb` reports the subtree corrupted.
- **Pre-existing parent**: same acknowledged-but-unreachable write, root hash moves, `verify_grovedb` errors.

This is the representation-boundary corruption described in the issue: a successful acknowledged mutation that typed readers and integrity checks interpret as different state. (It does not require the #685 append/keyed conflict or #779's populated prior state.)

## Fix

One check at the top of `TreeCacheMerkByPath::execute_ops_on_path`, immediately after the level's `in_tree_type` is derived: if the type `uses_non_merk_data_storage()`, the batch is refused with `InvalidBatchOperation` before any write.

- Covers **parents created in the same batch** — the batch structure's `TreeCache::insert` registers the fresh Merk with the element's real tree type, so the same check fires — and **pre-existing parents**, whose type comes from the stored element at open.
- Covers **every op family** dispatched into the non-Merk path (insert, delete, references), and **nested subtrees**: a grandchild level applies first, but its root propagates into the append parent's own path where the check fires and the whole batch rolls back.
- **Typed append operations are unaffected** on every version: preprocessing rewrites them into `ReplaceNonMerkTreeRoot` ops at the *parent* level, which never dispatches into the non-Merk tree's own path. Creating empty append-family trees in a batch also remains valid.
- Estimation caches are untouched (they never apply state).

## Versioning

Gated to GROVE_V4+ via a new slot `apply_batch.non_merk_parent_keyed_ops_rejection`, because it flips an accepted batch into a refused one. GROVE_V1..V3 keep the released accepting behavior for replay; a test pins that with a `CommitmentTree` (the append-family type live on mainnet).

## Tests

- `batch_rejection_tests`: rejection for all four append-family types with same-batch-created and pre-existing parents (unchanged root hash, unchanged element, clean `verify_grovedb`), keyed-delete rejection, nested-subtree rejection with full rollback, empty-creation + typed-append positive control, and the GROVE_V3 replay pin.
- `batch_unit_tests` Group 7 fixtures previously asserted the corrupting propagation as success; they now assert the V4+ rejection while still running the accepting GROVE_V3 path so the `Occupied`-entry → `InsertNonMerkTree` conversion branches stay covered.

## Out of scope

The non-batch `insert()` of a keyed child under an *existing* append-family parent (and `apply_operations_without_batching`, which routes through it) is a separate known gap on the direct-insert path (`validate_insertable_into` only rejects `PrivateDocumentStore`) and is not changed here to avoid colliding with the pending insert-path PRs #922/#923.

🤖 Generated with [Claude Code](https://claude.com/claude-code)