### PR TITLE
fix: reset parent element and commitment when clearing append-family trees (#893)

### DIFF
--- a/grovedb-version/src/version/v4.rs
+++ b/grovedb-version/src/version/v4.rs
@@ -413,7 +413,13 @@ pub const GROVE_V4: GroveVersion = GroveVersion {
             },
             delete: GroveDBOperationsDeleteVersions {
                 delete: 0,
-                clear_subtree: 0,
+                // v1: clearing a non-Merk data tree (MmrTree, BulkAppendTree,
+                // DenseAppendOnlyFixedSizeTree, CommitmentTree,
+                // PrivateDocumentStore) also resets the parent element to its
+                // canonical empty state and propagates, instead of leaving a
+                // stale count/commitment over the cleared payload (issue
+                // #893).
+                clear_subtree: 1,
                 delete_with_sectional_storage_function: 0,
                 delete_if_empty_tree: 0,
                 delete_if_empty_tree_with_sectional_storage_function: 0,

--- a/grovedb/src/operations/delete/clear_subtree/mod.rs
+++ b/grovedb/src/operations/delete/clear_subtree/mod.rs
@@ -1,0 +1,113 @@
+//! `clear_subtree` — versioned dispatch.
+//!
+//! Deletes all elements in a specified subtree, leaving the subtree itself
+//! (and the element pointing at it) in place.
+//!
+//! For ordinary Merk-backed subtrees both versions behave identically: the
+//! Merk is emptied and its new (null) root hash is propagated to the root.
+//! The versions differ only for **non-Merk data trees** (`MmrTree`,
+//! `BulkAppendTree`, `DenseAppendOnlyFixedSizeTree`, `CommitmentTree`,
+//! `PrivateDocumentStore`), whose payload lives in the data namespace and
+//! whose count and state commitment live in the *parent* element. What the
+//! parent commits to after a clear changes the grovedb root hash, so the
+//! difference is **consensus-critical** and version-gated (issue #893):
+//!
+//! * **[v0]** — legacy behaviour, frozen for `GROVE_V1`..`GROVE_V3` (live in
+//!   production). The payload is cleared from the data namespace and the
+//!   operation reports success, but the parent element is left untouched: it
+//!   still carries the old count / mmr size and the old state commitment,
+//!   and nothing is propagated. The database is left contradicting itself —
+//!   the retained commitment describes data that no longer exists — and
+//!   `verify_grovedb` flags the subtree. Kept bug-for-bug for replay
+//!   compatibility.
+//! * **[v1]** — `GROVE_V4`+. The payload clear, the parent-element reset and
+//!   the upward propagation are staged into one storage batch and committed
+//!   atomically. The parent element is rewritten to its canonical empty
+//!   state — count / mmr size zeroed, configuration (chunk power, height,
+//!   entry size), flags and any `NonCounted`-style wrapper retained — and
+//!   the child hash is reset to the same convention the insert path binds
+//!   for an empty tree (`NULL_HASH`, or the type's empty-state root for
+//!   `CommitmentTree` / `PrivateDocumentStore`). The rewrite propagates
+//!   through ancestors with the indexed-aware walk, refreshing the entry's
+//!   canonical secondary row when the parent is an indexed primary.
+//!
+//! The implementations are otherwise identical. See [v0] / [v1].
+//!
+//! [v0]: self::v0
+//! [v1]: self::v1
+
+mod v0;
+mod v1;
+
+use grovedb_costs::{CostResult, CostsExt, OperationCost};
+use grovedb_path::SubtreePath;
+use grovedb_version::version::GroveVersion;
+
+use super::ClearOptions;
+use crate::{Error, GroveDb, TransactionArg};
+
+impl GroveDb {
+    /// Delete all elements in a specified subtree.
+    /// Returns if we successfully cleared the subtree.
+    ///
+    /// # Dangling references
+    ///
+    /// This operation does **not** check for incoming references (it has no
+    /// backward-references propagation option). Any
+    /// [`Reference`](crate::Element::Reference) or
+    /// [`BidirectionalReference`](crate::Element::BidirectionalReference)
+    /// elements elsewhere in the database that point to elements within the
+    /// cleared subtree will become dangling. See the
+    /// [module-level documentation](super) for details.
+    pub fn clear_subtree<'b, B, P>(
+        &self,
+        path: P,
+        options: Option<ClearOptions>,
+        transaction: TransactionArg,
+        grove_version: &GroveVersion,
+    ) -> Result<bool, Error>
+    where
+        B: AsRef<[u8]> + 'b,
+        P: Into<SubtreePath<'b, B>>,
+    {
+        self.clear_subtree_with_costs(path, options, transaction, grove_version)
+            .unwrap()
+    }
+
+    /// Delete all elements in a specified subtree and get back costs
+    /// Warning: The costs for this operation are not yet correct, hence we
+    /// should keep this private for now
+    /// Returns if we successfully cleared the subtree
+    ///
+    /// Version dispatch (consensus-critical) — see the module documentation.
+    fn clear_subtree_with_costs<'b, B, P>(
+        &self,
+        path: P,
+        options: Option<ClearOptions>,
+        transaction: TransactionArg,
+        grove_version: &GroveVersion,
+    ) -> CostResult<bool, Error>
+    where
+        B: AsRef<[u8]> + 'b,
+        P: Into<SubtreePath<'b, B>>,
+    {
+        match grove_version
+            .grovedb_versions
+            .operations
+            .delete
+            .clear_subtree
+        {
+            0 => self.clear_subtree_with_costs_v0(path.into(), options, transaction, grove_version),
+            1 => self.clear_subtree_with_costs_v1(path.into(), options, transaction, grove_version),
+            version => Err(
+                grovedb_version::error::GroveVersionError::UnknownVersionMismatch {
+                    method: "clear_subtree".to_string(),
+                    known_versions: vec![0, 1],
+                    received: version,
+                }
+                .into(),
+            )
+            .wrap_with_cost(OperationCost::default()),
+        }
+    }
+}

