### PR TITLE
fix: preserve NonCounted wrapper on typed non-Merk tree appends (GROVE_V4)

### DIFF
--- a/grovedb-version/src/version/grovedb_versions.rs
+++ b/grovedb-version/src/version/grovedb_versions.rs
@@ -191,6 +191,33 @@ pub struct GroveDBOperationsVersions {
     pub worst_case: GroveDBOperationsWorstCaseVersions,
     pub private_document_store: GroveDBOperationsPrivateDocumentStoreVersions,
     pub flat_drop: GroveDBOperationsFlatDropVersions,
+    pub non_merk_tree: GroveDBOperationsNonMerkTreeVersions,
+}
+
+/// Version slots shared by the non-Merk data-tree families
+/// (`CommitmentTree`, `MmrTree`, `BulkAppendTree`,
+/// `DenseAppendOnlyFixedSizeTree`, `PrivateDocumentStore`).
+#[derive(Clone, Debug, Default)]
+pub struct GroveDBOperationsNonMerkTreeVersions {
+    /// How a typed write (a direct append, or the batch
+    /// `ReplaceNonMerkTreeRoot` op every batch append preprocesses into)
+    /// rebuilds the parent-Merk element that anchors the tree.
+    ///
+    /// - `0` (V1..V3): the rebuilt element is written BARE, so a stored
+    ///   `NonCounted(tree)` loses its wrapper on its first append. That
+    ///   flips the tree's contribution to a `CountTree` / `CountSumTree`
+    ///   parent from 0 to 1, changing the parent aggregate and with it the
+    ///   root hash. The one exception is `PrivateDocumentStore`, whose
+    ///   wrapper was always restored: the element type cannot exist before
+    ///   `GROVE_V4`, so preserving it never altered a released outcome.
+    /// - `1` (V4+): the wrapper is restored for every family.
+    ///
+    /// Every rewrite path already reads the old element (flags are
+    /// preserved from it), so the version costs no extra read — the slot
+    /// gates the fix because restoring the wrapper moves a committed root
+    /// hash and rewrites the wrapper's serialized bytes that V1..V3
+    /// dropped.
+    pub parent_element_rewrap: FeatureVersion,
 }
 
 /// Version slots for the flat-subtree drop family (issue #848): O(1)

--- a/grovedb-version/src/version/v1.rs
+++ b/grovedb-version/src/version/v1.rs
@@ -8,8 +8,9 @@ use crate::version::{
         GroveDBOperationsAverageCaseVersions, GroveDBOperationsDeleteUpTreeVersions,
         GroveDBOperationsDeleteVersions, GroveDBOperationsFlatDropVersions,
         GroveDBOperationsGetVersions, GroveDBOperationsIndexedAxisVersions,
-        GroveDBOperationsInsertVersions, GroveDBOperationsPrivateDocumentStoreVersions,
-        GroveDBOperationsProofVersions, GroveDBOperationsQueryVersions, GroveDBOperationsVersions,
+        GroveDBOperationsInsertVersions, GroveDBOperationsNonMerkTreeVersions,
+        GroveDBOperationsPrivateDocumentStoreVersions, GroveDBOperationsProofVersions,
+        GroveDBOperationsQueryVersions, GroveDBOperationsVersions,
         GroveDBOperationsWorstCaseVersions, GroveDBPathQueryMethodVersions, GroveDBQueryLimits,
         GroveDBReplicationVersions, GroveDBStorageCostVersions, GroveDBVersions,
     },
@@ -231,6 +232,14 @@ pub const GROVE_V1: GroveVersion = GroveVersion {
             flat_drop: GroveDBOperationsFlatDropVersions {
                 drop_flat_subtree: 0,
                 batch_delete_tree_drop_flat: 0,
+            },
+            // Released behaviour: a typed append rewrites the parent
+            // element bare, dropping a stored NonCounted wrapper (except
+            // for PrivateDocumentStore, which cannot exist before
+            // GROVE_V4). Preserved for replay; GROVE_V4 restores the
+            // wrapper for every family.
+            non_merk_tree: GroveDBOperationsNonMerkTreeVersions {
+                parent_element_rewrap: 0,
             },
         },
         aggregate_sum_path_query_methods: GroveDBAggregateSumPathQueryMethodVersions { merge: 0 },

--- a/grovedb-version/src/version/v2.rs
+++ b/grovedb-version/src/version/v2.rs
@@ -8,8 +8,9 @@ use crate::version::{
         GroveDBOperationsAverageCaseVersions, GroveDBOperationsDeleteUpTreeVersions,
         GroveDBOperationsDeleteVersions, GroveDBOperationsFlatDropVersions,
         GroveDBOperationsGetVersions, GroveDBOperationsIndexedAxisVersions,
-        GroveDBOperationsInsertVersions, GroveDBOperationsPrivateDocumentStoreVersions,
-        GroveDBOperationsProofVersions, GroveDBOperationsQueryVersions, GroveDBOperationsVersions,
+        GroveDBOperationsInsertVersions, GroveDBOperationsNonMerkTreeVersions,
+        GroveDBOperationsPrivateDocumentStoreVersions, GroveDBOperationsProofVersions,
+        GroveDBOperationsQueryVersions, GroveDBOperationsVersions,
         GroveDBOperationsWorstCaseVersions, GroveDBPathQueryMethodVersions, GroveDBQueryLimits,
         GroveDBReplicationVersions, GroveDBStorageCostVersions, GroveDBVersions,
     },
@@ -231,6 +232,14 @@ pub const GROVE_V2: GroveVersion = GroveVersion {
             flat_drop: GroveDBOperationsFlatDropVersions {
                 drop_flat_subtree: 0,
                 batch_delete_tree_drop_flat: 0,
+            },
+            // Released behaviour: a typed append rewrites the parent
+            // element bare, dropping a stored NonCounted wrapper (except
+            // for PrivateDocumentStore, which cannot exist before
+            // GROVE_V4). Preserved for replay; GROVE_V4 restores the
+            // wrapper for every family.
+            non_merk_tree: GroveDBOperationsNonMerkTreeVersions {
+                parent_element_rewrap: 0,
             },
         },
         aggregate_sum_path_query_methods: GroveDBAggregateSumPathQueryMethodVersions { merge: 0 },

