### PR TITLE
fix: validate indexed secondary roots against the stored element (#897)

### DIFF
--- a/grovedb-version/src/version/v4.rs
+++ b/grovedb-version/src/version/v4.rs
@@ -235,8 +235,15 @@
 //!   a tree element, which the batch resolver has always rejected; v1
 //!   accepted it and committed only `H(tree element bytes)`, a hash that does
 //!   not bind the subtree's contents, so the row could not be proved and
-//!   subtree changes never disturbed it. Gated because (i) moves a committed
-//!   root and (ii)/(iii) flip an accepted/rejected outcome.
+//!   subtree changes never disturbed it. (iv) A directly inserted non-empty
+//!   indexed-tree element (PCIT / PSIT / PCPSIT) has its claimed secondary
+//!   root keys validated against the STORED element's canonical values
+//!   (issue #897). v1 opened each secondary Merk with the incoming key and
+//!   compared the returned root key against that same input — circular, so
+//!   any existing node key of the secondary (every row is one) passed and
+//!   committed the hash of a non-root node, authenticating a strict subtree
+//!   of the index as the whole index. Gated because (i) moves a committed
+//!   root and (ii)/(iii)/(iv) flip an accepted/rejected outcome.
 //!
 //! - `storage_costs.add_basic_storage_removal_to_sectioned_storage_removal:
 //!   1` — combining a `BasicStorageRemoval` with a `SectionedStorageRemoval`

--- a/grovedb/src/operations/insert/add_element_on_transaction/mod.rs
+++ b/grovedb/src/operations/insert/add_element_on_transaction/mod.rs
@@ -28,7 +28,11 @@
 //!   later read failed on. The batch path already refuses it. v2 further
 //!   refuses a reference whose terminal is a tree, as the batch resolver
 //!   always has; v0/v1 accepted it and committed a hash that does not bind
-//!   the subtree's contents. Selected by `GROVE_V4`+.
+//!   the subtree's contents. v2 also validates a non-empty indexed-tree
+//!   element's claimed secondary root keys against the STORED element
+//!   (issue #897); v0/v1 opened each secondary with the incoming key and
+//!   compared the result against that same input, which any existing node
+//!   key of the secondary Merk passes. Selected by `GROVE_V4`+.
 //!
 //! The implementations are otherwise identical. See [v0] / [v1] / [v2].
 //!

--- a/grovedb/src/operations/insert/add_element_on_transaction/v0.rs
+++ b/grovedb/src/operations/insert/add_element_on_transaction/v0.rs
@@ -14,6 +14,11 @@
 //! `value_hash(serialized)` to `combine_hash(value_hash(serialized), NULL_HASH)`,
 //! which changes the grovedb root and breaks consensus when v11 is replayed.
 //!
+//! KNOWN, DELIBERATELY PRESERVED FLAW (issue #897, fixed in [`super::v2`]):
+//! the indexed-tree arms validate a non-empty element's claimed secondary
+//! root key circularly (opening the secondary WITH the claimed key). Frozen
+//! here for replay; do not tighten.
+//!
 //! v0 therefore differs from [`super::v1`] ONLY in the placement of those three
 //! match arms: here they join the `Op::Put` arm; there they join the layered
 //! arm. Everything else is identical. (The v12-only `ProvableSumTree` /

--- a/grovedb/src/operations/insert/add_element_on_transaction/v1.rs
+++ b/grovedb/src/operations/insert/add_element_on_transaction/v1.rs
@@ -1,4 +1,5 @@
-//! `add_element_on_transaction` — **v1** (current behaviour, `GROVE_V3`+).
+//! `add_element_on_transaction` — **v1** (`GROVE_V3`; superseded by
+//! [`super::v2`] from `GROVE_V4`).
 //!
 //! `CountSumTree` / `ProvableCountTree` / `ProvableCountSumTree` are inserted as
 //! **layered subtrees** (`Op::PutLayeredReference`), the same way the batch
@@ -11,6 +12,13 @@
 //! ONLY in the match arm for those three element types, where v0 uses the
 //! plain-value `Op::Put` path instead. See the module docs in
 //! [`super`][`mod@super`] for the consensus rationale.
+//!
+//! KNOWN, DELIBERATELY PRESERVED FLAW (issue #897, fixed in [`super::v2`]):
+//! the indexed-tree arms here validate a non-empty element's claimed
+//! secondary root key by opening the secondary Merk WITH that key and
+//! comparing the returned root key against the same input — circular, so any
+//! existing node key of the secondary Merk passes and commits a non-root
+//! node's hash. `GROVE_V3` is live; do not tighten this here.
 
 use grovedb_costs::{
     cost_return_on_error, cost_return_on_error_into, cost_return_on_error_no_add, CostResult,

--- a/grovedb/src/operations/insert/add_element_on_transaction/v2.rs
+++ b/grovedb/src/operations/insert/add_element_on_transaction/v2.rs
@@ -31,6 +31,19 @@
 //! updated"`), but v0/v1 accepted it and committed only `H(tree element
 //! bytes)` — a commitment that does not bind the subtree's contents and whose
 //! row cannot be proved. v1 keeps accepting it for the same consensus reason.
+//!
+//! v2 also binds a non-empty indexed-tree element's claimed secondary root
+//! keys (PCIT / PSIT secondary, PCPSIT per-axis roots) to the **stored**
+//! element's values before opening the secondaries (issue #897). v0/v1 opened
+//! each secondary Merk with the incoming key and compared the returned root
+//! key against that same input — circular, since every row of a secondary
+//! Merk is a node key in its storage and any of them opens successfully as a
+//! "root". A caller supplying the canonical primary root key and aggregates
+//! but a non-root node key as a secondary root committed the hash of an
+//! interior/leaf node, authenticating a strict subtree of the index as the
+//! whole index. The stored element's bytes are hash-committed by the parent
+//! Merk, so they are the canonical authority; v1 keeps the circular check for
+//! the same consensus reason.
 
 use grovedb_costs::{
     cost_return_on_error, cost_return_on_error_into, cost_return_on_error_no_add, CostResult,
@@ -426,6 +439,8 @@ impl GroveDb {
                         ))
                         .wrap_with_cost(cost);
                     }
+                    // Fetch the STORED element once — it serves two guards.
+                    //
                     // In-place conversion guard: a DIFFERENT tree element
                     // already stored at this key can pass every check above
                     // (a plain ProvableCountTree's subtree is byte-compatible
@@ -434,23 +449,61 @@ impl GroveDb {
                     // would start EMPTY over a populated primary — the same
                     // no-reindex hazard as an axes schema change. Refuse
                     // the conversion.
-                    let stored_is_other_tree = cost_return_on_error!(
+                    //
+                    // Canonical secondary binding (issue #897): the claimed
+                    // secondary_root_key must equal the STORED element's.
+                    // The primary is bound canonically already — its Merk is
+                    // opened with the root key read from the stored parent
+                    // element — but the secondary Merk is opened WITH the
+                    // incoming key, so comparing the returned root key
+                    // against that same input is circular: every row of the
+                    // secondary Merk is a node key in its storage, any of
+                    // them opens successfully as a "root", and the caller
+                    // would commit the hash of an interior/leaf node,
+                    // authenticating a strict subtree of the index as the
+                    // whole index. The stored element's bytes are
+                    // hash-committed by the parent Merk, so its
+                    // secondary_root_key is the canonical authority.
+                    let stored_underlying = cost_return_on_error!(
                         &mut cost,
                         Element::get_optional(&subtree_to_insert_into, key, true, grove_version)
                             .map_err(Error::MerkError)
                     )
-                    .is_some_and(|existing| {
-                        let u = existing.into_underlying();
-                        u.is_any_tree() && !matches!(u, Element::ProvableCountIndexedTree(..))
-                    });
-                    if stored_is_other_tree {
-                        return Err(Error::InvalidInput(
-                            "CountIndexedTree direct insertion: an existing tree of a \
+                    .map(|existing| existing.into_underlying());
+                    match stored_underlying {
+                        Some(Element::ProvableCountIndexedTree(_, stored_secondary, _, _)) => {
+                            if &stored_secondary != secondary {
+                                return Err(Error::InvalidInput(
+                                    "CountIndexedTree direct insertion: provided \
+                                     secondary_root_key does not match the stored element's \
+                                     canonical secondary root key",
+                                ))
+                                .wrap_with_cost(cost);
+                            }
+                        }
+                        Some(other) if other.is_any_tree() => {
+                            return Err(Error::InvalidInput(
+                                "CountIndexedTree direct insertion: an existing tree of a \
                                  different type is stored at this key; converting it in place \
                                  would leave the secondary index empty over a populated \
                                  primary (no reindex path)",
-                        ))
-                        .wrap_with_cost(cost);
+                            ))
+                            .wrap_with_cost(cost);
+                        }
+                        // No stored element / stored non-tree cannot occur:
+                        // `open_transactional_merk_at_path` above only
+                        // succeeds when a stored TREE element exists at this
+                        // key. Fail closed anyway — with no stored
+                        // same-variant element there is no canonical
+                        // authority to bind the claimed secondary to.
+                        _ => {
+                            return Err(Error::InvalidInput(
+                                "CountIndexedTree direct insertion: a non-empty claim \
+                                 requires an existing stored indexed element to validate \
+                                 the secondary root key against",
+                            ))
+                            .wrap_with_cost(cost);
+                        }
                     }
                     // Also bind the claimed count_value to the primary's
                     // actual aggregate. Without this, a caller could
@@ -556,6 +609,8 @@ impl GroveDb {
                         ))
                         .wrap_with_cost(cost);
                     }
+                    // Fetch the STORED element once — it serves two guards.
+                    //
                     // In-place conversion guard: a DIFFERENT tree element
                     // already stored at this key can pass every check above
                     // (a plain ProvableSumTree's subtree is byte-compatible
@@ -564,23 +619,52 @@ impl GroveDb {
                     // would start EMPTY over a populated primary — the same
                     // no-reindex hazard as an axes schema change. Refuse
                     // the conversion.
-                    let stored_is_other_tree = cost_return_on_error!(
+                    //
+                    // Canonical secondary binding (issue #897): the claimed
+                    // secondary_root_key must equal the STORED element's —
+                    // the secondary Merk below is opened WITH the incoming
+                    // key, so comparing the returned root key against that
+                    // same input is circular (any row node key of the
+                    // secondary opens successfully as a "root"). See the
+                    // PCIT arm above for the full rationale.
+                    let stored_underlying = cost_return_on_error!(
                         &mut cost,
                         Element::get_optional(&subtree_to_insert_into, key, true, grove_version)
                             .map_err(Error::MerkError)
                     )
-                    .is_some_and(|existing| {
-                        let u = existing.into_underlying();
-                        u.is_any_tree() && !matches!(u, Element::ProvableSumIndexedTree(..))
-                    });
-                    if stored_is_other_tree {
-                        return Err(Error::InvalidInput(
-                            "ProvableSumIndexedTree direct insertion: an existing tree of a \
+                    .map(|existing| existing.into_underlying());
+                    match stored_underlying {
+                        Some(Element::ProvableSumIndexedTree(_, stored_secondary, _, _)) => {
+                            if &stored_secondary != secondary {
+                                return Err(Error::InvalidInput(
+                                    "ProvableSumIndexedTree direct insertion: provided \
+                                     secondary_root_key does not match the stored element's \
+                                     canonical secondary root key",
+                                ))
+                                .wrap_with_cost(cost);
+                            }
+                        }
+                        Some(other) if other.is_any_tree() => {
+                            return Err(Error::InvalidInput(
+                                "ProvableSumIndexedTree direct insertion: an existing tree of a \
                                  different type is stored at this key; converting it in place \
                                  would leave the secondary index empty over a populated \
                                  primary (no reindex path)",
-                        ))
-                        .wrap_with_cost(cost);
+                            ))
+                            .wrap_with_cost(cost);
+                        }
+                        // No stored element / stored non-tree cannot occur:
+                        // `open_transactional_merk_at_path` above only
+                        // succeeds when a stored TREE element exists at this
+                        // key. Fail closed anyway.
+                        _ => {
+                            return Err(Error::InvalidInput(
+                                "ProvableSumIndexedTree direct insertion: a non-empty claim \
+                                 requires an existing stored indexed element to validate the \
+                                 secondary root key against",
+                            ))
+                            .wrap_with_cost(cost);
+                        }
                     }
                     if p_aggregate.as_sum_i64() != *sum_value {
                         return Err(Error::InvalidInput(
@@ -737,14 +821,48 @@ impl GroveDb {
                     // axes). Dropping an axis likewise orphans a populated
                     // secondary Merk. There is no backfill/reindex API, so
                     // the only safe answer is to refuse the schema change.
-                    let stored_axis_tags: Option<Vec<u8>> = cost_return_on_error!(
+                    // Canonical axis-root binding (issue #897) rides the same
+                    // stored-element fetch: each claimed per-axis
+                    // secondary_root_key must equal the STORED element's —
+                    // the per-axis Merks below are opened WITH the incoming
+                    // keys, so comparing the returned root key against that
+                    // same input is circular (any row node key of an axis
+                    // secondary opens successfully as a "root"). See the
+                    // PCIT arm above for the full rationale.
+                    let stored_underlying = cost_return_on_error!(
                         &mut cost,
                         Element::get_optional(&subtree_to_insert_into, key, true, grove_version)
                             .map_err(Error::MerkError)
                     )
-                    .and_then(|existing| match existing.into_underlying() {
-                        Element::ProvableCountProvableSumIndexedTree(_, _, _, stored_axes, _) => {
-                            Some(stored_axes.iter().map(|(t, _)| *t).collect::<Vec<u8>>())
+                    .map(|existing| existing.into_underlying());
+                    match stored_underlying {
+                        Some(Element::ProvableCountProvableSumIndexedTree(
+                            _,
+                            _,
+                            _,
+                            stored_axes,
+                            _,
+                        )) => {
+                            let stored_tags: Vec<u8> =
+                                stored_axes.iter().map(|(t, _)| *t).collect();
+                            let incoming_tags: Vec<u8> = axes.iter().map(|(t, _)| *t).collect();
+                            if stored_tags != incoming_tags {
+                                return Err(Error::InvalidInput(
+                                    "ProvableCountProvableSumIndexedTree direct insertion: the \
+                                     axes schema does not match the stored element; axes cannot \
+                                     be added or removed on an existing indexed tree (no reindex \
+                                     path exists)",
+                                ))
+                                .wrap_with_cost(cost);
+                            }
+                            if &stored_axes != axes {
+                                return Err(Error::InvalidInput(
+                                    "ProvableCountProvableSumIndexedTree direct insertion: a \
+                                     provided axis secondary_root_key does not match the stored \
+                                     element's canonical axis root key",
+                                ))
+                                .wrap_with_cost(cost);
+                            }
                         }
                         // In-place conversion guard: a stored tree of a
                         // DIFFERENT type (e.g. a plain
@@ -752,13 +870,9 @@ impl GroveDb {
                         // byte-compatible with a PCPSIT primary) would pass the
                         // aggregate checks above while the axis secondaries
                         // start EMPTY over a populated primary — the same
-                        // no-reindex hazard as an axes schema change. Mark it
-                        // for rejection below.
-                        other if other.is_any_tree() => Some(vec![u8::MAX]),
-                        _ => None,
-                    });
-                    if let Some(stored_tags) = stored_axis_tags {
-                        if stored_tags == vec![u8::MAX] {
+                        // no-reindex hazard as an axes schema change. Refuse
+                        // the conversion.
+                        Some(other) if other.is_any_tree() => {
                             return Err(Error::InvalidInput(
                                 "ProvableCountProvableSumIndexedTree direct insertion: an \
                                  existing tree of a different type is stored at this key; \
@@ -767,12 +881,15 @@ impl GroveDb {
                             ))
                             .wrap_with_cost(cost);
                         }
-                        let incoming_tags: Vec<u8> = axes.iter().map(|(t, _)| *t).collect();
-                        if stored_tags != incoming_tags {
+                        // No stored element / stored non-tree cannot occur:
+                        // `open_transactional_merk_at_path` above only
+                        // succeeds when a stored TREE element exists at this
+                        // key. Fail closed anyway.
+                        _ => {
                             return Err(Error::InvalidInput(
-                                "ProvableCountProvableSumIndexedTree direct insertion: the axes \
-                                 schema does not match the stored element; axes cannot be added \
-                                 or removed on an existing indexed tree (no reindex path exists)",
+                                "ProvableCountProvableSumIndexedTree direct insertion: a \
+                                 non-empty claim requires an existing stored indexed element to \
+                                 validate the axis secondary root keys against",
                             ))
                             .wrap_with_cost(cost);
                         }

--- a/grovedb/src/operations/insert/mod.rs
+++ b/grovedb/src/operations/insert/mod.rs
@@ -897,8 +897,11 @@ mod tests {
     // partial state behind.
     //
     // The guards are byte-identical in the v0 (`GROVE_V1` / `GROVE_V2`)
-    // and v1 (`GROVE_V3`+) snapshots, so each scenario is parameterized by
-    // grove version and run under both.
+    // and v1 (`GROVE_V3`) snapshots, so each scenario is parameterized by
+    // grove version and run under both. v2 (`GROVE_V4`+) additionally
+    // validates the claimed secondary root keys against the STORED
+    // element (issue #897), so the secondary-mismatch scenarios reject
+    // there with the canonical-authority messages instead.
     // ------------------------------------------------------------------
 
     // Exact rejection messages emitted by the indexed-tree arms of
@@ -945,6 +948,19 @@ mod tests {
     const PCPSIT_AXIS_SECONDARY_MISMATCH: &str =
         "ProvableCountProvableSumIndexedTree direct insertion: provided axis secondary_root_key \
          does not match the existing secondary Merk's root key";
+
+    // v2 (`GROVE_V4`+) rejects the same secondary-mismatch scenarios
+    // earlier, against the STORED element's canonical root keys
+    // (issue #897).
+    const PCIT_SECONDARY_CANONICAL_MISMATCH: &str =
+        "CountIndexedTree direct insertion: provided secondary_root_key does not match the stored \
+         element's canonical secondary root key";
+    const PSIT_SECONDARY_CANONICAL_MISMATCH: &str =
+        "ProvableSumIndexedTree direct insertion: provided secondary_root_key does not match the \
+         stored element's canonical secondary root key";
+    const PCPSIT_AXIS_SECONDARY_CANONICAL_MISMATCH: &str =
+        "ProvableCountProvableSumIndexedTree direct insertion: a provided axis secondary_root_key \
+         does not match the stored element's canonical axis root key";
 
     /// A root key no Merk in these fixtures can have: nothing is ever
     /// stored under it, so `Merk::open_layered_with_root_key` loads an
@@ -1328,11 +1344,19 @@ mod tests {
         assert!(issues.is_empty(), "issues: {issues:?}");
     }
 
-    /// The secondary (index) Merk's root key is validated the same way the
-    /// primary's is. A claimed key that no node lives under opens as an
+    /// The secondary (index) Merk's root key is validated too. Under the
+    /// v0/v1 snapshots a claimed key that no node lives under opens as an
     /// empty secondary, whose root key is `None` — the mismatch is caught
-    /// instead of being committed into the element bytes.
-    fn indexed_secondary_root_key_mismatch_is_rejected(gv: &GroveVersion) {
+    /// instead of being committed into the element bytes. Under v2
+    /// (`GROVE_V4`+) the same claims are rejected earlier, against the
+    /// STORED element's canonical root keys (issue #897) — the expected
+    /// messages are passed in per snapshot.
+    fn indexed_secondary_root_key_mismatch_is_rejected(
+        gv: &GroveVersion,
+        pcit_expected: &str,
+        psit_expected: &str,
+        pcpsit_axis_expected: &str,
+    ) {
         let db = make_test_grovedb(gv);
         let (pcit_primary, _, pcit_count) = populate_pcit(&db, gv, b"cidx");
         let (psit_primary, _, psit_sum) = populate_psit(&db, gv, b"psit");
@@ -1350,7 +1374,7 @@ mod tests {
                 gv,
             )
             .unwrap();
-        assert_invalid_input(result, PCIT_SECONDARY_MISMATCH);
+        assert_invalid_input(result, pcit_expected);
 
         // PSIT — honest primary + sum, bogus secondary.
         let result = db
@@ -1363,7 +1387,7 @@ mod tests {
                 gv,
             )
             .unwrap();
-        assert_invalid_input(result, PSIT_SECONDARY_MISMATCH);
+        assert_invalid_input(result, psit_expected);
 
         // PCPSIT — the axis TAGS still match what is stored (so the
         // schema guard passes), but the count axis carries a bogus
@@ -1386,7 +1410,7 @@ mod tests {
                 gv,
             )
             .unwrap();
-        assert_invalid_input(result, PCPSIT_AXIS_SECONDARY_MISMATCH);
+        assert_invalid_input(result, pcpsit_axis_expected);
 
         let issues = db.verify_grovedb(None, true, true, gv).expect("verify");
         assert!(issues.is_empty(), "issues: {issues:?}");
@@ -1559,21 +1583,52 @@ mod tests {
         indexed_partial_state_is_rejected(&GROVE_V1);
         indexed_primary_root_key_mismatch_is_rejected(&GROVE_V1);
         indexed_variant_mismatch_is_rejected(&GROVE_V1);
-        indexed_secondary_root_key_mismatch_is_rejected(&GROVE_V1);
+        indexed_secondary_root_key_mismatch_is_rejected(
+            &GROVE_V1,
+            PCIT_SECONDARY_MISMATCH,
+            PSIT_SECONDARY_MISMATCH,
+            PCPSIT_AXIS_SECONDARY_MISMATCH,
+        );
         pcpsit_axes_schema_change_is_rejected(&GROVE_V1);
         pcpsit_over_plain_provable_count_sum_tree_has_no_axes_schema(&GROVE_V1);
     }
 
-    /// v1 snapshot (`GROVE_V3`+, latest) — the indexed-tree arms are
-    /// identical to v0's, so the same guards must hold.
+    /// v1 snapshot (`GROVE_V3`) — the indexed-tree arms are identical to
+    /// v0's, so the same guards must hold.
     #[test]
     fn indexed_tree_direct_insert_guards_v1() {
+        use grovedb_version::version::v3::GROVE_V3;
+
+        indexed_partial_state_is_rejected(&GROVE_V3);
+        indexed_primary_root_key_mismatch_is_rejected(&GROVE_V3);
+        indexed_variant_mismatch_is_rejected(&GROVE_V3);
+        indexed_secondary_root_key_mismatch_is_rejected(
+            &GROVE_V3,
+            PCIT_SECONDARY_MISMATCH,
+            PSIT_SECONDARY_MISMATCH,
+            PCPSIT_AXIS_SECONDARY_MISMATCH,
+        );
+        pcpsit_axes_schema_change_is_rejected(&GROVE_V3);
+        pcpsit_over_plain_provable_count_sum_tree_has_no_axes_schema(&GROVE_V3);
+    }
+
+    /// v2 snapshot (`GROVE_V4`+, latest) — same guards, but the claimed
+    /// secondary root keys are validated against the STORED element's
+    /// canonical values (issue #897), so the secondary-mismatch scenarios
+    /// reject with the canonical-authority messages.
+    #[test]
+    fn indexed_tree_direct_insert_guards_v2() {
         let gv = GroveVersion::latest();
 
         indexed_partial_state_is_rejected(gv);
         indexed_primary_root_key_mismatch_is_rejected(gv);
         indexed_variant_mismatch_is_rejected(gv);
-        indexed_secondary_root_key_mismatch_is_rejected(gv);
+        indexed_secondary_root_key_mismatch_is_rejected(
+            gv,
+            PCIT_SECONDARY_CANONICAL_MISMATCH,
+            PSIT_SECONDARY_CANONICAL_MISMATCH,
+            PCPSIT_AXIS_SECONDARY_CANONICAL_MISMATCH,
+        );
         pcpsit_axes_schema_change_is_rejected(gv);
         pcpsit_over_plain_provable_count_sum_tree_has_no_axes_schema(gv);
     }

--- a/grovedb/src/tests/direct_insert_indexed_tests.rs
+++ b/grovedb/src/tests/direct_insert_indexed_tests.rs
@@ -1184,6 +1184,275 @@ mod tests {
         assert!(matches!(result, Err(Error::InvalidInput(_))));
     }
 
+    // -----------------------------------------------------------------
+    // Issue #897: the claimed secondary root key must be validated
+    // against the STORED element (canonical authority), not against the
+    // Merk opened WITH that same claimed key. Every row of a secondary
+    // Merk is a node key in its storage, so `open_layered_with_root_key`
+    // succeeds for any of them and returns the claimed key back —
+    // a circular check. Before the fix, a caller supplying the canonical
+    // primary root key and aggregate but a NON-ROOT node key as the
+    // secondary root committed the hash of an interior/leaf node,
+    // authenticating a strict subtree of the index as the whole index.
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn direct_insert_pcit_existing_nonroot_secondary_node_key_rejected() {
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"cidx",
+            Element::empty_provable_count_indexed_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("create");
+        // Three children, each deriving count 1, so the count-axis
+        // secondary Merk holds three row nodes (one of them the root).
+        for k in [b"a".as_ref(), b"b", b"c"] {
+            db.insert_into_count_indexed_tree(
+                [TEST_LEAF, b"cidx"].as_ref(),
+                k,
+                Element::empty_provable_count_tree(),
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("populate");
+            db.insert(
+                [TEST_LEAF, b"cidx", k].as_ref(),
+                b"row",
+                Element::new_item(b"v".to_vec()),
+                None,
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("derive child count");
+        }
+        let elem = db
+            .get_raw([TEST_LEAF].as_ref().into(), b"cidx", None, grove_version)
+            .unwrap()
+            .expect("get");
+        let (real_primary, real_secondary, real_count) = match elem.underlying() {
+            Element::ProvableCountIndexedTree(p, s, c, _) => (p.clone(), s.clone(), *c),
+            other => panic!("expected PCIT, got {:?}", other),
+        };
+        assert_eq!(real_count, 3);
+        let canonical_root = real_secondary.expect("secondary root");
+
+        // Compute the three CURRENT secondary row keys
+        // (`count_be(1) ‖ item_key`) and pick one that is NOT the root:
+        // it exists in the secondary Merk's storage as a non-root node.
+        let forged = [b"a".as_ref(), b"b", b"c"]
+            .iter()
+            .map(|k| {
+                let mut sk = grovedb_element::indexed::encode_count_sort_key(1).to_vec();
+                sk.extend_from_slice(k);
+                sk
+            })
+            .find(|sk| *sk != canonical_root)
+            .expect("a non-root row key");
+
+        let bogus = Element::new_provable_count_indexed_tree_with_root_keys_and_count_value(
+            real_primary,
+            Some(forged),
+            real_count,
+            None,
+        );
+        let result = db
+            .insert(
+                [TEST_LEAF].as_ref(),
+                b"cidx",
+                bogus,
+                Some(override_tree_opts()),
+                None,
+                grove_version,
+            )
+            .unwrap();
+        assert!(
+            matches!(result, Err(Error::InvalidInput(_))),
+            "a forged secondary root key that exists as a non-root node must be rejected, \
+             got {:?}",
+            result
+        );
+        // The canonical state must be untouched and verifiable.
+        let issues = db
+            .verify_grovedb(None, true, true, grove_version)
+            .expect("verify");
+        assert!(issues.is_empty(), "issues: {:?}", issues);
+    }
+
+    #[test]
+    fn direct_insert_psit_existing_nonroot_secondary_node_key_rejected() {
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"psit",
+            Element::empty_provable_sum_indexed_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("create");
+        let rows: [(&[u8], i64); 3] = [(b"a", 5), (b"b", 7), (b"c", 9)];
+        for (k, sum) in rows {
+            db.insert_into_provable_sum_indexed_tree(
+                [TEST_LEAF, b"psit"].as_ref(),
+                k,
+                Element::new_sum_item(sum),
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("populate");
+        }
+        let elem = db
+            .get_raw([TEST_LEAF].as_ref().into(), b"psit", None, grove_version)
+            .unwrap()
+            .expect("get");
+        let (real_primary, real_secondary, real_sum) = match elem.underlying() {
+            Element::ProvableSumIndexedTree(p, s, sv, _) => (p.clone(), s.clone(), *sv),
+            other => panic!("expected PSIT, got {:?}", other),
+        };
+        assert_eq!(real_sum, 21);
+        let canonical_root = real_secondary.expect("secondary root");
+
+        // Sum-axis row keys are `sum_sortable_be(8) ‖ item_key`.
+        let forged = rows
+            .iter()
+            .map(|(k, sum)| {
+                let mut sk = grovedb_element::indexed::encode_sum_sort_key(*sum).to_vec();
+                sk.extend_from_slice(k);
+                sk
+            })
+            .find(|sk| *sk != canonical_root)
+            .expect("a non-root row key");
+
+        let bogus = Element::ProvableSumIndexedTree(real_primary, Some(forged), real_sum, None);
+        let result = db
+            .insert(
+                [TEST_LEAF].as_ref(),
+                b"psit",
+                bogus,
+                Some(override_tree_opts()),
+                None,
+                grove_version,
+            )
+            .unwrap();
+        assert!(
+            matches!(result, Err(Error::InvalidInput(_))),
+            "a forged secondary root key that exists as a non-root node must be rejected, \
+             got {:?}",
+            result
+        );
+        let issues = db
+            .verify_grovedb(None, true, true, grove_version)
+            .expect("verify");
+        assert!(issues.is_empty(), "issues: {:?}", issues);
+    }
+
+    #[test]
+    fn direct_insert_pcpsit_existing_nonroot_axis_node_key_rejected() {
+        let grove_version = GroveVersion::latest();
+        let db = make_test_grovedb(grove_version);
+        let axes: Vec<(u8, Option<Vec<u8>>)> =
+            vec![(IndexAxis::Count.tag(), None), (IndexAxis::Sum.tag(), None)];
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"pcpsit",
+            Element::empty_provable_count_provable_sum_indexed_tree(axes).expect("axes canonical"),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("create");
+        let rows: [(&[u8], i64); 3] = [(b"a", 10), (b"b", -3), (b"c", 7)];
+        for (k, sum) in rows {
+            db.insert_into_provable_count_provable_sum_indexed_tree(
+                [TEST_LEAF, b"pcpsit"].as_ref(),
+                k,
+                Element::new_item_with_sum_item(b"v".to_vec(), sum),
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("populate");
+        }
+        let elem = db
+            .get_raw([TEST_LEAF].as_ref().into(), b"pcpsit", None, grove_version)
+            .unwrap()
+            .expect("get");
+        let (real_primary, real_count, real_sum, real_axes) = match elem.underlying() {
+            Element::ProvableCountProvableSumIndexedTree(p, c, s, a, _) => {
+                (p.clone(), *c, *s, a.clone())
+            }
+            other => panic!("expected PCPSIT, got {:?}", other),
+        };
+        assert_eq!(real_count, 3);
+        assert_eq!(real_sum, 14);
+
+        // Forge the SUM axis root with one of its non-root row node keys
+        // (`sum_sortable_be(8) ‖ item_key`); keep the count axis canonical.
+        let canonical_sum_root = real_axes
+            .iter()
+            .find(|(t, _)| *t == IndexAxis::Sum.tag())
+            .and_then(|(_, rk)| rk.clone())
+            .expect("sum axis root");
+        let forged = rows
+            .iter()
+            .map(|(k, sum)| {
+                let mut sk = grovedb_element::indexed::encode_sum_sort_key(*sum).to_vec();
+                sk.extend_from_slice(k);
+                sk
+            })
+            .find(|sk| *sk != canonical_sum_root)
+            .expect("a non-root row key");
+        let forged_axes: Vec<(u8, Option<Vec<u8>>)> = real_axes
+            .iter()
+            .map(|(t, rk)| {
+                if *t == IndexAxis::Sum.tag() {
+                    (*t, Some(forged.clone()))
+                } else {
+                    (*t, rk.clone())
+                }
+            })
+            .collect();
+
+        let bogus = Element::ProvableCountProvableSumIndexedTree(
+            real_primary,
+            real_count,
+            real_sum,
+            forged_axes,
+            None,
+        );
+        let result = db
+            .insert(
+                [TEST_LEAF].as_ref(),
+                b"pcpsit",
+                bogus,
+                Some(override_tree_opts()),
+                None,
+                grove_version,
+            )
+            .unwrap();
+        assert!(
+            matches!(result, Err(Error::InvalidInput(_))),
+            "a forged axis root key that exists as a non-root node must be rejected, got {:?}",
+            result
+        );
+        let issues = db
+            .verify_grovedb(None, true, true, grove_version)
+            .expect("verify");
+        assert!(issues.is_empty(), "issues: {:?}", issues);
+    }
+
     #[test]
     fn non_counted_indexed_child_rejected_in_provable_count_tree() {
         let grove_version = GroveVersion::latest();

--- a/grovedb/src/tests/verify_grovedb_indexed_tests.rs
+++ b/grovedb/src/tests/verify_grovedb_indexed_tests.rs
@@ -1402,6 +1402,14 @@ mod tests {
             grove_version,
         );
 
+        // Rebind the parent element to the tampered secondary root through
+        // the GROVE_V3 insert arm: since issue #897 the V4+ arm validates
+        // the claimed secondary root key against the stored element and
+        // refuses this exact write (pinned by
+        // `direct_insert_psit_existing_nonroot_secondary_node_key_rejected`),
+        // but V3 accepted it, and states written that way can exist on
+        // disk. The commitment bytes V3 produces are identical to V4's, so
+        // this stays a faithful setup for the relational verifier below.
         db.insert(
             [TEST_LEAF].as_ref(),
             b"psit",
@@ -1413,10 +1421,10 @@ mod tests {
                 propagate_backward_references: false,
             }),
             None,
-            grove_version,
+            &grovedb_version::version::v3::GROVE_V3,
         )
         .unwrap()
-        .expect("rebind authenticated secondary root");
+        .expect("rebind authenticated secondary root via the pre-#897 V3 arm");
 
         let issues = db
             .verify_grovedb(None, false, true, grove_version)


### PR DESCRIPTION
Fixes #897 (audit M019).

## The vulnerability — confirmed real

Direct insertion of a non-empty indexed-tree element (`ProvableCountIndexedTree`, `ProvableSumIndexedTree`, `ProvableCountProvableSumIndexedTree`) validated the claimed secondary root key by opening the secondary Merk **with that key** and comparing the returned root key against the same input — circular. Every row of a secondary Merk is a node key in its storage, so `open_layered_with_root_key` succeeds for any of them and hands the claimed key back.

The primary was never affected: `open_transactional_merk_at_path` reads the root key from the **stored** parent element, so the primary comparison is against canonical state. But a caller supplying the canonical primary root key and aggregates plus a **non-root node key** of the secondary Merk as the secondary root passed every check and committed the hash of an interior/leaf node — authenticating a strict subtree of the index as the whole index. Rows outside that subtree vanish from the authenticated index (wrong top-k/rank results, false absence), while the untouched primary keeps every check green.

Reproduced on current `develop` for all three variants: the new regression tests, run before the fix, saw the forged insert return `Ok(())`.

## The fix

In the **v2 arm** of `add_element_on_transaction` (selected by `GROVE_V4`'s `add_element_on_transaction: 2`, so the version dispatch itself is the gate — same pattern as #922/#923):

- The claimed secondary root key must equal the **stored element's** value; the stored bytes are hash-committed by the parent Merk, so they are the canonical authority. Only after that equality is established are the secondaries opened (with what is now the canonical key) to derive the committed hashes.
- PCPSIT compares the complete `(tag, root_key)` axes mapping after the existing tags-only schema check.
- The no-stored-element / stored-non-tree case (unreachable — the primary open errors first) fails closed instead of open.
- The in-place conversion guards are preserved with identical messages; the stored element is fetched once for both checks, so tracked costs are unchanged.

v0/v1 keep the historical behaviour (`GROVE_V3` is live) and carry KNOWN-FLAW header notes pointing here. The batch path is unaffected: it refuses non-empty indexed overwrites outright.

## Tests

- `direct_insert_{pcit,psit}_existing_nonroot_secondary_node_key_rejected` and `direct_insert_pcpsit_existing_nonroot_axis_node_key_rejected`: forge with an **existing non-root row key** (`sort_key ‖ item_key`) — the shape the old code accepted (the pre-existing mismatch tests used nonexistent keys, which even the old code rejected because the open fails).
- `indexed_tree_direct_insert_guards_v1` now pins the frozen `GROVE_V3` arm explicitly; new `indexed_tree_direct_insert_guards_v2` pins the canonical-authority messages at latest.
- `verify_grovedb_psit_detects_coherently_rebound_relational_drift` staged its corrupt state through exactly this vector; it now rebinds through the `GROVE_V3` arm, simulating a pre-V4-written state, and still pins the relational verifier's detection.

Full `grovedb` lib suite green (3308 tests); clippy `--all-targets` clean on the touched crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)