--- a/grovedb/src/operations/delete/clear_subtree/v0.rs
+++ b/grovedb/src/operations/delete/clear_subtree/v0.rs
@@ -1,0 +1,171 @@
+//! `clear_subtree_with_costs` version 0.
+//!
+//! Differs from [v1](super::v1) ONLY in how a non-Merk data tree (`MmrTree`,
+//! `BulkAppendTree`, `DenseAppendOnlyFixedSizeTree`, `CommitmentTree`,
+//! `PrivateDocumentStore`) is cleared: the payload is deleted from the data
+//! namespace and the operation returns success, but the parent element keeps
+//! its old count / state commitment and nothing is propagated, leaving the
+//! retained commitment describing data that no longer exists (issue #893).
+//!
+//! Selected by `GROVE_V1`, `GROVE_V2` and `GROVE_V3` — all live in
+//! production, so the incoherent behaviour is kept bug-for-bug for replay
+//! compatibility.
+
+use std::collections::HashMap;
+
+use grovedb_costs::{
+    cost_return_on_error, cost_return_on_error_no_add, CostResult, CostsExt, OperationCost,
+};
+use grovedb_merk::{element::decode::ElementDecodeExtensions, proofs::Query, KVIterator, Merk};
+use grovedb_path::SubtreePath;
+use grovedb_storage::{
+    rocksdb_storage::PrefixedRocksDbTransactionContext, Storage, StorageBatch, StorageContext,
+};
+use grovedb_version::version::GroveVersion;
+
+use super::super::{ClearOptions, DeleteOptions};
+use crate::{util::TxRef, Element, Error, GroveDb, TransactionArg};
+
+impl GroveDb {
+    /// Clear a subtree — version 0 (frozen, see the module documentation).
+    pub(crate) fn clear_subtree_with_costs_v0<'b, B: AsRef<[u8]>>(
+        &self,
+        subtree_path: SubtreePath<'b, B>,
+        options: Option<ClearOptions>,
+        transaction: TransactionArg,
+        grove_version: &GroveVersion,
+    ) -> CostResult<bool, Error> {
+        let tx = TxRef::new(&self.db, transaction);
+
+        let mut cost = OperationCost::default();
+        let batch = StorageBatch::new();
+
+        let options = options.unwrap_or_default();
+
+        let mut merk_to_clear = cost_return_on_error!(
+            &mut cost,
+            self.open_transactional_merk_at_path(
+                subtree_path.clone(),
+                tx.as_ref(),
+                Some(&batch),
+                grove_version,
+            )
+        );
+
+        // Clearing an indexed primary would empty the primary Merk while
+        // leaving every per-axis secondary Merk fully populated, so the
+        // element's secondary root key / axes digest would still commit to
+        // rows that no longer exist. Reject rather than corrupt; callers
+        // should delete the indexed tree itself (which sweeps all axes) or
+        // remove entries through the dedicated `delete_from_*` APIs.
+        cost_return_on_error_no_add!(
+            cost,
+            crate::operations::indexed_tree::reject_generic_write_into_indexed_primary(
+                merk_to_clear.tree_type,
+                "clear_subtree",
+            )
+        );
+
+        // Non-Merk data trees store data in the data namespace as non-Element
+        // entries.  We cannot iterate them with Element::iterator, so just
+        // clear the storage directly.
+        if merk_to_clear.tree_type.uses_non_merk_data_storage() {
+            let mut storage = self
+                .db
+                .get_transactional_storage_context(subtree_path.clone(), Some(&batch), tx.as_ref())
+                .unwrap_add_cost(&mut cost);
+            cost_return_on_error!(
+                &mut cost,
+                storage.clear().map_err(|e| {
+                    Error::CorruptedData(format!(
+                        "unable to clear non-merk tree data from storage: {e}",
+                    ))
+                })
+            );
+
+            cost_return_on_error!(
+                &mut cost,
+                self.db
+                    .commit_multi_context_batch(batch, Some(tx.as_ref()))
+                    .map_err(Into::into)
+            );
+
+            return tx.commit_local().map(|_| true).wrap_with_cost(cost);
+        }
+
+        if options.check_for_subtrees {
+            let mut all_query = Query::new();
+            all_query.insert_all();
+
+            let mut element_iterator =
+                KVIterator::new(merk_to_clear.storage.raw_iter(), &all_query).unwrap();
+
+            // delete all nested subtrees
+            while let Some((key, element_value)) =
+                element_iterator.next_kv().unwrap_add_cost(&mut cost)
+            {
+                let element = match Element::raw_decode(&element_value, grove_version) {
+                    Ok(e) => e,
+                    Err(e) => {
+                        return Err(Error::CorruptedData(format!(
+                            "unable to decode element while clearing subtree: {e}"
+                        )))
+                        .wrap_with_cost(cost);
+                    }
+                };
+                if element.is_any_tree() {
+                    if options.allow_deleting_subtrees {
+                        cost_return_on_error!(
+                            &mut cost,
+                            self.delete(
+                                subtree_path.clone(),
+                                key.as_slice(),
+                                Some(DeleteOptions {
+                                    allow_deleting_non_empty_trees: true,
+                                    deleting_non_empty_trees_returns_error: false,
+                                    ..Default::default()
+                                }),
+                                Some(tx.as_ref()),
+                                grove_version,
+                            )
+                        );
+                    } else if options.trying_to_clear_with_subtrees_returns_error {
+                        return Err(Error::ClearingTreeWithSubtreesNotAllowed(
+                            "options do not allow to clear this merk tree as it contains subtrees",
+                        ))
+                        .wrap_with_cost(cost);
+                    } else {
+                        return Ok(false).wrap_with_cost(cost);
+                    }
+                }
+            }
+        }
+
+        // delete non subtree values
+        cost_return_on_error!(&mut cost, merk_to_clear.clear().map_err(Error::MerkError));
+
+        // propagate changes
+        let mut merk_cache: HashMap<SubtreePath<B>, Merk<PrefixedRocksDbTransactionContext>> =
+            HashMap::default();
+        merk_cache.insert(subtree_path.clone(), merk_to_clear);
+        cost_return_on_error!(
+            &mut cost,
+            self.propagate_changes_with_transaction(
+                merk_cache,
+                subtree_path.clone(),
+                tx.as_ref(),
+                &batch,
+                grove_version,
+            )
+        );
+
+        cost_return_on_error!(
+            &mut cost,
+            self.db
+                .commit_multi_context_batch(batch, Some(tx.as_ref()))
+                .map_err(Into::into)
+        );
+
+        tx.commit_local().map(|_| true).wrap_with_cost(cost)
+    }
+}