--- a/grovedb-version/src/version/v3.rs
+++ b/grovedb-version/src/version/v3.rs
@@ -8,8 +8,9 @@ use crate::version::{
         GroveDBOperationsAverageCaseVersions, GroveDBOperationsDeleteUpTreeVersions,
         GroveDBOperationsDeleteVersions, GroveDBOperationsFlatDropVersions,
         GroveDBOperationsGetVersions, GroveDBOperationsIndexedAxisVersions,
-        GroveDBOperationsInsertVersions, GroveDBOperationsPrivateDocumentStoreVersions,
-        GroveDBOperationsProofVersions, GroveDBOperationsQueryVersions, GroveDBOperationsVersions,
+        GroveDBOperationsInsertVersions, GroveDBOperationsNonMerkTreeVersions,
+        GroveDBOperationsPrivateDocumentStoreVersions, GroveDBOperationsProofVersions,
+        GroveDBOperationsQueryVersions, GroveDBOperationsVersions,
         GroveDBOperationsWorstCaseVersions, GroveDBPathQueryMethodVersions, GroveDBQueryLimits,
         GroveDBReplicationVersions, GroveDBStorageCostVersions, GroveDBVersions,
     },
@@ -235,6 +236,14 @@ pub const GROVE_V3: GroveVersion = GroveVersion {
             flat_drop: GroveDBOperationsFlatDropVersions {
                 drop_flat_subtree: 0,
                 batch_delete_tree_drop_flat: 0,
+            },
+            // Released behaviour: a typed append rewrites the parent
+            // element bare, dropping a stored NonCounted wrapper (except
+            // for PrivateDocumentStore, which cannot exist before
+            // GROVE_V4). Preserved for replay; GROVE_V4 restores the
+            // wrapper for every family.
+            non_merk_tree: GroveDBOperationsNonMerkTreeVersions {
+                parent_element_rewrap: 0,
             },
         },
         aggregate_sum_path_query_methods: GroveDBAggregateSumPathQueryMethodVersions { merge: 0 },

--- a/grovedb-version/src/version/v4.rs
+++ b/grovedb-version/src/version/v4.rs
@@ -238,6 +238,18 @@
 //!   subtree changes never disturbed it. Gated because (i) moves a committed
 //!   root and (ii)/(iii) flip an accepted/rejected outcome.
 //!
+//! - `operations.non_merk_tree.parent_element_rewrap: 1` — a typed append to
+//!   a `NonCounted`-wrapped non-Merk data tree (`CommitmentTree`, `MmrTree`,
+//!   `BulkAppendTree`, `DenseAppendOnlyFixedSizeTree`) restores the wrapper
+//!   when it rewrites the tree's parent-Merk element, on the direct append
+//!   paths and on the batch `ReplaceNonMerkTreeRoot` rebuild alike. V1..V3
+//!   rebuild the element bare, so the first append silently strips the
+//!   wrapper and flips the tree's contribution to a `CountTree` /
+//!   `CountSumTree` parent from 0 to 1 — changing the parent aggregate and
+//!   the root hash — preserved for replay. `PrivateDocumentStore` restored
+//!   its wrapper at every version: the type cannot exist before GROVE_V4,
+//!   so its preservation never altered a released outcome.
+//!
 //! - `storage_costs.add_basic_storage_removal_to_sectioned_storage_removal:
 //!   1` — combining a `BasicStorageRemoval` with a `SectionedStorageRemoval`
 //!   folds the basic bytes into the default identifier's `UNKNOWN_EPOCH`
@@ -274,8 +286,9 @@ use crate::version::{
         GroveDBOperationsAverageCaseVersions, GroveDBOperationsDeleteUpTreeVersions,
         GroveDBOperationsDeleteVersions, GroveDBOperationsFlatDropVersions,
         GroveDBOperationsGetVersions, GroveDBOperationsIndexedAxisVersions,
-        GroveDBOperationsInsertVersions, GroveDBOperationsPrivateDocumentStoreVersions,
-        GroveDBOperationsProofVersions, GroveDBOperationsQueryVersions, GroveDBOperationsVersions,
+        GroveDBOperationsInsertVersions, GroveDBOperationsNonMerkTreeVersions,
+        GroveDBOperationsPrivateDocumentStoreVersions, GroveDBOperationsProofVersions,
+        GroveDBOperationsQueryVersions, GroveDBOperationsVersions,
         GroveDBOperationsWorstCaseVersions, GroveDBPathQueryMethodVersions, GroveDBQueryLimits,
         GroveDBReplicationVersions, GroveDBStorageCostVersions, GroveDBVersions,
     },
@@ -528,6 +541,13 @@ pub const GROVE_V4: GroveVersion = GroveVersion {
             flat_drop: GroveDBOperationsFlatDropVersions {
                 drop_flat_subtree: 1,
                 batch_delete_tree_drop_flat: 1,
+            },
+            // v1: a typed append restores a stored NonCounted wrapper on
+            // the rewritten parent element for every non-Merk tree family.
+            // V1..V3 keep the released wrapper drop (PrivateDocumentStore
+            // excepted) to preserve committed root hashes.
+            non_merk_tree: GroveDBOperationsNonMerkTreeVersions {
+                parent_element_rewrap: 1,
             },
         },
         aggregate_sum_path_query_methods: GroveDBAggregateSumPathQueryMethodVersions { merge: 0 },