--- a/grovedb/src/operations/delete/clear_subtree/v1.rs
+++ b/grovedb/src/operations/delete/clear_subtree/v1.rs
@@ -1,0 +1,299 @@
+//! `clear_subtree_with_costs` version 1.
+//!
+//! Differs from [v0](super::v0) ONLY in how a non-Merk data tree (`MmrTree`,
+//! `BulkAppendTree`, `DenseAppendOnlyFixedSizeTree`, `CommitmentTree`,
+//! `PrivateDocumentStore`) is cleared: in addition to deleting the payload
+//! from the data namespace, the parent element is rewritten to its canonical
+//! empty state — count / mmr size zeroed, configuration, flags and any
+//! `NonCounted`-style wrapper retained — with the child hash reset to the
+//! same convention the insert path binds for an empty tree, and the rewrite
+//! is propagated through ancestors (refreshing the entry's canonical
+//! secondary row when the parent is an indexed primary). Payload clear,
+//! element reset and propagation are staged into one storage batch, so they
+//! commit atomically (issue #893).
+//!
+//! Selected by `GROVE_V4`+.
+
+use std::collections::HashMap;
+
+use grovedb_costs::{
+    cost_return_on_error, cost_return_on_error_no_add, CostResult, CostsExt, OperationCost,
+};
+use grovedb_merk::{
+    element::{decode::ElementDecodeExtensions, insert::ElementInsertToStorageExtensions},
+    proofs::Query,
+    tree::hash::NULL_HASH,
+    KVIterator, Merk,
+};
+use grovedb_path::SubtreePath;
+use grovedb_storage::{
+    rocksdb_storage::PrefixedRocksDbTransactionContext, Storage, StorageBatch, StorageContext,
+};
+use grovedb_version::version::GroveVersion;
+
+use super::super::{ClearOptions, DeleteOptions};
+use crate::{util::TxRef, Element, Error, GroveDb, TransactionArg};
+
+impl GroveDb {
+    /// Clear a subtree — version 1 (see the module documentation).
+    pub(crate) fn clear_subtree_with_costs_v1<'b, B: AsRef<[u8]>>(
+        &self,
+        subtree_path: SubtreePath<'b, B>,
+        options: Option<ClearOptions>,
+        transaction: TransactionArg,
+        grove_version: &GroveVersion,
+    ) -> CostResult<bool, Error> {
+        let tx = TxRef::new(&self.db, transaction);
+
+        let mut cost = OperationCost::default();
+        let batch = StorageBatch::new();
+
+        let options = options.unwrap_or_default();
+
+        let mut merk_to_clear = cost_return_on_error!(
+            &mut cost,
+            self.open_transactional_merk_at_path(
+                subtree_path.clone(),
+                tx.as_ref(),
+                Some(&batch),
+                grove_version,
+            )
+        );
+
+        // Clearing an indexed primary would empty the primary Merk while
+        // leaving every per-axis secondary Merk fully populated, so the
+        // element's secondary root key / axes digest would still commit to
+        // rows that no longer exist. Reject rather than corrupt; callers
+        // should delete the indexed tree itself (which sweeps all axes) or
+        // remove entries through the dedicated `delete_from_*` APIs.
+        cost_return_on_error_no_add!(
+            cost,
+            crate::operations::indexed_tree::reject_generic_write_into_indexed_primary(
+                merk_to_clear.tree_type,
+                "clear_subtree",
+            )
+        );
+
+        // Non-Merk data trees store data in the data namespace as non-Element
+        // entries.  We cannot iterate them with Element::iterator, so clear
+        // the storage directly — and, because their count and state
+        // commitment live in the parent element rather than in the (always
+        // empty) Merk, reset that element to its canonical empty state and
+        // propagate, all staged into the same storage batch so payload
+        // clear, element reset and propagation commit atomically.
+        if merk_to_clear.tree_type.uses_non_merk_data_storage() {
+            let (parent_path, parent_key) = cost_return_on_error_no_add!(
+                cost,
+                subtree_path.derive_parent().ok_or(Error::CorruptedPath(
+                    "a non-Merk data tree cannot be the root tree".to_string()
+                ))
+            );
+
+            // The stored element, wrapper and flags included.
+            let stored_element = cost_return_on_error!(
+                &mut cost,
+                self.get_raw_caching_optional(
+                    parent_path.clone(),
+                    parent_key,
+                    true,
+                    Some(tx.as_ref()),
+                    grove_version,
+                )
+            );
+
+            // Zero the count / mmr size, keeping configuration, flags and
+            // any wrapper. The child hash must match what the insert path
+            // binds for a freshly inserted empty tree of the same type —
+            // see `add_element_on_transaction`.
+            let mut emptied_element = stored_element.clone();
+            let empty_child_hash = match emptied_element.underlying_mut() {
+                Element::MmrTree(mmr_size, ..) => {
+                    *mmr_size = 0;
+                    NULL_HASH
+                }
+                Element::BulkAppendTree(total_count, ..) => {
+                    *total_count = 0;
+                    NULL_HASH
+                }
+                Element::DenseAppendOnlyFixedSizeTree(count, ..) => {
+                    *count = 0;
+                    NULL_HASH
+                }
+                Element::CommitmentTree(total_count, ..) => {
+                    *total_count = 0;
+                    grovedb_commitment_tree::EMPTY_COMMITMENT_TREE_STATE_ROOT
+                }
+                Element::PrivateDocumentStore(total_count, entry_size, chunk_power, _) => {
+                    let empty_root =
+                        grovedb_private_document_store::empty_private_document_store_state_root(
+                            *entry_size,
+                            *chunk_power,
+                        );
+                    *total_count = 0;
+                    empty_root
+                }
+                _ => {
+                    return Err(Error::CorruptedData(
+                        "tree type uses non-merk data storage but the stored element is not a \
+                         non-Merk data tree"
+                            .to_string(),
+                    ))
+                    .wrap_with_cost(cost);
+                }
+            };
+
+            // Clear the payload from the data namespace.
+            let mut storage = self
+                .db
+                .get_transactional_storage_context(subtree_path.clone(), Some(&batch), tx.as_ref())
+                .unwrap_add_cost(&mut cost);
+            cost_return_on_error!(
+                &mut cost,
+                storage.clear().map_err(|e| {
+                    Error::CorruptedData(format!(
+                        "unable to clear non-merk tree data from storage: {e}",
+                    ))
+                })
+            );
+
+            drop(merk_to_clear);
+
+            // Rewrite the parent element and propagate the new child hash,
+            // refreshing the entry's canonical secondary row when the
+            // parent is an indexed primary — the same walk the typed
+            // append paths use.
+            let mut parent_merk = cost_return_on_error!(
+                &mut cost,
+                self.open_transactional_merk_at_path(
+                    parent_path.clone(),
+                    tx.as_ref(),
+                    Some(&batch),
+                    grove_version,
+                )
+            );
+
+            let old_indexed_state = cost_return_on_error!(
+                &mut cost,
+                GroveDb::capture_indexed_entry_state(
+                    &parent_merk,
+                    parent_key,
+                    &stored_element,
+                    grove_version,
+                )
+            );
+
+            cost_return_on_error!(
+                &mut cost,
+                emptied_element
+                    .insert_subtree(
+                        &mut parent_merk,
+                        parent_key,
+                        empty_child_hash,
+                        None,
+                        grove_version,
+                    )
+                    .map_err(|e| e.into())
+            );
+
+            let mut merk_cache: HashMap<SubtreePath<B>, Merk<PrefixedRocksDbTransactionContext>> =
+                HashMap::default();
+            merk_cache.insert(parent_path.clone(), parent_merk);
+            cost_return_on_error!(
+                &mut cost,
+                self.propagate_changes_with_transaction_refreshing_indexed_row(
+                    merk_cache,
+                    parent_path,
+                    parent_key,
+                    old_indexed_state,
+                    tx.as_ref(),
+                    &batch,
+                    grove_version,
+                )
+            );
+
+            cost_return_on_error!(
+                &mut cost,
+                self.db
+                    .commit_multi_context_batch(batch, Some(tx.as_ref()))
+                    .map_err(Into::into)
+            );
+
+            return tx.commit_local().map(|_| true).wrap_with_cost(cost);
+        }
+
+        if options.check_for_subtrees {
+            let mut all_query = Query::new();
+            all_query.insert_all();
+
+            let mut element_iterator =
+                KVIterator::new(merk_to_clear.storage.raw_iter(), &all_query).unwrap();
+
+            // delete all nested subtrees
+            while let Some((key, element_value)) =
+                element_iterator.next_kv().unwrap_add_cost(&mut cost)
+            {
+                let element = match Element::raw_decode(&element_value, grove_version) {
+                    Ok(e) => e,
+                    Err(e) => {
+                        return Err(Error::CorruptedData(format!(
+                            "unable to decode element while clearing subtree: {e}"
+                        )))
+                        .wrap_with_cost(cost);
+                    }
+                };
+                if element.is_any_tree() {
+                    if options.allow_deleting_subtrees {
+                        cost_return_on_error!(
+                            &mut cost,
+                            self.delete(
+                                subtree_path.clone(),
+                                key.as_slice(),
+                                Some(DeleteOptions {
+                                    allow_deleting_non_empty_trees: true,
+                                    deleting_non_empty_trees_returns_error: false,
+                                    ..Default::default()
+                                }),
+                                Some(tx.as_ref()),
+                                grove_version,
+                            )
+                        );
+                    } else if options.trying_to_clear_with_subtrees_returns_error {
+                        return Err(Error::ClearingTreeWithSubtreesNotAllowed(
+                            "options do not allow to clear this merk tree as it contains subtrees",
+                        ))
+                        .wrap_with_cost(cost);
+                    } else {
+                        return Ok(false).wrap_with_cost(cost);
+                    }
+                }
+            }
+        }
+
+        // delete non subtree values
+        cost_return_on_error!(&mut cost, merk_to_clear.clear().map_err(Error::MerkError));
+
+        // propagate changes
+        let mut merk_cache: HashMap<SubtreePath<B>, Merk<PrefixedRocksDbTransactionContext>> =
+            HashMap::default();
+        merk_cache.insert(subtree_path.clone(), merk_to_clear);
+        cost_return_on_error!(
+            &mut cost,
+            self.propagate_changes_with_transaction(
+                merk_cache,
+                subtree_path.clone(),
+                tx.as_ref(),
+                &batch,
+                grove_version,
+            )
+        );
+
+        cost_return_on_error!(
+            &mut cost,
+            self.db
+                .commit_multi_context_batch(batch, Some(tx.as_ref()))
+                .map_err(Into::into)
+        );
+
+        tx.commit_local().map(|_| true).wrap_with_cost(cost)
+    }
+}

--- a/grovedb/src/operations/delete/mod.rs
+++ b/grovedb/src/operations/delete/mod.rs
@@ -23,6 +23,10 @@
 
 #[cfg(feature = "estimated_costs")]
 mod average_case;
+/// Versioned dispatch for `clear_subtree`. Consensus-critical — see the
+/// module docs (issue #893).
+#[cfg(feature = "minimal")]
+mod clear_subtree;
 /// Versioned dispatch for `delete_internal_on_transaction` (the shared
 /// delete path). Consensus-critical — see the module docs.
 #[cfg(feature = "minimal")]
@@ -38,7 +42,7 @@ pub mod flat_drop;
 mod worst_case;
 
 #[cfg(feature = "minimal")]
-use std::collections::{BTreeSet, HashMap};
+use std::collections::BTreeSet;
 
 #[cfg(feature = "minimal")]
 pub use delete_up_tree::DeleteUpTreeOptions;
@@ -46,22 +50,18 @@ pub use delete_up_tree::DeleteUpTreeOptions;
 pub use flat_drop::PendingPrefixDropsReport;
 #[cfg(feature = "minimal")]
 use grovedb_costs::{
-    cost_return_on_error, cost_return_on_error_no_add,
+    cost_return_on_error,
     storage_cost::removal::{StorageRemovedBytes, StorageRemovedBytes::BasicStorageRemoval},
     CostResult, CostsExt, OperationCost,
 };
-use grovedb_merk::element::{
-    decode::ElementDecodeExtensions, tree_type::ElementTreeTypeExtensions,
-};
+use grovedb_merk::element::tree_type::ElementTreeTypeExtensions;
 #[cfg(feature = "minimal")]
-use grovedb_merk::{proofs::Query, KVIterator, MaybeTree};
+use grovedb_merk::MaybeTree;
 #[cfg(feature = "minimal")]
-use grovedb_merk::{Error as MerkError, Merk, MerkOptions};
+use grovedb_merk::{Error as MerkError, MerkOptions};
 use grovedb_path::SubtreePath;
 #[cfg(feature = "minimal")]
-use grovedb_storage::{
-    rocksdb_storage::PrefixedRocksDbTransactionContext, Storage, StorageBatch, StorageContext,
-};
+use grovedb_storage::{Storage, StorageBatch};
 use grovedb_version::{check_grovedb_v0_with_cost, version::GroveVersion};
 
 use crate::util::{compat, TxRef};
@@ -207,192 +207,6 @@ impl GroveDb {
         );
 
         tx.commit_local().wrap_with_cost(cost)