--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -4069,8 +4069,9 @@ where
                     );
                 }
                 GroveOp::ReplaceNonMerkTreeRoot { hash, meta } => {
-                    // Read existing element to preserve flags (and, for a
-                    // PrivateDocumentStore, its NonCounted wrapper).
+                    // Read existing element to preserve flags (and its
+                    // NonCounted wrapper, where the grove version calls for
+                    // that).
                     let merk = self.merks.get(path).expect("the Merk is cached");
                     let existing = cost_return_on_error!(
                         &mut cost,
@@ -4083,32 +4084,22 @@ where
                     // `meta.to_element` always builds a BARE element, so a
                     // stored `NonCounted(tree)` would come back counted and
                     // change its parent count tree's aggregate — and with it
-                    // the root hash. Restore the wrapper.
-                    //
-                    // Scoped to PrivateDocumentStore deliberately: the same
-                    // latent defect exists for CommitmentTree / MmrTree /
-                    // BulkAppendTree / DenseTree, but those are live on
-                    // GROVE_V1..V3, so repairing them changes a released
-                    // consensus outcome and belongs in its own version-gated
-                    // change. PDS cannot exist before V4, so fixing it here
-                    // alters nothing that has ever been committed. The
-                    // element was already read above, so this costs nothing
-                    // extra.
-                    let element = if existing_non_counted
-                        && matches!(meta, NonMerkTreeMeta::PrivateDocumentStore { .. })
-                    {
-                        cost_return_on_error_no_add!(
-                            cost,
-                            element.into_non_counted().map_err(|_| {
-                                Error::CorruptedCodeExecution(
-                                    "into_non_counted called on a wrapped element during \
-                                     ReplaceNonMerkTreeRoot",
-                                )
-                            })
+                    // the root hash. Restore the wrapper if the grove
+                    // version calls for it: GROVE_V4+ restores it for every
+                    // family, while V1..V3 restore it for
+                    // PrivateDocumentStore alone and keep the released
+                    // wrapper drop for CommitmentTree / MmrTree /
+                    // BulkAppendTree / DenseTree (consensus-gated — see
+                    // `rewrap_non_merk_tree_parent_element`). The element
+                    // was already read above, so this costs nothing extra.
+                    let element = cost_return_on_error_no_add!(
+                        cost,
+                        GroveDb::rewrap_non_merk_tree_parent_element(
+                            element,
+                            existing_non_counted,
+                            grove_version,
                         )
-                    } else {
-                        element
-                    };
+                    );
                     let merk_feature_type = cost_return_on_error_into_no_add!(
                         cost,
                         element.get_feature_type(in_tree_type)

--- a/grovedb/src/operations/bulk_append_tree.rs
+++ b/grovedb/src/operations/bulk_append_tree.rs
@@ -58,6 +58,9 @@ impl GroveDb {
         );
 
         // Look through NonCounted: a wrapped BulkAppendTree is still one.
+        // Remember it so the element rewrite below can restore it when the
+        // grove version calls for that.
+        let stored_was_non_counted = element.is_non_counted();
         let (total_count, chunk_power, existing_flags) = match element.underlying() {
             Element::BulkAppendTree(tc, cp, flags) => (*tc, *cp, flags.clone()),
             _ => {
@@ -141,6 +144,17 @@ impl GroveDb {
 
         let updated_element =
             Element::new_bulk_append_tree(new_total_count, chunk_power, existing_flags);
+        // Restore a stored NonCounted wrapper if the grove version calls
+        // for it (consensus-gated — see
+        // `rewrap_non_merk_tree_parent_element`).
+        let updated_element = cost_return_on_error_no_add!(
+            cost,
+            GroveDb::rewrap_non_merk_tree_parent_element(
+                updated_element,
+                stored_was_non_counted,
+                grove_version,
+            )
+        );
 
         cost_return_on_error_into!(
             &mut cost,

--- a/grovedb/src/operations/commitment_tree.rs
+++ b/grovedb/src/operations/commitment_tree.rs
@@ -124,6 +124,9 @@ impl GroveDb {
         );
 
         // Look through NonCounted: a wrapped CommitmentTree is still one.
+        // Remember it so the element rewrite below can restore it when the
+        // grove version calls for that.
+        let stored_was_non_counted = element.is_non_counted();
         let (total_count, chunk_power, existing_flags) = match element.underlying() {
             Element::CommitmentTree(total_count, chunk_power, flags) => {
                 (*total_count, *chunk_power, flags.clone())
@@ -226,6 +229,17 @@ impl GroveDb {
 
         let updated_element =
             Element::new_commitment_tree(new_total_count, chunk_power, existing_flags);
+        // Restore a stored NonCounted wrapper if the grove version calls
+        // for it (consensus-gated — see
+        // `rewrap_non_merk_tree_parent_element`).
+        let updated_element = cost_return_on_error_no_add!(
+            cost,
+            GroveDb::rewrap_non_merk_tree_parent_element(
+                updated_element,
+                stored_was_non_counted,
+                grove_version,
+            )
+        );
 
         cost_return_on_error_into!(
             &mut cost,

--- a/grovedb/src/operations/dense_tree.rs
+++ b/grovedb/src/operations/dense_tree.rs
@@ -55,7 +55,9 @@ impl GroveDb {
         );
 
         // Look through NonCounted: a wrapped DenseAppendOnlyFixedSizeTree
-        // is still one.
+        // is still one. Remember it so the element rewrite below can
+        // restore it when the grove version calls for that.
+        let stored_was_non_counted = element.is_non_counted();
         let (existing_count, height, existing_flags) = match element.underlying() {
             Element::DenseAppendOnlyFixedSizeTree(count, h, flags) => (*count, *h, flags.clone()),
             _ => {
@@ -130,6 +132,17 @@ impl GroveDb {
         );
 
         let updated_element = Element::new_dense_tree(new_count, height, existing_flags);
+        // Restore a stored NonCounted wrapper if the grove version calls
+        // for it (consensus-gated — see
+        // `rewrap_non_merk_tree_parent_element`).
+        let updated_element = cost_return_on_error_no_add!(
+            cost,
+            GroveDb::rewrap_non_merk_tree_parent_element(
+                updated_element,
+                stored_was_non_counted,
+                grove_version,
+            )
+        );
 
         cost_return_on_error_into!(
             &mut cost,

--- a/grovedb/src/operations/mmr_tree.rs
+++ b/grovedb/src/operations/mmr_tree.rs
@@ -61,7 +61,9 @@ impl GroveDb {
 
         // Look through `NonCounted`: a wrapped MmrTree is still an MmrTree
         // for typed-API purposes; the wrapper only affects parent count
-        // aggregation.
+        // aggregation. Remember it so the element rewrite below can restore
+        // it when the grove version calls for that.
+        let stored_was_non_counted = element.is_non_counted();
         let (mmr_size, existing_flags) = match element.underlying() {
             Element::MmrTree(size, flags) => (*size, flags.clone()),
             _ => {
@@ -151,6 +153,17 @@ impl GroveDb {
         );
 
         let updated_element = Element::new_mmr_tree(new_mmr_size, existing_flags);
+        // Restore a stored NonCounted wrapper if the grove version calls
+        // for it (consensus-gated — see
+        // `rewrap_non_merk_tree_parent_element`).
+        let updated_element = cost_return_on_error_no_add!(
+            cost,
+            GroveDb::rewrap_non_merk_tree_parent_element(
+                updated_element,
+                stored_was_non_counted,
+                grove_version,
+            )
+        );
 
         // A canonical indexed secondary row binds this entry's committed
         // value hash, and an append moves it while leaving `(count, sum)`

--- a/grovedb/src/operations/mod.rs
+++ b/grovedb/src/operations/mod.rs
@@ -29,6 +29,9 @@ pub mod dense_tree;
 /// Private document store operations
 pub mod private_document_store;
 
+#[cfg(feature = "minimal")]
+pub(crate) mod rewrap_non_merk_tree_parent_element;
+
 /// Caller-driven subtree-root replacement. Bypasses grovedb's normal
 /// "compute child hash from subtree state" invariant — see the module-level
 /// docs in `replace_subtree_root.rs` for the safety contract.

--- a/grovedb/src/operations/private_document_store.rs
+++ b/grovedb/src/operations/private_document_store.rs
@@ -240,19 +240,18 @@ impl GroveDb {
         // Re-wrap when the stored element was NonCounted. Dropping the
         // wrapper here would flip the store's contribution to a CountTree /
         // CountSumTree parent from 0 to 1 on its first append, changing the
-        // parent aggregate and the consensus root hash.
-        let updated_element = if was_non_counted {
-            cost_return_on_error_no_add!(
-                cost,
-                Element::new_non_counted(updated_element).map_err(|e| {
-                    Error::CorruptedData(format!(
-                        "failed to re-wrap private document store in NonCounted: {e}"
-                    ))
-                })
+        // parent aggregate and the consensus root hash. Both versions of
+        // the shared rewrap helper preserve a PrivateDocumentStore's
+        // wrapper (the type cannot exist before GROVE_V4, so its
+        // preservation never altered a released outcome).
+        let updated_element = cost_return_on_error_no_add!(
+            cost,
+            GroveDb::rewrap_non_merk_tree_parent_element(
+                updated_element,
+                was_non_counted,
+                grove_version,
             )
-        } else {
-            updated_element
-        };
+        );
 
         cost_return_on_error_into!(
             &mut cost,

--- a/grovedb/src/operations/rewrap_non_merk_tree_parent_element/mod.rs
+++ b/grovedb/src/operations/rewrap_non_merk_tree_parent_element/mod.rs
@@ -70,3 +70,70 @@ impl GroveDb {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use grovedb_version::version::{v3::GROVE_V3, GroveVersion};
+
+    use crate::{Element, Error, GroveDb};
+
+    /// v0 (GROVE_V3) restores the wrapper for a PrivateDocumentStore — the
+    /// carve-out that was always safe because the type cannot exist before
+    /// GROVE_V4.
+    #[test]
+    fn v0_restores_wrapper_for_private_document_store_only() {
+        let pds = Element::empty_private_document_store(32, 4).expect("valid config");
+        let rewrapped = GroveDb::rewrap_non_merk_tree_parent_element(pds.clone(), true, &GROVE_V3)
+            .expect("rewrap");
+        assert!(rewrapped.is_non_counted());
+
+        // Every other family keeps the released wrapper drop under v0.
+        let mmr = Element::empty_mmr_tree();
+        let bare =
+            GroveDb::rewrap_non_merk_tree_parent_element(mmr, true, &GROVE_V3).expect("rewrap");
+        assert!(!bare.is_non_counted());
+
+        // An unwrapped stored element passes through on both variants.
+        let untouched =
+            GroveDb::rewrap_non_merk_tree_parent_element(pds, false, &GROVE_V3).expect("rewrap");
+        assert!(!untouched.is_non_counted());
+    }
+
+    /// v1 (GROVE_V4+) restores the wrapper for every family, and surfaces a
+    /// typed error if a non-wrappable element were ever fed through.
+    #[test]
+    fn v1_restores_wrapper_and_surfaces_wrap_errors() {
+        let grove_version = GroveVersion::latest();
+        let mmr = Element::empty_mmr_tree();
+        let rewrapped =
+            GroveDb::rewrap_non_merk_tree_parent_element(mmr.clone(), true, grove_version)
+                .expect("rewrap");
+        assert!(rewrapped.is_non_counted());
+
+        let untouched = GroveDb::rewrap_non_merk_tree_parent_element(mmr, false, grove_version)
+            .expect("rewrap");
+        assert!(!untouched.is_non_counted());
+
+        // The rewrite paths only build bare elements, but a cross-wrapper
+        // input must error rather than nest wrappers.
+        let not_summed = Element::empty_sum_tree()
+            .into_not_summed()
+            .expect("wrap in NotSummed");
+        let result = GroveDb::rewrap_non_merk_tree_parent_element(not_summed, true, grove_version);
+        assert!(matches!(result, Err(Error::ElementError(_))));
+    }
+
+    /// An unknown slot value fails closed with a version-mismatch error.
+    #[test]
+    fn unknown_version_fails_closed() {
+        let mut version = GroveVersion::latest().clone();
+        version
+            .grovedb_versions
+            .operations
+            .non_merk_tree
+            .parent_element_rewrap = 9;
+        let result =
+            GroveDb::rewrap_non_merk_tree_parent_element(Element::empty_mmr_tree(), true, &version);
+        assert!(matches!(result, Err(Error::VersionError(_))));
+    }
+}

--- a/grovedb/src/operations/rewrap_non_merk_tree_parent_element/mod.rs
+++ b/grovedb/src/operations/rewrap_non_merk_tree_parent_element/mod.rs
@@ -1,0 +1,72 @@
+//! `rewrap_non_merk_tree_parent_element` — versioned dispatch.
+//!
+//! Every typed write to a non-Merk data tree — the direct appends
+//! (`commitment_tree_insert`, `mmr_tree_append`, `bulk_append`,
+//! `dense_tree_insert`, `private_document_store_insert`) and the batch
+//! `ReplaceNonMerkTreeRoot` op they all preprocess into — rewrites the
+//! parent-Merk element that anchors the tree, rebuilding it from the new
+//! entry count and the stored element's flags. The rebuild constructors
+//! (`Element::new_mmr_tree` and friends) produce a BARE element, so a stored
+//! `NonCounted(tree)` needs its wrapper restored on the way out or the
+//! rewrite strips it.
+//!
+//! Whether the wrapper is restored is **consensus-critical** and
+//! version-gated on `operations.non_merk_tree.parent_element_rewrap`: the
+//! wrapper is what makes the tree contribute 0 instead of 1 to a `CountTree`
+//! / `CountSumTree` parent, so restoring it changes the parent aggregate and
+//! with it the root hash.
+//!
+//! * **[v0]** — released behaviour, `GROVE_V1`..`GROVE_V3`. The element is
+//!   written bare and the wrapper is silently dropped by the first append —
+//!   the parent count flips from 0 to 1. The one exception is
+//!   `PrivateDocumentStore`, whose wrapper is restored: the element type
+//!   cannot exist before `GROVE_V4` (all its slots are 0), so preserving it
+//!   never altered a committed outcome.
+//! * **[v1]** — `GROVE_V4`+. The wrapper is restored for every family.
+//!
+//! Every rewrite path already reads the stored element (its flags are
+//! preserved from it), so the versions charge the same reads — the gate
+//! exists because v1 moves a committed root hash and rewrites wrapper bytes
+//! that v0 dropped.
+//!
+//! [v0]: self::v0
+//! [v1]: self::v1
+
+mod v0;
+mod v1;
+
+use grovedb_version::version::GroveVersion;
+
+use crate::{Element, Error, GroveDb};
+
+impl GroveDb {
+    /// Restore a stored `NonCounted` wrapper on a rebuilt non-Merk tree
+    /// parent element, if the grove version calls for it.
+    ///
+    /// `rebuilt` is the bare element freshly constructed with the tree's
+    /// updated entry count and the stored element's flags;
+    /// `stored_was_non_counted` says whether the stored element the rewrite
+    /// replaces was `NonCounted`-wrapped.
+    pub(crate) fn rewrap_non_merk_tree_parent_element(
+        rebuilt: Element,
+        stored_was_non_counted: bool,
+        grove_version: &GroveVersion,
+    ) -> Result<Element, Error> {
+        match grove_version
+            .grovedb_versions
+            .operations
+            .non_merk_tree
+            .parent_element_rewrap
+        {
+            0 => v0::rewrap_non_merk_tree_parent_element_v0(rebuilt, stored_was_non_counted),
+            1 => v1::rewrap_non_merk_tree_parent_element_v1(rebuilt, stored_was_non_counted),
+            version => Err(Error::VersionError(
+                grovedb_version::error::GroveVersionError::UnknownVersionMismatch {
+                    method: "rewrap_non_merk_tree_parent_element".to_string(),
+                    known_versions: vec![0, 1],
+                    received: version,
+                },
+            )),
+        }
+    }
+}

--- a/grovedb/src/operations/rewrap_non_merk_tree_parent_element/v0.rs
+++ b/grovedb/src/operations/rewrap_non_merk_tree_parent_element/v0.rs
@@ -1,0 +1,30 @@
+//! `rewrap_non_merk_tree_parent_element` version 0.
+//!
+//! Differs from [v1](super::v1) ONLY in which families get a stored
+//! `NonCounted` wrapper restored: v0 restores it for `PrivateDocumentStore`
+//! alone and writes every other family bare, dropping the wrapper — the
+//! released behaviour, preserved because restoring it changes a `CountTree`
+//! / `CountSumTree` parent's aggregate and the root hash. The
+//! `PrivateDocumentStore` exception is safe at every version: the element
+//! type cannot exist before `GROVE_V4`, so its preservation never altered a
+//! committed outcome.
+//!
+//! Selected by `GROVE_V1`..`GROVE_V3`.
+
+use crate::{Element, Error};
+
+pub(super) fn rewrap_non_merk_tree_parent_element_v0(
+    rebuilt: Element,
+    stored_was_non_counted: bool,
+) -> Result<Element, Error> {
+    if stored_was_non_counted && matches!(rebuilt, Element::PrivateDocumentStore(..)) {
+        rebuilt.into_non_counted().map_err(|_| {
+            Error::CorruptedCodeExecution(
+                "into_non_counted called on a wrapped element during non-Merk tree parent \
+                 element rewrap",
+            )
+        })
+    } else {
+        Ok(rebuilt)
+    }
+}

--- a/grovedb/src/operations/rewrap_non_merk_tree_parent_element/v0.rs
+++ b/grovedb/src/operations/rewrap_non_merk_tree_parent_element/v0.rs
@@ -18,12 +18,10 @@ pub(super) fn rewrap_non_merk_tree_parent_element_v0(
     stored_was_non_counted: bool,
 ) -> Result<Element, Error> {
     if stored_was_non_counted && matches!(rebuilt, Element::PrivateDocumentStore(..)) {
-        rebuilt.into_non_counted().map_err(|_| {
-            Error::CorruptedCodeExecution(
-                "into_non_counted called on a wrapped element during non-Merk tree parent \
-                 element rewrap",
-            )
-        })
+        // Infallible for a bare PrivateDocumentStore; the typed error is
+        // surfaced rather than unwrapped in case a future change ever
+        // feeds a wrapper through.
+        rebuilt.into_non_counted().map_err(Error::from)
     } else {
         Ok(rebuilt)
     }

--- a/grovedb/src/operations/rewrap_non_merk_tree_parent_element/v1.rs
+++ b/grovedb/src/operations/rewrap_non_merk_tree_parent_element/v1.rs
@@ -17,12 +17,10 @@ pub(super) fn rewrap_non_merk_tree_parent_element_v1(
     stored_was_non_counted: bool,
 ) -> Result<Element, Error> {
     if stored_was_non_counted {
-        rebuilt.into_non_counted().map_err(|_| {
-            Error::CorruptedCodeExecution(
-                "into_non_counted called on a wrapped element during non-Merk tree parent \
-                 element rewrap",
-            )
-        })
+        // Infallible for the bare non-Merk tree elements the rewrite paths
+        // build; the typed error is surfaced rather than unwrapped in case
+        // a future change ever feeds a wrapper through.
+        rebuilt.into_non_counted().map_err(Error::from)
     } else {
         Ok(rebuilt)
     }

--- a/grovedb/src/operations/rewrap_non_merk_tree_parent_element/v1.rs
+++ b/grovedb/src/operations/rewrap_non_merk_tree_parent_element/v1.rs
@@ -1,0 +1,29 @@
+//! `rewrap_non_merk_tree_parent_element` version 1.
+//!
+//! Differs from [v0](super::v0) ONLY in which families get a stored
+//! `NonCounted` wrapper restored: v1 restores it for every non-Merk tree
+//! family, so an append to a wrapped `CommitmentTree` / `MmrTree` /
+//! `BulkAppendTree` / `DenseAppendOnlyFixedSizeTree` no longer strips the
+//! wrapper and flips the tree's contribution to a `CountTree` /
+//! `CountSumTree` parent from 0 to 1 (v0 restored it for
+//! `PrivateDocumentStore` alone).
+//!
+//! Selected by `GROVE_V4`+.
+
+use crate::{Element, Error};
+
+pub(super) fn rewrap_non_merk_tree_parent_element_v1(
+    rebuilt: Element,
+    stored_was_non_counted: bool,
+) -> Result<Element, Error> {
+    if stored_was_non_counted {
+        rebuilt.into_non_counted().map_err(|_| {
+            Error::CorruptedCodeExecution(
+                "into_non_counted called on a wrapped element during non-Merk tree parent \
+                 element rewrap",
+            )
+        })
+    } else {
+        Ok(rebuilt)
+    }
+}

--- a/grovedb/src/tests/mod.rs
+++ b/grovedb/src/tests/mod.rs
@@ -96,6 +96,7 @@ mod merged_descending_subset_bound_tests;
 mod misc_coverage_tests;
 mod mmr_tree_tests;
 mod non_counted_tests;
+mod non_merk_wrapper_preservation_tests;
 mod not_counted_or_summed_tests;
 mod not_summed_tests;
 mod operations_coverage_tests;

--- a/grovedb/src/tests/non_merk_wrapper_preservation_tests.rs
+++ b/grovedb/src/tests/non_merk_wrapper_preservation_tests.rs
@@ -1,0 +1,448 @@
+//! Wrapper preservation on typed appends to non-Merk data trees.
+//!
+//! A typed append (direct or batch) rewrites the tree's parent-Merk element
+//! from the new entry count and the stored flags. The rebuild constructors
+//! produce a BARE element, so a stored `NonCounted(tree)` needs its wrapper
+//! restored or the append strips it — flipping the tree's contribution to a
+//! `CountTree` parent from 0 to 1, and with it the parent aggregate and the
+//! root hash.
+//!
+//! `GROVE_V4`+ restores the wrapper for every family
+//! (`operations.non_merk_tree.parent_element_rewrap: 1` — see
+//! `rewrap_non_merk_tree_parent_element`); `GROVE_V1`..`GROVE_V3` keep the
+//! released wrapper drop, pinned here so the legacy replay path cannot
+//! silently change. `PrivateDocumentStore`, whose wrapper is preserved at
+//! every version, is covered in `private_document_store_tests`.
+
+use grovedb_commitment_tree::{DashMemo, NoteBytesData, TransmittedNoteCiphertext};
+use grovedb_version::version::{v3::GROVE_V3, GroveVersion};
+
+use crate::{
+    batch::QualifiedGroveDbOp,
+    tests::{common::EMPTY_PATH, make_empty_grovedb, TempGroveDb},
+    Element,
+};
+
+/// Chunk power for the bulk-append and commitment trees (buffer of 2^4
+/// entries — large enough that no test triggers compaction).
+const TEST_CHUNK_POWER: u8 = 4;
+
+/// Read the root `CountTree`'s recorded aggregate count.
+fn count_tree_value(db: &TempGroveDb, grove_version: &GroveVersion) -> u64 {
+    match db
+        .get(EMPTY_PATH, b"counted", None, grove_version)
+        .unwrap()
+        .expect("get count tree")
+    {
+        Element::CountTree(_, count, _) => count,
+        other => panic!("expected CountTree, got {}", other.type_str()),
+    }
+}
+
+/// Build a `CountTree` at `counted` holding the given tree element wrapped in
+/// `NonCounted` at `counted/tree`, and assert the parent count starts at 0.
+fn make_non_counted_tree_under_count_tree(
+    inner: Element,
+    grove_version: &GroveVersion,
+) -> TempGroveDb {
+    let db = make_empty_grovedb();
+    db.insert(
+        EMPTY_PATH,
+        b"counted",
+        Element::empty_count_tree(),
+        None,
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("insert count tree");
+
+    let wrapped = Element::new_non_counted(inner).expect("wrap in NonCounted");
+    db.insert(&[b"counted"], b"tree", wrapped, None, None, grove_version)
+        .unwrap()
+        .expect("insert NonCounted tree");
+
+    assert_eq!(
+        count_tree_value(&db, grove_version),
+        0,
+        "a NonCounted child must not be counted"
+    );
+    db
+}
+
+/// Read the RAW stored element at `counted/tree` — `get` resolves through
+/// wrappers by design, so only the raw read shows whether one survived.
+fn stored_tree(db: &TempGroveDb, grove_version: &GroveVersion) -> Element {
+    db.get_raw(
+        [b"counted".as_slice()].as_ref().into(),
+        b"tree",
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("get raw tree")
+}
+
+/// Assert the wrapper survived the append, the entry landed, the parent
+/// count is untouched, and the grove verifies clean.
+fn assert_wrapper_preserved(db: &TempGroveDb, entry_count: u64, grove_version: &GroveVersion) {
+    let stored = stored_tree(db, grove_version);
+    assert!(
+        stored.is_non_counted(),
+        "the append must not strip the NonCounted wrapper, got {}",
+        stored.type_str()
+    );
+    assert_eq!(stored.non_merk_entry_count(), Some(entry_count));
+    assert_eq!(
+        count_tree_value(db, grove_version),
+        0,
+        "appending to a NonCounted tree must not change the parent's count"
+    );
+
+    let issues = db
+        .verify_grovedb(None, true, false, grove_version)
+        .expect("verify_grovedb");
+    assert!(issues.is_empty(), "issues: {:?}", issues);
+}
+
+/// Assert the released `GROVE_V3` behaviour: the append strips the wrapper,
+/// the tree becomes counted, and the grove still verifies clean.
+fn assert_wrapper_dropped_on_v3(db: &TempGroveDb, entry_count: u64) {
+    let stored = stored_tree(db, &GROVE_V3);
+    assert!(
+        !stored.is_non_counted(),
+        "GROVE_V3 must keep the released wrapper drop, got {}",
+        stored.type_str()
+    );
+    assert_eq!(stored.non_merk_entry_count(), Some(entry_count));
+    assert_eq!(
+        count_tree_value(db, &GROVE_V3),
+        1,
+        "the bare tree must count toward its parent under GROVE_V3"
+    );
+
+    let issues = db
+        .verify_grovedb(None, true, false, &GROVE_V3)
+        .expect("verify_grovedb");
+    assert!(issues.is_empty(), "issues: {:?}", issues);
+}
+
+/// A deterministic test ciphertext for the commitment tree appends. Layout:
+/// `epk_bytes (32) || enc_ciphertext (104) || out_ciphertext (80)`.
+fn test_ciphertext(index: u8) -> TransmittedNoteCiphertext<DashMemo> {
+    let mut epk_bytes = [0u8; 32];
+    epk_bytes[0] = index;
+    let mut enc_data = [0u8; 104];
+    enc_data[0] = index;
+    let mut out_ciphertext = [0u8; 80];
+    out_ciphertext[0] = index;
+    TransmittedNoteCiphertext::from_parts(epk_bytes, NoteBytesData(enc_data), out_ciphertext)
+}
+
+/// A deterministic 32-byte note commitment, top bit cleared so the bytes are
+/// a valid Pallas field element.
+fn test_cmx(index: u8) -> [u8; 32] {
+    let mut bytes = [0u8; 32];
+    bytes[0] = index;
+    bytes[31] &= 0x7f;
+    bytes
+}
+
+// ===========================================================================
+// MmrTree
+// ===========================================================================
+
+#[test]
+fn test_mmr_direct_append_preserves_non_counted_wrapper() {
+    let grove_version = GroveVersion::latest();
+    let db = make_non_counted_tree_under_count_tree(Element::empty_mmr_tree(), grove_version);
+
+    db.mmr_tree_append(
+        &[b"counted"],
+        b"tree",
+        b"leaf".to_vec(),
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("append");
+
+    // mmr_size of a single-leaf MMR is 1.
+    assert_wrapper_preserved(&db, 1, grove_version);
+}
+
+#[test]
+fn test_mmr_batch_append_preserves_non_counted_wrapper() {
+    let grove_version = GroveVersion::latest();
+    let db = make_non_counted_tree_under_count_tree(Element::empty_mmr_tree(), grove_version);
+
+    let ops = vec![QualifiedGroveDbOp::mmr_tree_append_op(
+        vec![b"counted".to_vec(), b"tree".to_vec()],
+        b"leaf".to_vec(),
+    )];
+    db.apply_batch(ops, None, None, grove_version)
+        .unwrap()
+        .expect("batch append");
+
+    assert_wrapper_preserved(&db, 1, grove_version);
+}
+
+#[test]
+fn test_mmr_append_drops_wrapper_on_grove_v3() {
+    // Direct path.
+    let db = make_non_counted_tree_under_count_tree(Element::empty_mmr_tree(), &GROVE_V3);
+    db.mmr_tree_append(&[b"counted"], b"tree", b"leaf".to_vec(), None, &GROVE_V3)
+        .unwrap()
+        .expect("append");
+    assert_wrapper_dropped_on_v3(&db, 1);
+
+    // Batch path.
+    let db = make_non_counted_tree_under_count_tree(Element::empty_mmr_tree(), &GROVE_V3);
+    let ops = vec![QualifiedGroveDbOp::mmr_tree_append_op(
+        vec![b"counted".to_vec(), b"tree".to_vec()],
+        b"leaf".to_vec(),
+    )];
+    db.apply_batch(ops, None, None, &GROVE_V3)
+        .unwrap()
+        .expect("batch append");
+    assert_wrapper_dropped_on_v3(&db, 1);
+}
+
+// ===========================================================================
+// DenseAppendOnlyFixedSizeTree
+// ===========================================================================
+
+#[test]
+fn test_dense_direct_insert_preserves_non_counted_wrapper() {
+    let grove_version = GroveVersion::latest();
+    let db = make_non_counted_tree_under_count_tree(Element::empty_dense_tree(4), grove_version);
+
+    db.dense_tree_insert(
+        &[b"counted"],
+        b"tree",
+        b"value".to_vec(),
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("insert");
+
+    assert_wrapper_preserved(&db, 1, grove_version);
+}
+
+#[test]
+fn test_dense_batch_insert_preserves_non_counted_wrapper() {
+    let grove_version = GroveVersion::latest();
+    let db = make_non_counted_tree_under_count_tree(Element::empty_dense_tree(4), grove_version);
+
+    let ops = vec![QualifiedGroveDbOp::dense_tree_insert_op(
+        vec![b"counted".to_vec(), b"tree".to_vec()],
+        b"value".to_vec(),
+    )];
+    db.apply_batch(ops, None, None, grove_version)
+        .unwrap()
+        .expect("batch insert");
+
+    assert_wrapper_preserved(&db, 1, grove_version);
+}
+
+#[test]
+fn test_dense_insert_drops_wrapper_on_grove_v3() {
+    // Direct path.
+    let db = make_non_counted_tree_under_count_tree(Element::empty_dense_tree(4), &GROVE_V3);
+    db.dense_tree_insert(&[b"counted"], b"tree", b"value".to_vec(), None, &GROVE_V3)
+        .unwrap()
+        .expect("insert");
+    assert_wrapper_dropped_on_v3(&db, 1);
+
+    // Batch path.
+    let db = make_non_counted_tree_under_count_tree(Element::empty_dense_tree(4), &GROVE_V3);
+    let ops = vec![QualifiedGroveDbOp::dense_tree_insert_op(
+        vec![b"counted".to_vec(), b"tree".to_vec()],
+        b"value".to_vec(),
+    )];
+    db.apply_batch(ops, None, None, &GROVE_V3)
+        .unwrap()
+        .expect("batch insert");
+    assert_wrapper_dropped_on_v3(&db, 1);
+}
+
+// ===========================================================================
+// BulkAppendTree
+// ===========================================================================
+
+#[test]
+fn test_bulk_direct_append_preserves_non_counted_wrapper() {
+    let grove_version = GroveVersion::latest();
+    let db = make_non_counted_tree_under_count_tree(
+        Element::empty_bulk_append_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
+        grove_version,
+    );
+
+    db.bulk_append(
+        &[b"counted"],
+        b"tree",
+        b"value".to_vec(),
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("append");
+
+    assert_wrapper_preserved(&db, 1, grove_version);
+}
+
+#[test]
+fn test_bulk_batch_append_preserves_non_counted_wrapper() {
+    let grove_version = GroveVersion::latest();
+    let db = make_non_counted_tree_under_count_tree(
+        Element::empty_bulk_append_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
+        grove_version,
+    );
+
+    let ops = vec![QualifiedGroveDbOp::bulk_append_op(
+        vec![b"counted".to_vec(), b"tree".to_vec()],
+        b"value".to_vec(),
+    )];
+    db.apply_batch(ops, None, None, grove_version)
+        .unwrap()
+        .expect("batch append");
+
+    assert_wrapper_preserved(&db, 1, grove_version);
+}
+
+#[test]
+fn test_bulk_append_drops_wrapper_on_grove_v3() {
+    // Direct path.
+    let db = make_non_counted_tree_under_count_tree(
+        Element::empty_bulk_append_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
+        &GROVE_V3,
+    );
+    db.bulk_append(&[b"counted"], b"tree", b"value".to_vec(), None, &GROVE_V3)
+        .unwrap()
+        .expect("append");
+    assert_wrapper_dropped_on_v3(&db, 1);
+
+    // Batch path.
+    let db = make_non_counted_tree_under_count_tree(
+        Element::empty_bulk_append_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
+        &GROVE_V3,
+    );
+    let ops = vec![QualifiedGroveDbOp::bulk_append_op(
+        vec![b"counted".to_vec(), b"tree".to_vec()],
+        b"value".to_vec(),
+    )];
+    db.apply_batch(ops, None, None, &GROVE_V3)
+        .unwrap()
+        .expect("batch append");
+    assert_wrapper_dropped_on_v3(&db, 1);
+}
+
+// ===========================================================================
+// CommitmentTree
+// ===========================================================================
+
+#[test]
+fn test_commitment_direct_insert_preserves_non_counted_wrapper() {
+    let grove_version = GroveVersion::latest();
+    let db = make_non_counted_tree_under_count_tree(
+        Element::empty_commitment_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
+        grove_version,
+    );
+
+    db.commitment_tree_insert(
+        &[b"counted"],
+        b"tree",
+        test_cmx(1),
+        [1u8; 32],
+        [2u8; 32],
+        test_ciphertext(1),
+        None,
+        grove_version,
+    )
+    .unwrap()
+    .expect("insert");
+
+    assert_wrapper_preserved(&db, 1, grove_version);
+}
+
+#[test]
+fn test_commitment_batch_insert_preserves_non_counted_wrapper() {
+    let grove_version = GroveVersion::latest();
+    let db = make_non_counted_tree_under_count_tree(
+        Element::empty_commitment_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
+        grove_version,
+    );
+
+    let ops = vec![QualifiedGroveDbOp::commitment_tree_insert_op_typed(
+        vec![b"counted".to_vec(), b"tree".to_vec()],
+        test_cmx(1),
+        [1u8; 32],
+        [2u8; 32],
+        &test_ciphertext(1),
+    )];
+    db.apply_batch(ops, None, None, grove_version)
+        .unwrap()
+        .expect("batch insert");
+
+    assert_wrapper_preserved(&db, 1, grove_version);
+}
+
+#[test]
+fn test_commitment_insert_drops_wrapper_on_grove_v3() {
+    // Direct path.
+    let db = make_non_counted_tree_under_count_tree(
+        Element::empty_commitment_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
+        &GROVE_V3,
+    );
+    db.commitment_tree_insert(
+        &[b"counted"],
+        b"tree",
+        test_cmx(1),
+        [1u8; 32],
+        [2u8; 32],
+        test_ciphertext(1),
+        None,
+        &GROVE_V3,
+    )
+    .unwrap()
+    .expect("insert");
+    assert_wrapper_dropped_on_v3(&db, 1);
+
+    // Batch path.
+    let db = make_non_counted_tree_under_count_tree(
+        Element::empty_commitment_tree(TEST_CHUNK_POWER).expect("valid chunk_power"),
+        &GROVE_V3,
+    );
+    let ops = vec![QualifiedGroveDbOp::commitment_tree_insert_op_typed(
+        vec![b"counted".to_vec(), b"tree".to_vec()],
+        test_cmx(1),
+        [1u8; 32],
+        [2u8; 32],
+        &test_ciphertext(1),
+    )];
+    db.apply_batch(ops, None, None, &GROVE_V3)
+        .unwrap()
+        .expect("batch insert");
+    assert_wrapper_dropped_on_v3(&db, 1);
+}
+
+// ===========================================================================
+// Wrapper survives repeated appends (the second append reads the state the
+// first one wrote)
+// ===========================================================================
+
+#[test]
+fn test_wrapper_survives_repeated_appends() {
+    let grove_version = GroveVersion::latest();
+    let db = make_non_counted_tree_under_count_tree(Element::empty_mmr_tree(), grove_version);
+
+    for i in 0..4u8 {
+        db.mmr_tree_append(&[b"counted"], b"tree", vec![i], None, grove_version)
+            .unwrap()
+            .expect("append");
+    }
+
+    // mmr_size of a 4-leaf MMR is 7 (4 leaves + 3 internal nodes).
+    assert_wrapper_preserved(&db, 7, grove_version);
+}


### PR DESCRIPTION
## Problem

Every typed append to a non-Merk data tree rewrites the tree's parent-Merk element, rebuilding it from the new entry count and the stored element's flags. The rebuild constructors (`Element::new_mmr_tree` and friends) produce a **bare** element, so a stored `NonCounted(tree)` lost its wrapper on its first append:

- direct paths: `mmr_tree_append`, `dense_tree_insert`, `bulk_append`, `commitment_tree_insert`
- batch path: the `ReplaceNonMerkTreeRoot` rebuild in `execute_ops_on_path` (which every batch append preprocesses into)

Dropping the wrapper flips the tree's contribution to a `CountTree` / `CountSumTree` parent from 0 to 1, changing the parent aggregate and with it the root hash. `PrivateDocumentStore` alone restored its wrapper — the batch arm carried an explicit PDS-only carve-out with an in-code note that the same latent defect exists for the other four families but is live on GROVE_V1..V3 and repairing it "belongs in its own version-gated change". This is that change.

## Fix (version-gated, GROVE_V4+)

- New slot `operations.non_merk_tree.parent_element_rewrap` (`GroveDBOperationsNonMerkTreeVersions`): `0` on GROVE_V1..V3, `1` on GROVE_V4. Documented in the v4.rs landing-zone list.
- House versioned dispatcher `grovedb/src/operations/rewrap_non_merk_tree_parent_element/{mod.rs,v0.rs,v1.rs}`:
  - **v0** (V1..V3): restores the wrapper for `PrivateDocumentStore` only — the released behaviour, preserved for replay.
  - **v1** (V4+): restores the wrapper for every family.
- All six rewrite sites route through the dispatcher: the four direct appends, the PDS direct append (previously an inline re-wrap), and the batch `ReplaceNonMerkTreeRoot` arm (the PDS-only carve-out is replaced by the versioned call).
- `GroveOp::InsertNonMerkTree` needs no change: it carries an explicit `non_counted` flag from the original insert op and already re-wraps.

Every rewrite path already reads the stored element (flags are preserved from it), so no extra reads are charged — the gate exists because restoring the wrapper moves a committed root hash and rewrites wrapper bytes V1..V3 dropped.

## Tests

`grovedb/src/tests/non_merk_wrapper_preservation_tests.rs` — for each of the four families under a `CountTree`:

- direct and batch appends under `GroveVersion::latest()` preserve the wrapper, keep the parent count at 0, and `verify_grovedb` reports clean;
- the same direct and batch appends under `GROVE_V3` pin the released drop (wrapper stripped, parent count 1, still verifying clean), so the legacy replay path cannot silently change;
- a repeated-append test confirms the wrapper survives appends that read the state a prior append wrote.

`PrivateDocumentStore` wrapper preservation is already covered in `private_document_store_tests` (unchanged behaviour on both dispatcher arms).

Full `grovedb` test suite green locally (3313 passed), `cargo clippy` clean.

## Follow-up

`grovedb/src/tests/clear_append_tree_tests.rs` (on PR #931's branch, not yet on develop) has a doc comment on `clear_non_counted_wrapped_private_document_store_preserves_wrapper` describing this defect as live for the other families — it should be updated (and that test optionally extended to the other families) once both PRs are in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)