-    }
-
-    /// Delete all elements in a specified subtree.
-    /// Returns if we successfully cleared the subtree.
-    ///
-    /// # Dangling references
-    ///
-    /// This operation does **not** check for incoming references (it has no
-    /// backward-references propagation option). Any
-    /// [`Reference`](crate::Element::Reference) or
-    /// [`BidirectionalReference`](crate::Element::BidirectionalReference)
-    /// elements elsewhere in the database that point to elements within the
-    /// cleared subtree will become dangling. See the
-    /// [module-level documentation](self) for details.
-    pub fn clear_subtree<'b, B, P>(
-        &self,
-        path: P,
-        options: Option<ClearOptions>,
-        transaction: TransactionArg,
-        grove_version: &GroveVersion,
-    ) -> Result<bool, Error>
-    where
-        B: AsRef<[u8]> + 'b,
-        P: Into<SubtreePath<'b, B>>,
-    {
-        self.clear_subtree_with_costs(path, options, transaction, grove_version)
-            .unwrap()
-    }
-
-    /// Delete all elements in a specified subtree and get back costs
-    /// Warning: The costs for this operation are not yet correct, hence we
-    /// should keep this private for now
-    /// Returns if we successfully cleared the subtree
-    fn clear_subtree_with_costs<'b, B, P>(
-        &self,
-        path: P,
-        options: Option<ClearOptions>,
-        transaction: TransactionArg,
-        grove_version: &GroveVersion,
-    ) -> CostResult<bool, Error>
-    where
-        B: AsRef<[u8]> + 'b,
-        P: Into<SubtreePath<'b, B>>,
-    {
-        check_grovedb_v0_with_cost!(
-            "clear_subtree",
-            grove_version
-                .grovedb_versions
-                .operations
-                .delete
-                .clear_subtree
-        );
-
-        let tx = TxRef::new(&self.db, transaction);
-
-        let subtree_path: SubtreePath<B> = path.into();
-        let mut cost = OperationCost::default();
-        let batch = StorageBatch::new();
-
-        let options = options.unwrap_or_default();
-
-        let mut merk_to_clear = cost_return_on_error!(
-            &mut cost,
-            self.open_transactional_merk_at_path(
-                subtree_path.clone(),
-                tx.as_ref(),
-                Some(&batch),
-                grove_version,
-            )
-        );
-
-        // Clearing an indexed primary would empty the primary Merk while
-        // leaving every per-axis secondary Merk fully populated, so the
-        // element's secondary root key / axes digest would still commit to
-        // rows that no longer exist. Reject rather than corrupt; callers
-        // should delete the indexed tree itself (which sweeps all axes) or
-        // remove entries through the dedicated `delete_from_*` APIs.
-        cost_return_on_error_no_add!(
-            cost,
-            crate::operations::indexed_tree::reject_generic_write_into_indexed_primary(
-                merk_to_clear.tree_type,
-                "clear_subtree",
-            )
-        );
-
-        // Non-Merk data trees store data in the data namespace as non-Element
-        // entries.  We cannot iterate them with Element::iterator, so just
-        // clear the storage directly.
-        if merk_to_clear.tree_type.uses_non_merk_data_storage() {
-            let mut storage = self
-                .db
-                .get_transactional_storage_context(subtree_path.clone(), Some(&batch), tx.as_ref())
-                .unwrap_add_cost(&mut cost);
-            cost_return_on_error!(
-                &mut cost,
-                storage.clear().map_err(|e| {
-                    Error::CorruptedData(format!(
-                        "unable to clear non-merk tree data from storage: {e}",
-                    ))
-                })
-            );
-
-            cost_return_on_error!(
-                &mut cost,
-                self.db
-                    .commit_multi_context_batch(batch, Some(tx.as_ref()))
-                    .map_err(Into::into)
-            );
-
-            return tx.commit_local().map(|_| true).wrap_with_cost(cost);
-        }
-
-        if options.check_for_subtrees {
-            let mut all_query = Query::new();
-            all_query.insert_all();
-
-            let mut element_iterator =
-                KVIterator::new(merk_to_clear.storage.raw_iter(), &all_query).unwrap();
-
-            // delete all nested subtrees
-            while let Some((key, element_value)) =
-                element_iterator.next_kv().unwrap_add_cost(&mut cost)
-            {
-                let element = match Element::raw_decode(&element_value, grove_version) {
-                    Ok(e) => e,
-                    Err(e) => {
-                        return Err(Error::CorruptedData(format!(
-                            "unable to decode element while clearing subtree: {e}"
-                        )))
-                        .wrap_with_cost(cost);
-                    }
-                };
-                if element.is_any_tree() {
-                    if options.allow_deleting_subtrees {
-                        cost_return_on_error!(
-                            &mut cost,
-                            self.delete(
-                                subtree_path.clone(),
-                                key.as_slice(),
-                                Some(DeleteOptions {
-                                    allow_deleting_non_empty_trees: true,
-                                    deleting_non_empty_trees_returns_error: false,
-                                    ..Default::default()
-                                }),
-                                Some(tx.as_ref()),
-                                grove_version,
-                            )
-                        );
-                    } else if options.trying_to_clear_with_subtrees_returns_error {
-                        return Err(Error::ClearingTreeWithSubtreesNotAllowed(
-                            "options do not allow to clear this merk tree as it contains subtrees",
-                        ))
-                        .wrap_with_cost(cost);
-                    } else {
-                        return Ok(false).wrap_with_cost(cost);
-                    }
-                }
-            }
-        }
-
-        // delete non subtree values
-        cost_return_on_error!(&mut cost, merk_to_clear.clear().map_err(Error::MerkError));
-
-        // propagate changes
-        let mut merk_cache: HashMap<SubtreePath<B>, Merk<PrefixedRocksDbTransactionContext>> =
-            HashMap::default();
-        merk_cache.insert(subtree_path.clone(), merk_to_clear);
-        cost_return_on_error!(
-            &mut cost,
-            self.propagate_changes_with_transaction(
-                merk_cache,
-                subtree_path.clone(),
-                tx.as_ref(),
-                &batch,
-                grove_version,
-            )
-        );
-
-        cost_return_on_error!(
-            &mut cost,
-            self.db
-                .commit_multi_context_batch(batch, Some(tx.as_ref()))
-                .map_err(Into::into)
-        );
-
-        tx.commit_local().map(|_| true).wrap_with_cost(cost)
     }
 
     /// Delete element with sectional storage function.

--- a/grovedb/src/tests/clear_append_tree_tests.rs
+++ b/grovedb/src/tests/clear_append_tree_tests.rs
@@ -462,3 +462,166 @@ fn clear_under_grove_v3_keeps_stale_parent_element() {
         "v0 must not propagate anything"
     );
 }
+
+// ---------------------------------------------------------------------------
+// v0 ordinary-Merk coverage — the pre-`GROVE_V4` implementation is frozen in
+// its own sub-file, so exercise its plain-Merk branches (identical in
+// behaviour to v1) under `GROVE_V3` explicitly.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn clear_ordinary_tree_under_grove_v3_clears_and_propagates() {
+    let grove_version = &GROVE_V3;
+    let db = make_empty_grovedb();
+
+    db.insert(
+        EMPTY_PATH,
+        b"tree",
+        Element::empty_tree(),
+        None,
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("insert tree");
+
+    let empty_root = root_hash(&db, grove_version);
+
+    for i in 0u8..5 {
+        db.insert(
+            [b"tree".as_ref()].as_ref(),
+            &[i],
+            Element::new_item(vec![i; 10]),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert item");
+    }
+    assert_ne!(root_hash(&db, grove_version), empty_root);
+
+    let cleared = db
+        .clear_subtree([b"tree".as_ref()].as_ref(), None, None, grove_version)
+        .expect("clear should succeed");
+    assert!(cleared);
+
+    assert!(db
+        .is_empty_tree([b"tree".as_ref()].as_ref(), None, grove_version)
+        .unwrap()
+        .expect("emptiness check"));
+    assert_eq!(
+        root_hash(&db, grove_version),
+        empty_root,
+        "an ordinary-Merk clear must propagate under v0 exactly as before"
+    );
+}
+
+#[test]
+fn clear_ordinary_tree_with_subtrees_under_grove_v3_option_branches() {
+    use crate::operations::delete::ClearOptions;
+
+    let grove_version = &GROVE_V3;
+    let db = make_empty_grovedb();
+
+    db.insert(
+        EMPTY_PATH,
+        b"tree",
+        Element::empty_tree(),
+        None,
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("insert tree");
+    db.insert(
+        [b"tree".as_ref()].as_ref(),
+        b"inner",
+        Element::empty_tree(),
+        None,
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("insert nested tree");
+
+    // Default options: error out on the nested subtree.
+    let result = db.clear_subtree([b"tree".as_ref()].as_ref(), None, None, grove_version);
+    assert!(
+        matches!(
+            result,
+            Err(crate::Error::ClearingTreeWithSubtreesNotAllowed(_))
+        ),
+        "expected ClearingTreeWithSubtreesNotAllowed, got {result:?}"
+    );
+
+    // Same, but asked to report instead of erroring.
+    let cleared = db
+        .clear_subtree(
+            [b"tree".as_ref()].as_ref(),
+            Some(ClearOptions {
+                check_for_subtrees: true,
+                allow_deleting_subtrees: false,
+                trying_to_clear_with_subtrees_returns_error: false,
+            }),
+            None,
+            grove_version,
+        )
+        .expect("clear should not error");
+    assert!(!cleared, "clear must report false when subtrees remain");
+
+    // Allowed to delete subtrees: clears everything.
+    let cleared = db
+        .clear_subtree(
+            [b"tree".as_ref()].as_ref(),
+            Some(ClearOptions {
+                check_for_subtrees: true,
+                allow_deleting_subtrees: true,
+                trying_to_clear_with_subtrees_returns_error: false,
+            }),
+            None,
+            grove_version,
+        )
+        .expect("clear should succeed");
+    assert!(cleared);
+    assert!(db
+        .is_empty_tree([b"tree".as_ref()].as_ref(), None, grove_version)
+        .unwrap()
+        .expect("emptiness check"));
+}
+
+#[test]
+fn clear_subtree_unknown_version_is_rejected() {
+    use grovedb_version::version::v4::GROVE_V4;
+
+    let db = make_empty_grovedb();
+    db.insert(
+        EMPTY_PATH,
+        b"tree",
+        Element::empty_tree(),
+        None,
+        None,
+        GroveVersion::latest(),
+    )
+    .unwrap()
+    .expect("insert tree");
+
+    let mut unknown = GROVE_V4.clone();
+    unknown.grovedb_versions.operations.delete.clear_subtree = 9;
+
+    let result = db.clear_subtree([b"tree".as_ref()].as_ref(), None, None, &unknown);
+    match result {
+        Err(crate::Error::VersionError(
+            grovedb_version::error::GroveVersionError::UnknownVersionMismatch {
+                method,
+                known_versions,
+                received,
+            },
+        )) => {
+            assert_eq!(method, "clear_subtree");
+            assert_eq!(known_versions, vec![0, 1]);
+            assert_eq!(received, 9);
+        }
+        other => panic!("expected UnknownVersionMismatch, got {other:?}"),
+    }
+}

--- a/grovedb/src/tests/clear_append_tree_tests.rs
+++ b/grovedb/src/tests/clear_append_tree_tests.rs
@@ -1,0 +1,464 @@
+//! Issue #893 — clearing a non-Merk data tree (MmrTree, BulkAppendTree,
+//! DenseAppendOnlyFixedSizeTree, CommitmentTree, PrivateDocumentStore) must
+//! leave the retained parent element and commitment describing the canonical
+//! empty child state.
+//!
+//! Under `GROVE_V4`+ (`clear_subtree` v1) the payload clear, the parent
+//! element reset (count zeroed, configuration / flags / wrapper retained)
+//! and the upward propagation commit atomically, so a cleared tree is
+//! indistinguishable — element, child hash and grovedb root — from a
+//! freshly inserted empty tree of the same type, and a subsequent typed
+//! append lands exactly where a first append into a fresh tree would.
+//!
+//! Under `GROVE_V1`..`GROVE_V3` (`clear_subtree` v0, live in production)
+//! the incoherent legacy behaviour — payload gone, parent element and
+//! commitment stale, nothing propagated — is pinned for replay
+//! compatibility.
+
+use grovedb_version::version::{v3::GROVE_V3, GroveVersion};
+
+use crate::{
+    tests::{common::EMPTY_PATH, make_empty_grovedb, TempGroveDb},
+    Element,
+};
+
+/// A distinctive flags payload used to check flag retention.
+const FLAGS: [u8; 3] = [7, 8, 9];
+
+fn root_hash(db: &TempGroveDb, grove_version: &GroveVersion) -> [u8; 32] {
+    db.root_hash(None, grove_version)
+        .unwrap()
+        .expect("root hash")
+}
+
+fn commitment_tree_row_insert(db: &TempGroveDb, key: &[u8], i: u8, grove_version: &GroveVersion) {
+    let mut cmx = [0u8; 32];
+    cmx[0] = i;
+    cmx[31] &= 0x7f;
+    let mut rho = [0u8; 32];
+    rho[0] = i;
+    rho[1] = 0xB0;
+    let mut cv_net = [0u8; 32];
+    cv_net[0] = i;
+    cv_net[1] = 0xCC;
+    let mut enc_data = [0u8; 104];
+    enc_data[0] = i;
+    let mut epk = [0u8; 32];
+    epk[0] = i;
+    let mut out_ct = [0u8; 80];
+    out_ct[0] = i;
+    let ciphertext = grovedb_commitment_tree::TransmittedNoteCiphertext::<
+        grovedb_commitment_tree::DashMemo,
+    >::from_parts(
+        epk,
+        grovedb_commitment_tree::NoteBytesData(enc_data),
+        out_ct,
+    );
+    db.commitment_tree_insert(
+        EMPTY_PATH,
+        key,
+        cmx,
+        rho,
+        cv_net,
+        ciphertext,
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("commitment tree insert");
+}
+
+/// Clear a populated tree and require its element, child commitment and the
+/// grovedb root to be exactly those of a never-populated twin; then append
+/// once into both and require they still agree.
+fn assert_clear_matches_fresh_tree(
+    element: Element,
+    append: impl Fn(&TempGroveDb, u8),
+    grove_version: &GroveVersion,
+) {
+    let key: &[u8] = b"tree";
+
+    let cleared_db = make_empty_grovedb();
+    cleared_db
+        .insert(EMPTY_PATH, key, element.clone(), None, None, grove_version)
+        .unwrap()
+        .expect("insert tree");
+    for i in 0..5u8 {
+        append(&cleared_db, i);
+    }
+
+    let fresh_db = make_empty_grovedb();
+    fresh_db
+        .insert(EMPTY_PATH, key, element.clone(), None, None, grove_version)
+        .unwrap()
+        .expect("insert tree");
+
+    assert_ne!(
+        root_hash(&cleared_db, grove_version),
+        root_hash(&fresh_db, grove_version),
+        "appends must have moved the root before the clear"
+    );
+
+    let cleared = cleared_db
+        .clear_subtree([key].as_ref(), None, None, grove_version)
+        .expect("clear should succeed");
+    assert!(cleared, "clear_subtree should return true");
+
+    let stored = cleared_db
+        .get_raw(EMPTY_PATH, key, None, grove_version)
+        .unwrap()
+        .expect("stored element after clear");
+    assert_eq!(
+        stored, element,
+        "cleared element must equal the freshly inserted empty element \
+         (count zeroed, configuration and flags retained)"
+    );
+
+    assert_eq!(
+        root_hash(&cleared_db, grove_version),
+        root_hash(&fresh_db, grove_version),
+        "a cleared tree must commit the same root as a never-populated twin"
+    );
+
+    let issues = cleared_db
+        .verify_grovedb(None, true, false, grove_version)
+        .expect("verify should not fail");
+    assert!(
+        issues.is_empty(),
+        "cleared database must be coherent, got: {:?}",
+        issues
+    );
+
+    // A typed append after the clear must land exactly where a first append
+    // into a fresh tree lands.
+    append(&cleared_db, 42);
+    append(&fresh_db, 42);
+    assert_eq!(
+        root_hash(&cleared_db, grove_version),
+        root_hash(&fresh_db, grove_version),
+        "an append after clear must match a first append into a fresh tree"
+    );
+
+    let issues = cleared_db
+        .verify_grovedb(None, true, false, grove_version)
+        .expect("verify should not fail");
+    assert!(
+        issues.is_empty(),
+        "database must stay coherent after the post-clear append, got: {:?}",
+        issues
+    );
+}
+
+#[test]
+fn clear_mmr_tree_resets_parent_element_and_commitment() {
+    let grove_version = GroveVersion::latest();
+    assert_clear_matches_fresh_tree(
+        Element::empty_mmr_tree_with_flags(Some(FLAGS.to_vec())),
+        |db, i| {
+            db.mmr_tree_append(EMPTY_PATH, b"tree", vec![i], None, grove_version)
+                .unwrap()
+                .expect("append value");
+        },
+        grove_version,
+    );
+
+    // Typed reads after clear + re-append: one leaf, at index 0.
+    let db = make_empty_grovedb();
+    db.insert(
+        EMPTY_PATH,
+        b"tree",
+        Element::empty_mmr_tree(),
+        None,
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("insert tree");
+    for i in 0..5u8 {
+        db.mmr_tree_append(EMPTY_PATH, b"tree", vec![i], None, grove_version)
+            .unwrap()
+            .expect("append value");
+    }
+    db.clear_subtree([b"tree".as_ref()].as_ref(), None, None, grove_version)
+        .expect("clear should succeed");
+    assert_eq!(
+        db.mmr_tree_leaf_count(EMPTY_PATH, b"tree", None, grove_version)
+            .unwrap()
+            .expect("leaf count"),
+        0
+    );
+    let (_, leaf_index) = db
+        .mmr_tree_append(EMPTY_PATH, b"tree", vec![99], None, grove_version)
+        .unwrap()
+        .expect("append after clear");
+    assert_eq!(leaf_index, 0, "append after clear must start over");
+    assert_eq!(
+        db.mmr_tree_get_value(EMPTY_PATH, b"tree", 0, None, grove_version)
+            .unwrap()
+            .expect("get value"),
+        Some(vec![99])
+    );
+}
+
+#[test]
+fn clear_bulk_append_tree_resets_parent_element_and_commitment() {
+    let grove_version = GroveVersion::latest();
+    // Chunk power 2 → 4 rows per chunk, so 5 appends span a completed chunk
+    // plus a partially filled buffer.
+    let element = Element::empty_bulk_append_tree_with_flags(2, Some(FLAGS.to_vec()))
+        .expect("valid chunk power");
+    assert_clear_matches_fresh_tree(
+        element,
+        |db, i| {
+            db.bulk_append(EMPTY_PATH, b"tree", vec![i, 0xB0], None, grove_version)
+                .unwrap()
+                .expect("bulk append");
+        },
+        grove_version,
+    );
+}
+
+#[test]
+fn clear_dense_tree_resets_parent_element_and_commitment() {
+    let grove_version = GroveVersion::latest();
+    assert_clear_matches_fresh_tree(
+        Element::empty_dense_tree_with_flags(5, Some(FLAGS.to_vec())),
+        |db, i| {
+            db.dense_tree_insert(EMPTY_PATH, b"tree", vec![i, 0xD0], None, grove_version)
+                .unwrap()
+                .expect("dense insert");
+        },
+        grove_version,
+    );
+}
+
+#[test]
+fn clear_commitment_tree_resets_parent_element_and_commitment() {
+    let grove_version = GroveVersion::latest();
+    let element = Element::empty_commitment_tree_with_flags(2, Some(FLAGS.to_vec()))
+        .expect("valid chunk power");
+    assert_clear_matches_fresh_tree(
+        element,
+        |db, i| commitment_tree_row_insert(db, b"tree", i, grove_version),
+        grove_version,
+    );
+}
+
+#[test]
+fn clear_private_document_store_resets_parent_element_and_commitment() {
+    let grove_version = GroveVersion::latest();
+    const ENTRY_SIZE: u32 = 48;
+    let element = Element::empty_private_document_store(ENTRY_SIZE, 2).expect("valid config");
+    assert_clear_matches_fresh_tree(
+        element,
+        |db, i| {
+            db.private_document_store_insert(
+                EMPTY_PATH,
+                b"tree",
+                vec![i; ENTRY_SIZE as usize],
+                None,
+                grove_version,
+            )
+            .unwrap()
+            .expect("pds insert");
+        },
+        grove_version,
+    );
+}
+
+/// A cleared tree nested below the root must propagate its reset commitment
+/// through every ancestor.
+#[test]
+fn clear_nested_mmr_tree_propagates_to_root() {
+    let grove_version = GroveVersion::latest();
+
+    let build = |populate: bool| {
+        let db = make_empty_grovedb();
+        db.insert(
+            EMPTY_PATH,
+            b"parent",
+            Element::empty_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert parent");
+        db.insert(
+            [b"parent".as_ref()].as_ref(),
+            b"log",
+            Element::empty_mmr_tree(),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("insert mmr tree");
+        if populate {
+            for i in 0..5u8 {
+                db.mmr_tree_append(
+                    [b"parent".as_ref()].as_ref(),
+                    b"log",
+                    vec![i],
+                    None,
+                    grove_version,
+                )
+                .unwrap()
+                .expect("append value");
+            }
+        }
+        db
+    };
+
+    let cleared_db = build(true);
+    let fresh_db = build(false);
+
+    let cleared = cleared_db
+        .clear_subtree(
+            [b"parent".as_ref(), b"log".as_ref()].as_ref(),
+            None,
+            None,
+            grove_version,
+        )
+        .expect("clear should succeed");
+    assert!(cleared);
+
+    assert_eq!(
+        root_hash(&cleared_db, grove_version),
+        root_hash(&fresh_db, grove_version),
+        "the reset commitment must propagate through the parent to the root"
+    );
+
+    let issues = cleared_db
+        .verify_grovedb(None, true, false, grove_version)
+        .expect("verify should not fail");
+    assert!(issues.is_empty(), "expected no issues, got: {:?}", issues);
+}
+
+/// A `NonCounted`-wrapped append tree keeps its wrapper (and the parent
+/// count tree keeps its aggregate) across a clear.
+///
+/// Uses `PrivateDocumentStore` because it is the one non-Merk type whose
+/// typed append preserves the wrapper: the MMR / bulk / dense / commitment
+/// append paths drop `NonCounted` on rewrite — a known legacy defect kept
+/// bug-for-bug because those types are live on `GROVE_V1`..`V3` (see the
+/// `ReplaceNonMerkTreeRoot` note in `batch/mod.rs`) — so a wrapped tree of
+/// those types no longer carries its wrapper by the time a clear runs.
+#[test]
+fn clear_non_counted_wrapped_private_document_store_preserves_wrapper() {
+    let grove_version = GroveVersion::latest();
+    let db = make_empty_grovedb();
+
+    const ENTRY_SIZE: u32 = 48;
+
+    db.insert(
+        EMPTY_PATH,
+        b"count",
+        Element::empty_count_tree(),
+        None,
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("insert count tree");
+
+    let mut inner = Element::empty_private_document_store(ENTRY_SIZE, 2).expect("valid config");
+    inner.set_flags(Some(FLAGS.to_vec()));
+    let wrapped = Element::new_non_counted(inner).expect("wrappable");
+    db.insert(
+        [b"count".as_ref()].as_ref(),
+        b"store",
+        wrapped.clone(),
+        None,
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("insert wrapped private document store");
+
+    for i in 0..3u8 {
+        db.private_document_store_insert(
+            [b"count".as_ref()].as_ref(),
+            b"store",
+            vec![i; ENTRY_SIZE as usize],
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("pds insert");
+    }
+
+    let cleared = db
+        .clear_subtree(
+            [b"count".as_ref(), b"store".as_ref()].as_ref(),
+            None,
+            None,
+            grove_version,
+        )
+        .expect("clear should succeed");
+    assert!(cleared);
+
+    let stored = db
+        .get_raw(
+            [b"count".as_ref()].as_ref().into(),
+            b"store",
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .expect("stored element after clear");
+    assert_eq!(
+        stored, wrapped,
+        "the NonCounted wrapper and flags must survive the clear"
+    );
+
+    let issues = db
+        .verify_grovedb(None, true, false, grove_version)
+        .expect("verify should not fail");
+    assert!(issues.is_empty(), "expected no issues, got: {:?}", issues);
+}
+
+/// v0 pin: under `GROVE_V3` (live in production) the legacy incoherence is
+/// preserved bug-for-bug — the payload is gone but the parent element keeps
+/// the old mmr size and nothing propagates.
+#[test]
+fn clear_under_grove_v3_keeps_stale_parent_element() {
+    let grove_version = &GROVE_V3;
+    let db = make_empty_grovedb();
+
+    db.insert(
+        EMPTY_PATH,
+        b"tree",
+        Element::empty_mmr_tree(),
+        None,
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("insert tree");
+    for i in 0..5u8 {
+        db.mmr_tree_append(EMPTY_PATH, b"tree", vec![i], None, grove_version)
+            .unwrap()
+            .expect("append value");
+    }
+
+    let root_before = root_hash(&db, grove_version);
+
+    let cleared = db
+        .clear_subtree([b"tree".as_ref()].as_ref(), None, None, grove_version)
+        .expect("clear should succeed");
+    assert!(cleared);
+
+    assert_eq!(
+        db.mmr_tree_leaf_count(EMPTY_PATH, b"tree", None, grove_version)
+            .unwrap()
+            .expect("leaf count"),
+        5,
+        "v0 must keep the stale count for replay compatibility"
+    );
+    assert_eq!(
+        root_hash(&db, grove_version),
+        root_before,
+        "v0 must not propagate anything"
+    );
+}

--- a/grovedb/src/tests/mod.rs
+++ b/grovedb/src/tests/mod.rs
@@ -30,6 +30,7 @@ mod bulk_append_tree_tests;
 mod checkpoint_tests;
 mod chunk_branch_proof_tests;
 mod chunk_proof_row_binding_tests;
+mod clear_append_tree_tests;
 mod commitment_tree_cost_bound_tests;
 mod commitment_tree_tests;
 mod coverage_round7_tests;


### PR DESCRIPTION
## Problem (issue #893, audit M015)

`clear_subtree` on a non-Merk data tree (`MmrTree`, `BulkAppendTree`, `DenseAppendOnlyFixedSizeTree`, `CommitmentTree`, `PrivateDocumentStore`) deleted the payload from the data namespace and returned success **without touching the parent element**: the element kept the old count / mmr size and the old state commitment, and nothing propagated. The database was left contradicting itself — a populated commitment over data that no longer exists — and `verify_grovedb` flagged the subtree. Ordinary Merk clears already propagated their new root; only the non-Merk branch returned early.

## Fix

`clear_subtree` is now version-dispatched in the house structure (`operations/delete/clear_subtree/{mod.rs,v0.rs,v1.rs}`), following the issue's "atomically reset" direction:

* **v0** — `GROVE_V1`..`GROVE_V3` (live in production): the incoherent legacy behaviour is kept bug-for-bug for replay compatibility.
* **v1** — `GROVE_V4`+: after clearing the payload, the parent element is rewritten to its canonical empty state — count / mmr size zeroed; configuration (chunk power, height, entry size), flags and any `NonCounted`-style wrapper retained — and the child hash is reset to the same convention the insert path binds for an empty tree (`NULL_HASH` for MMR / bulk / dense, `EMPTY_COMMITMENT_TREE_STATE_ROOT` for a commitment tree, the config-parametrized empty state root for a private document store). The rewrite propagates through ancestors with the indexed-aware walk (`propagate_changes_with_transaction_refreshing_indexed_row`), the same one the typed append paths use, so a canonical secondary row is refreshed when the parent is an indexed primary. Payload clear, element reset and propagation are staged into **one storage batch**, so they commit atomically.

`GROVE_V4.operations.delete.clear_subtree` is bumped to 1; all released versions stay at 0.

## Validation (per the issue's checklist)

New tests in `grovedb/src/tests/clear_append_tree_tests.rs`, for **each** append family:

* clear → the stored element equals the freshly inserted empty element (count zeroed, config + flags retained), the grovedb **root hash equals a never-populated twin's**, and `verify_grovedb` is clean;
* a subsequent typed append lands exactly where a first append into a fresh tree lands (root-hash equality again), and typed reads restart at index 0;
* nested case: the reset commitment propagates through a parent tree to the root;
* wrapper/flag preservation across the atomic clear (`NonCounted(PrivateDocumentStore)` under a `CountTree` — PDS is the one family whose typed append preserves the wrapper; the MMR/bulk/dense/CT appends drop it, a known defect already documented at the `ReplaceNonMerkTreeRoot` arm in `batch/mod.rs` and deliberately out of scope here);
* `GROVE_V3` pin: the legacy stale-element, no-propagation behaviour is preserved.

`cargo test -p grovedb -p grovedb-version` — 3308 + 56 pass; `cargo clippy -p grovedb --all-targets` clean.

Fixes #893

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Clearing supported append-only and commitment-based trees now resets their parent state, updates commitments, and propagates changes to ancestors.
  - Cleared trees can be reused as empty trees, with subsequent appends starting at the correct index.
  - Existing legacy behavior remains available for older GroveDB versions to preserve compatibility.

- **Validation**
  - Added coverage for supported tree types, subtree options, version handling, and rejection of unknown operation versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->