### PR TITLE
fix(grovedb): sweep nested indexed secondaries in every recursive cleanup (#888)

### DIFF
--- a/grovedb-version/src/version/grovedb_versions.rs
+++ b/grovedb-version/src/version/grovedb_versions.rs
@@ -138,6 +138,18 @@ pub struct GroveDBApplyBatchVersions {
     /// an accepted/rejected outcome — a mismatched delete that V1..V3
     /// accept is refused on V4+ when an indexed tree is involved.
     pub delete_tree_cleanup_type_source: FeatureVersion,
+    /// Whether full and partial batch `DeleteTree` cleanup sweeps every
+    /// discovered subtree's indexed secondary namespaces (issue #888).
+    ///
+    /// - `0` (V1..V3): recursively clear primary namespaces only, retaining
+    ///   the separate top-level indexed-secondary pass and its costs.
+    /// - `1` (V4+): also sweep all three secondary axes for every subtree.
+    ///
+    /// Empty secondary sweeps still charge seeks, boundary reads, and
+    /// prefix hashes, including for ordinary trees. These costs must not
+    /// change on released versions. Direct deletion is unaffected: it
+    /// already swept secondaries recursively on every version.
+    pub delete_tree_recursive_secondary_cleanup: FeatureVersion,
     /// Whether a batch overwrite (`InsertOrReplace` / `Replace` / `Patch`,
     /// with tree-override protection off) classifies the element it
     /// displaces to detect an indexed tree being overwritten.

--- a/grovedb-version/src/version/v1.rs
+++ b/grovedb-version/src/version/v1.rs
@@ -38,6 +38,7 @@ pub const GROVE_V1: GroveVersion = GroveVersion {
             apply_partial_batch_with_element_flags_update: 0,
             estimated_case_operations_for_batch: 0,
             delete_tree_cleanup_type_source: 0,
+            delete_tree_recursive_secondary_cleanup: 0,
             overwrite_indexed_cleanup_inspection: 0,
             keyless_op_cost_dispatch: 0,
             add_on_op_collision: 0,

--- a/grovedb-version/src/version/v2.rs
+++ b/grovedb-version/src/version/v2.rs
@@ -38,6 +38,7 @@ pub const GROVE_V2: GroveVersion = GroveVersion {
             apply_partial_batch_with_element_flags_update: 0,
             estimated_case_operations_for_batch: 0,
             delete_tree_cleanup_type_source: 0,
+            delete_tree_recursive_secondary_cleanup: 0,
             overwrite_indexed_cleanup_inspection: 0,
             keyless_op_cost_dispatch: 0,
             add_on_op_collision: 0,

--- a/grovedb-version/src/version/v3.rs
+++ b/grovedb-version/src/version/v3.rs
@@ -38,6 +38,7 @@ pub const GROVE_V3: GroveVersion = GroveVersion {
             apply_partial_batch_with_element_flags_update: 0,
             estimated_case_operations_for_batch: 0,
             delete_tree_cleanup_type_source: 0,
+            delete_tree_recursive_secondary_cleanup: 0,
             overwrite_indexed_cleanup_inspection: 0,
             keyless_op_cost_dispatch: 0,
             add_on_op_collision: 0,

--- a/grovedb-version/src/version/v4.rs
+++ b/grovedb-version/src/version/v4.rs
@@ -12,6 +12,13 @@
 //!   observer), so V4 charges exactly the V1..V3 cost — the gate exists
 //!   because it flips an accepted/rejected outcome, not because of cost.
 //!
+//! - `apply_batch.delete_tree_recursive_secondary_cleanup: 1` — full and
+//!   partial batch `DeleteTree` cleanup sweeps each descendant's indexed
+//!   secondary namespaces (issue #888). V1..V3 retain primary-only recursion
+//!   and the separate top-level secondary pass: even empty secondary sweeps
+//!   charge additional seeks, reads, and hashes for ordinary trees. Direct
+//!   deletion already swept descendants' secondaries and is unchanged.
+//!
 //! - `apply_batch.overwrite_indexed_cleanup_inspection: 1` — a batch
 //!   overwrite (with tree-override protection off, references included)
 //!   classifies the element it displaces to detect an indexed tree being
@@ -336,6 +343,7 @@ pub const GROVE_V4: GroveVersion = GroveVersion {
             apply_partial_batch_with_element_flags_update: 0,
             estimated_case_operations_for_batch: 0,
             delete_tree_cleanup_type_source: 1,
+            delete_tree_recursive_secondary_cleanup: 1,
             overwrite_indexed_cleanup_inspection: 1,
             keyless_op_cost_dispatch: 1,
             add_on_op_collision: 1,

--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -6761,8 +6761,11 @@ impl GroveDb {
         // Clean up storage for deleted standard Merk subtrees.
         // The parent key has been removed from the parent Merk by apply_body,
         // but the child subtree's storage (and any nested subtrees) remains.
-        // We use find_subtrees to recursively discover all nested subtrees
-        // and clear their storage, matching the non-batch delete behavior.
+        // The shared recursive cleanup discovers all nested subtrees via
+        // find_subtrees and clears each one's primary namespace AND its
+        // per-axis indexed-tree secondary namespaces (issue #888 — a nested
+        // indexed primary's secondaries live outside the path-prefix walk),
+        // matching the non-batch delete behavior.
         //
         // NOTE: find_subtrees reads from the committed transaction state
         // (without the pending storage_batch), so any subtrees *inserted*
@@ -6774,25 +6777,16 @@ impl GroveDb {
         // BatchApplyOptions::disable_operation_consistency_check.
         for child_path in &merk_delete_paths {
             let child_subtree_path: SubtreePath<Vec<u8>> = child_path.as_slice().into();
-            let subtrees_paths = cost_return_on_error!(
+            cost_return_on_error!(
                 &mut cost,
-                self.find_subtrees(&child_subtree_path, Some(tx.as_ref()), grove_version)
+                self.clear_subtree_storage_recursively(
+                    &child_subtree_path,
+                    tx.as_ref(),
+                    &storage_batch,
+                    "batch delete",
+                    grove_version,
+                )
             );
-            for subtree_path in subtrees_paths {
-                let p: SubtreePath<_> = subtree_path.as_slice().into();
-                let mut storage = self
-                    .db
-                    .get_transactional_storage_context(p, Some(&storage_batch), tx.as_ref())
-                    .unwrap_add_cost(&mut cost);
-                cost_return_on_error!(
-                    &mut cost,
-                    storage.clear().map_err(|e| {
-                        Error::CorruptedData(format!(
-                            "unable to clean up merk subtree storage in batch delete: {e}",
-                        ))
-                    })
-                );
-            }
         }
 
         // Indexed-tree secondary cleanup. find_subtrees walks the
@@ -6849,66 +6843,24 @@ impl GroveDb {
         // (parent_path + cidx_key).
         for cidx_path in &cidx_overwrite_cleanup_paths {
             let cidx_subtree_path: SubtreePath<Vec<u8>> = cidx_path.as_slice().into();
-            // Clear all primary subtree storage recursively via
-            // find_subtrees (same walk as DeleteTree cleanup above).
-            let subtrees_paths = cost_return_on_error!(
+            // Clear all primary subtree storage recursively (same walk as
+            // the DeleteTree cleanup above), sweeping every discovered
+            // subtree's per-axis secondary namespaces too — this covers
+            // both the replaced cidx's own secondaries (find_subtrees
+            // includes the root path itself) and any nested indexed
+            // primary inside it (issue #888). Sweeping all three axes is
+            // safe: clear on empty is a no-op, so this also works for
+            // PCIT-only overwrites (the sum / avg slots are empty).
+            cost_return_on_error!(
                 &mut cost,
-                self.find_subtrees(&cidx_subtree_path, Some(tx.as_ref()), grove_version)
+                self.clear_subtree_storage_recursively(
+                    &cidx_subtree_path,
+                    tx.as_ref(),
+                    &storage_batch,
+                    "batch overwrite",
+                    grove_version,
+                )
             );
-            for subtree_path in subtrees_paths {
-                let p: SubtreePath<_> = subtree_path.as_slice().into();
-                let mut storage = self
-                    .db
-                    .get_transactional_storage_context(p, Some(&storage_batch), tx.as_ref())
-                    .unwrap_add_cost(&mut cost);
-                cost_return_on_error!(
-                    &mut cost,
-                    storage.clear().map_err(|e| {
-                        Error::CorruptedData(format!(
-                            "unable to clean up cidx primary subtree storage in batch \
-                             overwrite: {e}",
-                        ))
-                    })
-                );
-            }
-            // Clear the per-axis secondary namespaces at
-            // Blake3(primary ‖ axis_tag). Sweep all three axes — clear
-            // on empty is a no-op, so this also works for PCIT-only
-            // overwrites (the sum / avg slots are empty).
-            let primary_prefix = grovedb_storage::rocksdb_storage::RocksDbStorage::build_prefix(
-                cidx_subtree_path.clone(),
-            )
-            .unwrap_add_cost(&mut cost);
-            for axis in [
-                grovedb_element::indexed::IndexAxis::Count,
-                grovedb_element::indexed::IndexAxis::Sum,
-                grovedb_element::indexed::IndexAxis::Avg,
-            ] {
-                let secondary_prefix =
-                    grovedb_storage::rocksdb_storage::RocksDbStorage::secondary_prefix_for(
-                        &primary_prefix,
-                        axis.tag(),
-                    )
-                    .unwrap_add_cost(&mut cost);
-                let mut secondary_storage = self
-                    .db
-                    .get_transactional_storage_context_by_subtree_prefix(
-                        secondary_prefix,
-                        Some(&storage_batch),
-                        tx.as_ref(),
-                    )
-                    .unwrap_add_cost(&mut cost);
-                cost_return_on_error!(
-                    &mut cost,
-                    secondary_storage.clear().map_err(|e| {
-                        Error::CorruptedData(format!(
-                            "unable to clean up indexed-tree secondary (axis {:?}) storage \
-                             in batch overwrite: {e}",
-                            axis
-                        ))
-                    })
-                );
-            }
         }
 
         // TODO: compute batch costs
@@ -7570,25 +7522,16 @@ impl GroveDb {
         // BatchApplyOptions::disable_operation_consistency_check.
         for child_path in &merk_delete_paths {
             let child_subtree_path: SubtreePath<Vec<u8>> = child_path.as_slice().into();
-            let subtrees_paths = cost_return_on_error!(
+            cost_return_on_error!(
                 &mut cost,
-                self.find_subtrees(&child_subtree_path, Some(tx.as_ref()), grove_version)
+                self.clear_subtree_storage_recursively(
+                    &child_subtree_path,
+                    tx.as_ref(),
+                    &storage_batch,
+                    "batch delete",
+                    grove_version,
+                )
             );
-            for subtree_path in subtrees_paths {
-                let p: SubtreePath<_> = subtree_path.as_slice().into();
-                let mut storage = self
-                    .db
-                    .get_transactional_storage_context(p, Some(&storage_batch), tx.as_ref())
-                    .unwrap_add_cost(&mut cost);
-                cost_return_on_error!(
-                    &mut cost,
-                    storage.clear().map_err(|e| {
-                        Error::CorruptedData(format!(
-                            "unable to clean up merk subtree storage in batch delete: {e}",
-                        ))
-                    })
-                );
-            }
         }
 
         // Indexed-tree secondary cleanup (parallels the
@@ -7641,60 +7584,20 @@ impl GroveDb {
             .collect();
         for cidx_path in all_cidx_overwrite_paths {
             let cidx_subtree_path: SubtreePath<Vec<u8>> = cidx_path.as_slice().into();
-            let subtrees_paths = cost_return_on_error!(
+            // Shared recursive cleanup: primary namespaces plus per-axis
+            // secondaries for every discovered subtree, covering the
+            // replaced cidx itself and any nested indexed primary inside
+            // it (issue #888).
+            cost_return_on_error!(
                 &mut cost,
-                self.find_subtrees(&cidx_subtree_path, Some(tx.as_ref()), grove_version)
+                self.clear_subtree_storage_recursively(
+                    &cidx_subtree_path,
+                    tx.as_ref(),
+                    &storage_batch,
+                    "batch overwrite",
+                    grove_version,
+                )
             );
-            for subtree_path in subtrees_paths {
-                let p: SubtreePath<_> = subtree_path.as_slice().into();
-                let mut storage = self
-                    .db
-                    .get_transactional_storage_context(p, Some(&storage_batch), tx.as_ref())
-                    .unwrap_add_cost(&mut cost);
-                cost_return_on_error!(
-                    &mut cost,
-                    storage.clear().map_err(|e| {
-                        Error::CorruptedData(format!(
-                            "unable to clean up cidx primary subtree storage in batch \
-                             overwrite: {e}",
-                        ))
-                    })
-                );
-            }
-            let primary_prefix = grovedb_storage::rocksdb_storage::RocksDbStorage::build_prefix(
-                cidx_subtree_path.clone(),
-            )
-            .unwrap_add_cost(&mut cost);
-            for axis in [
-                grovedb_element::indexed::IndexAxis::Count,
-                grovedb_element::indexed::IndexAxis::Sum,
-                grovedb_element::indexed::IndexAxis::Avg,
-            ] {
-                let secondary_prefix =
-                    grovedb_storage::rocksdb_storage::RocksDbStorage::secondary_prefix_for(
-                        &primary_prefix,
-                        axis.tag(),
-                    )
-                    .unwrap_add_cost(&mut cost);
-                let mut secondary_storage = self
-                    .db
-                    .get_transactional_storage_context_by_subtree_prefix(
-                        secondary_prefix,
-                        Some(&storage_batch),
-                        tx.as_ref(),
-                    )
-                    .unwrap_add_cost(&mut cost);
-                cost_return_on_error!(
-                    &mut cost,
-                    secondary_storage.clear().map_err(|e| {
-                        Error::CorruptedData(format!(
-                            "unable to clean up indexed-tree secondary (axis {:?}) storage \
-                             in batch overwrite: {e}",
-                            axis
-                        ))
-                    })
-                );
-            }
         }
 
         // let's build the write batch

--- a/grovedb/src/batch/mod.rs
+++ b/grovedb/src/batch/mod.rs
@@ -6765,7 +6765,9 @@ impl GroveDb {
         // find_subtrees and clears each one's primary namespace AND its
         // per-axis indexed-tree secondary namespaces (issue #888 — a nested
         // indexed primary's secondaries live outside the path-prefix walk),
-        // matching the non-batch delete behavior.
+        // matching the non-batch delete behavior on V4+. V1..V3 retain
+        // primary-only recursion because even empty secondary sweeps
+        // charge additional costs for ordinary trees.
         //
         // NOTE: find_subtrees reads from the committed transaction state
         // (without the pending storage_batch), so any subtrees *inserted*
@@ -6783,6 +6785,11 @@ impl GroveDb {
                     &child_subtree_path,
                     tx.as_ref(),
                     &storage_batch,
+                    grove_version
+                        .grovedb_versions
+                        .apply_batch
+                        .delete_tree_recursive_secondary_cleanup
+                        >= 1,
                     "batch delete",
                     grove_version,
                 )
@@ -6857,6 +6864,7 @@ impl GroveDb {
                     &cidx_subtree_path,
                     tx.as_ref(),
                     &storage_batch,
+                    true,
                     "batch overwrite",
                     grove_version,
                 )
@@ -7528,6 +7536,11 @@ impl GroveDb {
                     &child_subtree_path,
                     tx.as_ref(),
                     &storage_batch,
+                    grove_version
+                        .grovedb_versions
+                        .apply_batch
+                        .delete_tree_recursive_secondary_cleanup
+                        >= 1,
                     "batch delete",
                     grove_version,
                 )
@@ -7594,6 +7607,7 @@ impl GroveDb {
                     &cidx_subtree_path,
                     tx.as_ref(),
                     &storage_batch,
+                    true,
                     "batch overwrite",
                     grove_version,
                 )

--- a/grovedb/src/batch/single_insert_cost_tests.rs
+++ b/grovedb/src/batch/single_insert_cost_tests.rs
@@ -1620,15 +1620,17 @@ mod tests {
     }
 
     #[test]
-    fn test_batch_plain_overwrites_and_tree_delete_cost_parity_v3_v4() {
-        // A batch touching NO indexed trees must cost byte-for-byte the same
-        // under GROVE_V3 and GROVE_V4. Both V4 gates
+    fn test_batch_plain_overwrites_and_tree_delete_versioned_costs_v3_v4() {
+        // Classifying a batch touching NO indexed trees must cost the same
+        // under GROVE_V3 and GROVE_V4. Both classification gates
         // (`overwrite_indexed_cleanup_inspection` and
         // `delete_tree_cleanup_type_source`) derive the old element from
         // data the apply already loads — the merk walk's own fetch of the
         // node being rewritten or deleted, and the emptiness pre-scan's own
         // read — instead of issuing a dedicated stored-element read, so
-        // their classification work is invisible to tracked cost.
+        // their classification work is invisible to tracked cost. V4's
+        // separate recursive-secondary-cleanup gate adds charged empty
+        // sweeps, which are checked independently below.
         let run = |grove_version: &GroveVersion| {
             let db = make_empty_grovedb();
             let tx = db.start_transaction();
@@ -1679,12 +1681,32 @@ mod tests {
 
         let v3 = run(&grovedb_version::version::v3::GROVE_V3);
         let v4 = run(&grovedb_version::version::v4::GROVE_V4);
+        let mut v4_primary_cleanup = grovedb_version::version::v4::GROVE_V4.clone();
+        v4_primary_cleanup
+            .grovedb_versions
+            .apply_batch
+            .delete_tree_recursive_secondary_cleanup = 0;
+        let v4_primary_cleanup = run(&v4_primary_cleanup);
         v3.value.as_ref().expect("v3 batch should apply");
         v4.value.as_ref().expect("v4 batch should apply");
+        v4_primary_cleanup
+            .value
+            .as_ref()
+            .expect("v4 batch with legacy cleanup should apply");
         assert_eq!(
-            v3.cost, v4.cost,
-            "a batch of plain overwrites plus a plain DeleteTree must \
-             produce an identical CostResult under V3 and V4"
+            v3.cost, v4_primary_cleanup.cost,
+            "V4 classification must not add costs to plain overwrites or deletion"
+        );
+        assert_eq!(
+            v4.cost,
+            v3.cost
+                + OperationCost {
+                    seek_count: 3,
+                    storage_loaded_bytes: 864,
+                    hash_node_calls: 4,
+                    ..Default::default()
+                },
+            "V4 cleanup adds only three empty secondary sweeps and their prefix hashes"
         );
     }
 

--- a/grovedb/src/operations/auxiliary.rs
+++ b/grovedb/src/operations/auxiliary.rs
@@ -32,13 +32,14 @@ use grovedb_costs::{
     cost_return_on_error, storage_cost::key_value_cost::KeyValueStorageCost, CostResult, CostsExt,
     OperationCost,
 };
+use grovedb_element::indexed::IndexAxis;
 use grovedb_path::SubtreePath;
-use grovedb_storage::{Storage, StorageContext};
+use grovedb_storage::{rocksdb_storage::RocksDbStorage, Storage, StorageBatch, StorageContext};
 use grovedb_version::version::GroveVersion;
 
 use crate::{
     element::elements_iterator::ElementIteratorExtensions, util::TxRef, Element, Error, GroveDb,
-    TransactionArg,
+    Transaction, TransactionArg,
 };
 
 impl GroveDb {
@@ -192,5 +193,85 @@ impl GroveDb {
             }
         }
         Ok(result).wrap_with_cost(cost)
+    }
+
+    /// Recursively clear ALL storage owned by the subtree at `path`: the
+    /// primary namespace of every nested subtree discovered by
+    /// [`Self::find_subtrees`], plus — for EVERY discovered subtree — the
+    /// per-axis indexed-tree secondary namespaces at
+    /// `Blake3(subtree_prefix ‖ axis_tag)` (S2-B derivation).
+    ///
+    /// This is the single recursive ownership-cleanup routine (issue #888)
+    /// shared by the direct delete (`delete_internal_on_transaction`
+    /// v0/v1), the batch `DeleteTree` post-apply pass (full and partial),
+    /// the batch cidx safe-subset overwrite pass, and the dedicated
+    /// indexed-tree child overwrite. `find_subtrees` only walks
+    /// path-derived prefixes, so a nested indexed-tree primary's secondary
+    /// namespaces are invisible to it; without the per-descendant sweep
+    /// they would be orphaned, and a later re-creation of the same
+    /// deterministic path (prefixes are path-derived) would resurrect the
+    /// stale secondary rows, breaking primary-secondary agreement.
+    ///
+    /// All three axis tags are swept unconditionally for every discovered
+    /// subtree rather than decoding each subtree's element to check its
+    /// tree type: clearing an empty namespace is a no-op, so the
+    /// redundancy is intentional defense-in-depth (it also removes a class
+    /// of missed-decoding bugs).
+    ///
+    /// `context` names the calling operation in error messages.
+    pub(crate) fn clear_subtree_storage_recursively<'db, B: AsRef<[u8]>>(
+        &'db self,
+        path: &SubtreePath<B>,
+        transaction: &'db Transaction,
+        batch: &'db StorageBatch,
+        context: &str,
+        grove_version: &GroveVersion,
+    ) -> CostResult<(), Error> {
+        let mut cost = OperationCost::default();
+
+        let subtrees_paths = cost_return_on_error!(
+            &mut cost,
+            self.find_subtrees(path, Some(transaction), grove_version)
+        );
+        for subtree_path in subtrees_paths {
+            let p: SubtreePath<_> = subtree_path.as_slice().into();
+            let mut storage = self
+                .db
+                .get_transactional_storage_context(p.clone(), Some(batch), transaction)
+                .unwrap_add_cost(&mut cost);
+            cost_return_on_error!(
+                &mut cost,
+                storage.clear().map_err(|e| {
+                    Error::CorruptedData(format!(
+                        "unable to clean up subtree storage in {context}: {e}",
+                    ))
+                })
+            );
+
+            let primary_prefix = RocksDbStorage::build_prefix(p).unwrap_add_cost(&mut cost);
+            for axis in [IndexAxis::Count, IndexAxis::Sum, IndexAxis::Avg] {
+                let secondary_prefix =
+                    RocksDbStorage::secondary_prefix_for(&primary_prefix, axis.tag())
+                        .unwrap_add_cost(&mut cost);
+                let mut secondary_storage = self
+                    .db
+                    .get_transactional_storage_context_by_subtree_prefix(
+                        secondary_prefix,
+                        Some(batch),
+                        transaction,
+                    )
+                    .unwrap_add_cost(&mut cost);
+                cost_return_on_error!(
+                    &mut cost,
+                    secondary_storage.clear().map_err(|e| {
+                        Error::CorruptedData(format!(
+                            "unable to clean up indexed-tree secondary (axis {axis:?}) in \
+                             {context}: {e}",
+                        ))
+                    })
+                );
+            }
+        }
+        Ok(()).wrap_with_cost(cost)
     }
 }

--- a/grovedb/src/operations/auxiliary.rs
+++ b/grovedb/src/operations/auxiliary.rs
@@ -195,9 +195,10 @@ impl GroveDb {
         Ok(result).wrap_with_cost(cost)
     }
 
-    /// Recursively clear ALL storage owned by the subtree at `path`: the
+    /// Recursively clear storage owned by the subtree at `path`: the
     /// primary namespace of every nested subtree discovered by
-    /// [`Self::find_subtrees`], plus — for EVERY discovered subtree — the
+    /// [`Self::find_subtrees`], plus — when `sweep_secondary_namespaces` is
+    /// enabled, for EVERY discovered subtree — the
     /// per-axis indexed-tree secondary namespaces at
     /// `Blake3(subtree_prefix ‖ axis_tag)` (S2-B derivation).
     ///
@@ -212,11 +213,16 @@ impl GroveDb {
     /// deterministic path (prefixes are path-derived) would resurrect the
     /// stale secondary rows, breaking primary-secondary agreement.
     ///
-    /// All three axis tags are swept unconditionally for every discovered
+    /// When enabled, all three axis tags are swept for every discovered
     /// subtree rather than decoding each subtree's element to check its
     /// tree type: clearing an empty namespace is a no-op, so the
     /// redundancy is intentional defense-in-depth (it also removes a class
     /// of missed-decoding bugs).
+    ///
+    /// Full and partial batch deletion disable the secondary sweep on
+    /// V1..V3 to preserve historical costs, including empty-namespace seeks
+    /// and hashes for ordinary trees. Direct deletion keeps it enabled on
+    /// every version because its legacy loop already included the sweep.
     ///
     /// `context` names the calling operation in error messages.
     pub(crate) fn clear_subtree_storage_recursively<'db, B: AsRef<[u8]>>(
@@ -224,6 +230,7 @@ impl GroveDb {
         path: &SubtreePath<B>,
         transaction: &'db Transaction,
         batch: &'db StorageBatch,
+        sweep_secondary_namespaces: bool,
         context: &str,
         grove_version: &GroveVersion,
     ) -> CostResult<(), Error> {
@@ -248,6 +255,9 @@ impl GroveDb {
                 })
             );
 
+            if !sweep_secondary_namespaces {
+                continue;
+            }
             let primary_prefix = RocksDbStorage::build_prefix(p).unwrap_add_cost(&mut cost);
             for axis in [IndexAxis::Count, IndexAxis::Sum, IndexAxis::Avg] {
                 let secondary_prefix =

--- a/grovedb/src/operations/delete/delete_internal_on_transaction/v0.rs
+++ b/grovedb/src/operations/delete/delete_internal_on_transaction/v0.rs
@@ -221,79 +221,23 @@ impl GroveDb {
                         })
                     );
                 } else {
-                    let subtrees_paths = cost_return_on_error!(
+                    // Shared recursive cleanup (issue #888): clears every
+                    // nested subtree's primary namespace via the
+                    // find_subtrees walk and, for each discovered subtree,
+                    // the per-axis indexed-tree secondary namespaces at
+                    // Blake3(its_prefix ‖ axis_tag) that the path-prefix
+                    // walk cannot see. The helper replicates the exact
+                    // cost sequence of the inline loop it replaced.
+                    cost_return_on_error!(
                         &mut cost,
-                        self.find_subtrees(
+                        self.clear_subtree_storage_recursively(
                             &subtree_merk_path_ref,
-                            Some(transaction),
-                            grove_version
+                            transaction,
+                            batch,
+                            "delete",
+                            grove_version,
                         )
                     );
-                    for subtree_path in subtrees_paths {
-                        let p: SubtreePath<_> = subtree_path.as_slice().into();
-                        let mut storage = self
-                            .db
-                            .get_transactional_storage_context(p.clone(), Some(batch), transaction)
-                            .unwrap_add_cost(&mut cost);
-
-                        cost_return_on_error!(
-                            &mut cost,
-                            storage.clear().map_err(|e| {
-                                Error::CorruptedData(format!(
-                                    "unable to cleanup tree from storage: {e}",
-                                ))
-                            })
-                        );
-
-                        // NESTED INDEXED-TREE SECONDARY CLEANUP.
-                        // find_subtrees enumerates every nested subtree
-                        // under the deletion target, but only the
-                        // primary's storage namespace is reachable via
-                        // the path-prefix walk. Any nested indexed-tree
-                        // primary inside the deleted subtree has its own
-                        // per-axis secondary namespaces at
-                        // Blake3(its_prefix ‖ axis_tag) — one for PCIT
-                        // (count), one for PSIT (sum), up to three for
-                        // PCPSIT — that find_subtrees cannot see; clear
-                        // them all too.
-                        //
-                        // Clearing the secondary prefix is idempotent on
-                        // non-indexed subtrees (their secondary namespace
-                        // is empty), so we sweep all three axis tags
-                        // unconditionally rather than decoding each
-                        // subtree's root element to check the tree type —
-                        // cheaper and removes a class of missed-decoding
-                        // bugs.
-                        let primary_prefix =
-                            RocksDbStorage::build_prefix(p).unwrap_add_cost(&mut cost);
-                        for axis in [
-                            grovedb_element::indexed::IndexAxis::Count,
-                            grovedb_element::indexed::IndexAxis::Sum,
-                            grovedb_element::indexed::IndexAxis::Avg,
-                        ] {
-                            let secondary_prefix =
-                                RocksDbStorage::secondary_prefix_for(&primary_prefix, axis.tag())
-                                    .unwrap_add_cost(&mut cost);
-                            let mut secondary_storage = self
-                                .db
-                                .get_transactional_storage_context_by_subtree_prefix(
-                                    secondary_prefix,
-                                    Some(batch),
-                                    transaction,
-                                )
-                                .unwrap_add_cost(&mut cost);
-                            cost_return_on_error!(
-                                &mut cost,
-                                secondary_storage.clear().map_err(|e| {
-                                    Error::CorruptedData(format!(
-                                        "unable to cleanup nested indexed-tree secondary \
-                                         (axis {:?}) in delete: {e}",
-                                        axis
-                                    ))
-                                })
-                            );
-                        }
-                    }
                 }
                 // Legacy behavior (frozen — see the module docs): reopen the
                 // parent layer labeled with the DELETED CHILD's tree type

--- a/grovedb/src/operations/delete/delete_internal_on_transaction/v0.rs
+++ b/grovedb/src/operations/delete/delete_internal_on_transaction/v0.rs
@@ -234,6 +234,7 @@ impl GroveDb {
                             &subtree_merk_path_ref,
                             transaction,
                             batch,
+                            true,
                             "delete",
                             grove_version,
                         )

--- a/grovedb/src/operations/delete/delete_internal_on_transaction/v1.rs
+++ b/grovedb/src/operations/delete/delete_internal_on_transaction/v1.rs
@@ -215,79 +215,23 @@ impl GroveDb {
                         })
                     );
                 } else {
-                    let subtrees_paths = cost_return_on_error!(
+                    // Shared recursive cleanup (issue #888): clears every
+                    // nested subtree's primary namespace via the
+                    // find_subtrees walk and, for each discovered subtree,
+                    // the per-axis indexed-tree secondary namespaces at
+                    // Blake3(its_prefix ‖ axis_tag) that the path-prefix
+                    // walk cannot see. The helper replicates the exact
+                    // cost sequence of the inline loop it replaced.
+                    cost_return_on_error!(
                         &mut cost,
-                        self.find_subtrees(
+                        self.clear_subtree_storage_recursively(
                             &subtree_merk_path_ref,
-                            Some(transaction),
-                            grove_version
+                            transaction,
+                            batch,
+                            "delete",
+                            grove_version,
                         )
                     );
-                    for subtree_path in subtrees_paths {
-                        let p: SubtreePath<_> = subtree_path.as_slice().into();
-                        let mut storage = self
-                            .db
-                            .get_transactional_storage_context(p.clone(), Some(batch), transaction)
-                            .unwrap_add_cost(&mut cost);
-
-                        cost_return_on_error!(
-                            &mut cost,
-                            storage.clear().map_err(|e| {
-                                Error::CorruptedData(format!(
-                                    "unable to cleanup tree from storage: {e}",
-                                ))
-                            })
-                        );
-
-                        // NESTED INDEXED-TREE SECONDARY CLEANUP.
-                        // find_subtrees enumerates every nested subtree
-                        // under the deletion target, but only the
-                        // primary's storage namespace is reachable via
-                        // the path-prefix walk. Any nested indexed-tree
-                        // primary inside the deleted subtree has its own
-                        // per-axis secondary namespaces at
-                        // Blake3(its_prefix ‖ axis_tag) — one for PCIT
-                        // (count), one for PSIT (sum), up to three for
-                        // PCPSIT — that find_subtrees cannot see; clear
-                        // them all too.
-                        //
-                        // Clearing the secondary prefix is idempotent on
-                        // non-indexed subtrees (their secondary namespace
-                        // is empty), so we sweep all three axis tags
-                        // unconditionally rather than decoding each
-                        // subtree's root element to check the tree type —
-                        // cheaper and removes a class of missed-decoding
-                        // bugs.
-                        let primary_prefix =
-                            RocksDbStorage::build_prefix(p).unwrap_add_cost(&mut cost);
-                        for axis in [
-                            grovedb_element::indexed::IndexAxis::Count,
-                            grovedb_element::indexed::IndexAxis::Sum,
-                            grovedb_element::indexed::IndexAxis::Avg,
-                        ] {
-                            let secondary_prefix =
-                                RocksDbStorage::secondary_prefix_for(&primary_prefix, axis.tag())
-                                    .unwrap_add_cost(&mut cost);
-                            let mut secondary_storage = self
-                                .db
-                                .get_transactional_storage_context_by_subtree_prefix(
-                                    secondary_prefix,
-                                    Some(batch),
-                                    transaction,
-                                )
-                                .unwrap_add_cost(&mut cost);
-                            cost_return_on_error!(
-                                &mut cost,
-                                secondary_storage.clear().map_err(|e| {
-                                    Error::CorruptedData(format!(
-                                        "unable to cleanup nested indexed-tree secondary \
-                                         (axis {:?}) in delete: {e}",
-                                        axis
-                                    ))
-                                })
-                            );
-                        }
-                    }
                 }
                 // Fixed behavior (issue #686): reuse the already-open parent
                 // Merk, which carries the parent's true tree type, so delete

--- a/grovedb/src/operations/delete/delete_internal_on_transaction/v1.rs
+++ b/grovedb/src/operations/delete/delete_internal_on_transaction/v1.rs
@@ -228,6 +228,7 @@ impl GroveDb {
                             &subtree_merk_path_ref,
                             transaction,
                             batch,
+                            true,
                             "delete",
                             grove_version,
                         )

--- a/grovedb/src/operations/indexed_tree.rs
+++ b/grovedb/src/operations/indexed_tree.rs
@@ -513,6 +513,7 @@ impl GroveDb {
             &entry_path,
             transaction,
             batch,
+            true,
             "dedicated indexed-tree overwrite/delete",
             grove_version,
         )

--- a/grovedb/src/operations/indexed_tree.rs
+++ b/grovedb/src/operations/indexed_tree.rs
@@ -120,10 +120,10 @@ pub(crate) fn axis_secondary_tree_type(axis: IndexAxis) -> TreeType {
 /// single implicit axis for PCIT / PSIT, the 1..=3 entry TLV for PCPSIT.
 ///
 /// Errors if `element` is not an indexed-tree variant or a PCPSIT axis tag
-/// is invalid. The one intentional non-caller is
-/// `cleanup_dedicated_indexed_child_storage`, which must stay tolerant of
-/// an invalid tag (cleanup of a corrupt element should still clear the
-/// valid axes rather than fail).
+/// is invalid. The one intentional non-caller is the storage cleanup path
+/// (`GroveDb::clear_subtree_storage_recursively`), which sweeps all three
+/// axis namespaces unconditionally instead of decoding the TLV — cleanup
+/// of a corrupt element must still clear every axis rather than fail.
 pub(crate) fn indexed_element_axes(
     element: &Element,
 ) -> Result<Vec<(IndexAxis, Option<Vec<u8>>)>, Error> {
@@ -490,9 +490,13 @@ impl GroveDb {
     /// child orphans the child's storage namespace — the entry is gone
     /// from the primary Merk but its descendants still occupy storage
     /// and resurface to `verify_grovedb`'s raw_iter pass (and to a
-    /// future insert at the same key). For an indexed-tree child the
-    /// per-axis secondary namespaces at `Blake3(primary_prefix ‖
-    /// axis_tag)` must be cleared too.
+    /// future insert at the same key). The shared recursive cleanup
+    /// also sweeps the per-axis secondary namespaces at
+    /// `Blake3(prefix ‖ axis_tag)` for every discovered subtree —
+    /// covering an indexed-tree `existing` child itself and any nested
+    /// indexed primary deeper inside it (issue #888). The all-axis
+    /// sweep never decodes the (possibly corrupt) element's axes TLV,
+    /// so cleanup of a corrupt element still clears every axis.
     fn cleanup_dedicated_indexed_child_storage<'db, 'b, B: AsRef<[u8]>>(
         &'db self,
         existing: &Element,
@@ -501,68 +505,18 @@ impl GroveDb {
         batch: &'db StorageBatch,
         grove_version: &GroveVersion,
     ) -> CostResult<(), Error> {
-        let mut cost = OperationCost::default();
+        let cost = OperationCost::default();
         if !existing.is_any_tree() {
             return Ok(()).wrap_with_cost(cost);
         }
-        // Recursively clear all primary subtree storage under entry_path.
-        let subtrees_paths = cost_return_on_error!(
-            &mut cost,
-            self.find_subtrees(&entry_path, Some(transaction), grove_version)
-        );
-        for subtree_path in subtrees_paths {
-            let p: SubtreePath<_> = subtree_path.as_slice().into();
-            let mut storage = self
-                .db
-                .get_transactional_storage_context(p, Some(batch), transaction)
-                .unwrap_add_cost(&mut cost);
-            cost_return_on_error!(
-                &mut cost,
-                storage.clear().map_err(|e| {
-                    Error::CorruptedData(format!(
-                        "unable to clean up old subtree storage in dedicated indexed-tree \
-                         overwrite/delete: {e}",
-                    ))
-                })
-            );
-        }
-        // Clear the per-axis secondary namespaces for indexed primaries.
-        let axes: Vec<IndexAxis> = match existing.underlying() {
-            Element::ProvableCountIndexedTree(..) => vec![IndexAxis::Count],
-            Element::ProvableSumIndexedTree(..) => vec![IndexAxis::Sum],
-            Element::ProvableCountProvableSumIndexedTree(_, _, _, axes_tlv, _) => axes_tlv
-                .iter()
-                .filter_map(|(tag, _)| IndexAxis::try_from_tag(*tag).ok())
-                .collect(),
-            _ => Vec::new(),
-        };
-        if !axes.is_empty() {
-            let primary_prefix =
-                RocksDbStorage::build_prefix(entry_path.clone()).unwrap_add_cost(&mut cost);
-            for axis in axes {
-                let secondary_prefix =
-                    RocksDbStorage::secondary_prefix_for(&primary_prefix, axis.tag())
-                        .unwrap_add_cost(&mut cost);
-                let mut secondary_storage = self
-                    .db
-                    .get_transactional_storage_context_by_subtree_prefix(
-                        secondary_prefix,
-                        Some(batch),
-                        transaction,
-                    )
-                    .unwrap_add_cost(&mut cost);
-                cost_return_on_error!(
-                    &mut cost,
-                    secondary_storage.clear().map_err(|e| {
-                        Error::CorruptedData(format!(
-                            "unable to clean up indexed secondary (axis {axis:?}) during \
-                             dedicated indexed-tree overwrite/delete: {e}",
-                        ))
-                    })
-                );
-            }
-        }
-        Ok(()).wrap_with_cost(cost)
+        self.clear_subtree_storage_recursively(
+            &entry_path,
+            transaction,
+            batch,
+            "dedicated indexed-tree overwrite/delete",
+            grove_version,
+        )
+        .add_cost(cost)
     }
 
     /// Validate that `path` names an indexed primary of the expected variant,

--- a/grovedb/src/tests/mod.rs
+++ b/grovedb/src/tests/mod.rs
@@ -97,6 +97,7 @@ mod merge_versioning_tests;
 mod merged_descending_subset_bound_tests;
 mod misc_coverage_tests;
 mod mmr_tree_tests;
+mod nested_indexed_secondary_cleanup_tests;
 mod non_counted_tests;
 mod non_merk_wrapper_preservation_tests;
 mod not_counted_or_summed_tests;

--- a/grovedb/src/tests/nested_indexed_secondary_cleanup_tests.rs
+++ b/grovedb/src/tests/nested_indexed_secondary_cleanup_tests.rs
@@ -23,18 +23,131 @@
 
 #[cfg(test)]
 mod tests {
+    use grovedb_costs::{storage_cost::removal::StorageRemovedBytes, OperationCost};
     use grovedb_element::indexed::IndexAxis;
     use grovedb_merk::tree_type::TreeType;
     use grovedb_path::SubtreePath;
     use grovedb_storage::{rocksdb_storage::RocksDbStorage, RawIterator, Storage, StorageContext};
-    use grovedb_version::version::GroveVersion;
+    use grovedb_version::version::{GroveVersion, GROVE_VERSIONS};
 
     use crate::{
         batch::{BatchApplyOptions, QualifiedGroveDbOp, SubelementsDeletionBehavior},
         operations::delete::DeleteOptions,
-        tests::{make_test_grovedb, TempGroveDb, TEST_LEAF},
+        tests::{make_empty_grovedb, make_test_grovedb, TempGroveDb, TEST_LEAF},
         Element, IndexedAxisEntrySliceExt,
     };
+
+    #[derive(Clone, Copy, Debug)]
+    enum DeleteRoute {
+        FullBatch,
+        PartialBatch,
+        Direct,
+    }
+
+    /// Costs measured on the parent of #934. Even an empty secondary
+    /// sweep charges seeks, boundary reads, and prefix hashes, so plain
+    /// trees must retain their released costs on V1..V3. Direct deletion
+    /// already swept secondaries and must keep doing so on every version.
+    fn assert_plain_tree_delete_costs(route: DeleteRoute) {
+        for gv in GROVE_VERSIONS {
+            let db = make_empty_grovedb();
+            let root: &[&[u8]] = &[];
+            db.insert(root, b"parent", Element::empty_tree(), None, None, gv)
+                .unwrap()
+                .expect("insert parent");
+            let expected_root = db.root_hash(None, gv).unwrap().expect("empty parent root");
+            db.insert(
+                &[b"parent".as_slice()],
+                b"child",
+                Element::empty_tree(),
+                None,
+                None,
+                gv,
+            )
+            .unwrap()
+            .expect("insert child");
+            db.insert(
+                &[b"parent".as_slice(), b"child".as_slice()],
+                b"item",
+                Element::new_item(vec![1]),
+                None,
+                None,
+                gv,
+            )
+            .unwrap()
+            .expect("populate child");
+
+            let ops = vec![QualifiedGroveDbOp::delete_tree_op(
+                vec![b"parent".to_vec()],
+                b"child".to_vec(),
+                TreeType::NormalTree,
+                SubelementsDeletionBehavior::DeleteChildren,
+            )];
+            let result = match route {
+                DeleteRoute::FullBatch => db.apply_batch(ops, None, None, gv),
+                DeleteRoute::PartialBatch => {
+                    db.apply_partial_batch(ops, None, |_, _| Ok(vec![]), None, gv)
+                }
+                DeleteRoute::Direct => db.delete(
+                    &[b"parent".as_slice()],
+                    b"child",
+                    Some(DeleteOptions {
+                        allow_deleting_non_empty_trees: true,
+                        deleting_non_empty_trees_returns_error: false,
+                        ..Default::default()
+                    }),
+                    None,
+                    gv,
+                ),
+            };
+            result.value.expect("delete child");
+            let (seek_count, storage_loaded_bytes, hash_node_calls) = match route {
+                DeleteRoute::Direct if gv.protocol_version <= 3 => (21, 2415, 14),
+                DeleteRoute::Direct => (20, 2340, 13),
+                _ if gv.protocol_version <= 3 => (13, 1135, 8),
+                _ => (16, 1999, 12),
+            };
+            let expected_cost = OperationCost {
+                seek_count,
+                storage_cost: grovedb_costs::storage_cost::StorageCost {
+                    added_bytes: 0,
+                    replaced_bytes: 80,
+                    removed_bytes: StorageRemovedBytes::BasicStorageRemoval(226),
+                },
+                storage_loaded_bytes,
+                hash_node_calls,
+                ..Default::default()
+            };
+            assert_eq!(
+                result.cost, expected_cost,
+                "{route:?} cost changed on Grove version {}",
+                gv.protocol_version,
+            );
+            assert_eq!(
+                db.root_hash(None, gv)
+                    .unwrap()
+                    .expect("root after deletion"),
+                expected_root,
+                "{route:?} root changed on Grove version {}",
+                gv.protocol_version,
+            );
+        }
+    }
+
+    #[test]
+    fn batch_delete_preserves_versioned_costs() {
+        assert_plain_tree_delete_costs(DeleteRoute::FullBatch);
+    }
+
+    #[test]
+    fn partial_batch_delete_preserves_versioned_costs() {
+        assert_plain_tree_delete_costs(DeleteRoute::PartialBatch);
+    }
+
+    #[test]
+    fn direct_delete_preserves_versioned_costs() {
+        assert_plain_tree_delete_costs(DeleteRoute::Direct);
+    }
 
     /// Derive the secondary-namespace prefix for an indexed primary at
     /// `primary_path` and axis `axis`.

--- a/grovedb/src/tests/nested_indexed_secondary_cleanup_tests.rs
+++ b/grovedb/src/tests/nested_indexed_secondary_cleanup_tests.rs
@@ -1,0 +1,541 @@
+//! Issue #888: recursive cleanup must reclaim the per-axis secondary
+//! namespaces owned by NESTED indexed trees, not only the primary
+//! prefixes the `find_subtrees` walk can see.
+//!
+//! A nested indexed-tree primary keeps its per-axis secondaries at
+//! `Blake3(primary_prefix ‖ axis_tag)` — outside the path-derived prefix
+//! space. The direct delete already swept them per descendant; these tests
+//! pin the same sweep for every other recursive cleanup route:
+//!
+//! - full-batch `DeleteTree` cleanup,
+//! - partial-batch `DeleteTree` cleanup,
+//! - batch cidx safe-subset overwrite cleanup,
+//! - the dedicated indexed-tree child overwrite
+//!   (`cleanup_dedicated_indexed_child_storage`),
+//! - and the direct delete itself (regression guard for the shared-helper
+//!   refactor).
+//!
+//! Prefixes are path-derived, so a survivor row would resurface inside any
+//! tree recreated at the same deterministic path, breaking
+//! primary-secondary agreement. Each test asserts raw namespace emptiness
+//! after cleanup, and the reuse test additionally recreates the path and
+//! checks the fresh index only sees fresh rows.
+
+#[cfg(test)]
+mod tests {
+    use grovedb_element::indexed::IndexAxis;
+    use grovedb_merk::tree_type::TreeType;
+    use grovedb_path::SubtreePath;
+    use grovedb_storage::{rocksdb_storage::RocksDbStorage, RawIterator, Storage, StorageContext};
+    use grovedb_version::version::GroveVersion;
+
+    use crate::{
+        batch::{BatchApplyOptions, QualifiedGroveDbOp, SubelementsDeletionBehavior},
+        operations::delete::DeleteOptions,
+        tests::{make_test_grovedb, TempGroveDb, TEST_LEAF},
+        Element, IndexedAxisEntrySliceExt,
+    };
+
+    /// Derive the secondary-namespace prefix for an indexed primary at
+    /// `primary_path` and axis `axis`.
+    fn secondary_prefix_for_path(primary_path: &[&[u8]], axis: IndexAxis) -> [u8; 32] {
+        let subtree: SubtreePath<&[u8]> = primary_path.into();
+        let primary_prefix = RocksDbStorage::build_prefix(subtree).unwrap();
+        RocksDbStorage::secondary_prefix_for(&primary_prefix, axis.tag()).unwrap()
+    }
+
+    /// Whether the storage namespace at `prefix` holds any rows.
+    fn namespace_non_empty(db: &TempGroveDb, prefix: [u8; 32]) -> bool {
+        let tx = db.start_transaction();
+        let ctx = db
+            .db
+            .get_transactional_storage_context_by_subtree_prefix(prefix, None, &tx)
+            .unwrap();
+        let mut iter = ctx.raw_iter();
+        iter.seek_to_first().unwrap();
+        iter.valid().unwrap()
+    }
+
+    /// Assert that all three axis namespaces of the indexed primary at
+    /// `primary_path` are empty.
+    fn assert_all_axis_namespaces_empty(db: &TempGroveDb, primary_path: &[&[u8]], context: &str) {
+        for axis in [IndexAxis::Count, IndexAxis::Sum, IndexAxis::Avg] {
+            let prefix = secondary_prefix_for_path(primary_path, axis);
+            assert!(
+                !namespace_non_empty(db, prefix),
+                "{context}: nested indexed secondary namespace (axis {axis:?}) must be empty \
+                 after cleanup"
+            );
+        }
+    }
+
+    /// Build `TEST_LEAF/outer` (plain tree) containing a populated nested
+    /// PCIT at `TEST_LEAF/outer/nested_pcit`, and return the nested
+    /// primary's count-axis secondary prefix (which is non-empty).
+    fn make_outer_tree_with_nested_pcit(db: &TempGroveDb, gv: &GroveVersion) -> [u8; 32] {
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"outer",
+            Element::empty_tree(),
+            None,
+            None,
+            gv,
+        )
+        .unwrap()
+        .expect("insert outer tree");
+        db.insert(
+            [TEST_LEAF, b"outer"].as_ref(),
+            b"nested_pcit",
+            Element::empty_provable_count_indexed_tree(),
+            None,
+            None,
+            gv,
+        )
+        .unwrap()
+        .expect("insert nested PCIT");
+        for key in [b"a" as &[u8], b"b"] {
+            db.insert_into_count_indexed_tree(
+                [TEST_LEAF, b"outer", b"nested_pcit"].as_ref(),
+                key,
+                Element::new_item(b"v".to_vec()),
+                None,
+                gv,
+            )
+            .unwrap()
+            .expect("populate nested PCIT");
+        }
+        let count_prefix =
+            secondary_prefix_for_path(&[TEST_LEAF, b"outer", b"nested_pcit"], IndexAxis::Count);
+        assert!(
+            namespace_non_empty(db, count_prefix),
+            "baseline: populating the nested PCIT must create count-axis secondary rows"
+        );
+        count_prefix
+    }
+
+    fn assert_verify_clean(db: &TempGroveDb, gv: &GroveVersion) {
+        let issues = db
+            .verify_grovedb(None, false, true, gv)
+            .expect("verify grovedb");
+        assert!(issues.is_empty(), "verification issues: {issues:?}");
+    }
+
+    // -----------------------------------------------------------------
+    // Full-batch DeleteTree cleanup
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn batch_delete_tree_clears_nested_indexed_secondaries() {
+        let gv = GroveVersion::latest();
+        let db = make_test_grovedb(gv);
+        make_outer_tree_with_nested_pcit(&db, gv);
+
+        db.apply_batch(
+            vec![QualifiedGroveDbOp::delete_tree_op(
+                vec![TEST_LEAF.to_vec()],
+                b"outer".to_vec(),
+                TreeType::NormalTree,
+                SubelementsDeletionBehavior::DeleteChildren,
+            )],
+            None,
+            None,
+            gv,
+        )
+        .unwrap()
+        .expect("batch delete outer tree");
+
+        assert_all_axis_namespaces_empty(
+            &db,
+            &[TEST_LEAF, b"outer", b"nested_pcit"],
+            "full batch DeleteTree",
+        );
+        assert_verify_clean(&db, gv);
+    }
+
+    /// Same route, indexed primary two levels below the deletion target and
+    /// carrying every axis (PCPSIT with count+sum+avg).
+    #[test]
+    fn batch_delete_tree_clears_deeply_nested_pcpsit_secondaries() {
+        let gv = GroveVersion::latest();
+        let db = make_test_grovedb(gv);
+
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"outer",
+            Element::empty_tree(),
+            None,
+            None,
+            gv,
+        )
+        .unwrap()
+        .expect("insert outer tree");
+        db.insert(
+            [TEST_LEAF, b"outer"].as_ref(),
+            b"mid",
+            Element::empty_tree(),
+            None,
+            None,
+            gv,
+        )
+        .unwrap()
+        .expect("insert mid tree");
+        let axes: Vec<(u8, Option<Vec<u8>>)> = {
+            let mut tags: Vec<u8> = [IndexAxis::Count, IndexAxis::Sum, IndexAxis::Avg]
+                .iter()
+                .map(|a| a.tag())
+                .collect();
+            tags.sort_unstable();
+            tags.into_iter().map(|t| (t, None)).collect()
+        };
+        db.insert(
+            [TEST_LEAF, b"outer", b"mid"].as_ref(),
+            b"pcpsit",
+            Element::empty_provable_count_provable_sum_indexed_tree(axes).expect("canonical axes"),
+            None,
+            None,
+            gv,
+        )
+        .unwrap()
+        .expect("insert nested PCPSIT");
+        db.insert_into_provable_count_provable_sum_indexed_tree(
+            [TEST_LEAF, b"outer", b"mid", b"pcpsit"].as_ref(),
+            b"entry",
+            Element::new_item_with_sum_item(b"v".to_vec(), 8),
+            None,
+            gv,
+        )
+        .unwrap()
+        .expect("populate nested PCPSIT");
+
+        let pcpsit_path: [&[u8]; 4] = [TEST_LEAF, b"outer", b"mid", b"pcpsit"];
+        for axis in [IndexAxis::Count, IndexAxis::Sum, IndexAxis::Avg] {
+            assert!(
+                namespace_non_empty(&db, secondary_prefix_for_path(&pcpsit_path, axis)),
+                "baseline: PCPSIT axis {axis:?} secondary must be populated"
+            );
+        }
+
+        db.apply_batch(
+            vec![QualifiedGroveDbOp::delete_tree_op(
+                vec![TEST_LEAF.to_vec()],
+                b"outer".to_vec(),
+                TreeType::NormalTree,
+                SubelementsDeletionBehavior::DeleteChildren,
+            )],
+            None,
+            None,
+            gv,
+        )
+        .unwrap()
+        .expect("batch delete outer tree");
+
+        assert_all_axis_namespaces_empty(&db, &pcpsit_path, "full batch DeleteTree (deep PCPSIT)");
+        assert_verify_clean(&db, gv);
+    }
+
+    // -----------------------------------------------------------------
+    // Partial-batch DeleteTree cleanup
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn partial_batch_delete_tree_clears_nested_indexed_secondaries() {
+        let gv = GroveVersion::latest();
+        let db = make_test_grovedb(gv);
+        make_outer_tree_with_nested_pcit(&db, gv);
+
+        db.apply_partial_batch(
+            vec![QualifiedGroveDbOp::delete_tree_op(
+                vec![TEST_LEAF.to_vec()],
+                b"outer".to_vec(),
+                TreeType::NormalTree,
+                SubelementsDeletionBehavior::DeleteChildren,
+            )],
+            None,
+            |_cost, _left_over_ops| Ok(vec![]),
+            None,
+            gv,
+        )
+        .unwrap()
+        .expect("partial batch delete outer tree");
+
+        assert_all_axis_namespaces_empty(
+            &db,
+            &[TEST_LEAF, b"outer", b"nested_pcit"],
+            "partial batch DeleteTree",
+        );
+        assert_verify_clean(&db, gv);
+    }
+
+    // -----------------------------------------------------------------
+    // Batch cidx safe-subset overwrite cleanup
+    // -----------------------------------------------------------------
+
+    /// Overwriting a populated PCIT with an empty PCIT (the safe subset)
+    /// must also clear the secondaries of an indexed primary NESTED under
+    /// one of the replaced PCIT's tree-typed children.
+    #[test]
+    fn batch_cidx_overwrite_clears_nested_indexed_secondaries() {
+        let gv = GroveVersion::latest();
+        let db = make_test_grovedb(gv);
+
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"cidx",
+            Element::empty_provable_count_indexed_tree(),
+            None,
+            None,
+            gv,
+        )
+        .unwrap()
+        .expect("insert PCIT");
+        db.insert_into_count_indexed_tree(
+            [TEST_LEAF, b"cidx"].as_ref(),
+            b"row",
+            Element::empty_tree(),
+            None,
+            gv,
+        )
+        .unwrap()
+        .expect("insert plain-tree row into PCIT");
+        db.insert(
+            [TEST_LEAF, b"cidx", b"row"].as_ref(),
+            b"nested_pcit",
+            Element::empty_provable_count_indexed_tree(),
+            None,
+            None,
+            gv,
+        )
+        .unwrap()
+        .expect("insert nested PCIT under the row subtree");
+        db.insert_into_count_indexed_tree(
+            [TEST_LEAF, b"cidx", b"row", b"nested_pcit"].as_ref(),
+            b"e",
+            Element::new_item(b"v".to_vec()),
+            None,
+            gv,
+        )
+        .unwrap()
+        .expect("populate nested PCIT");
+
+        let nested_path: [&[u8]; 4] = [TEST_LEAF, b"cidx", b"row", b"nested_pcit"];
+        assert!(
+            namespace_non_empty(
+                &db,
+                secondary_prefix_for_path(&nested_path, IndexAxis::Count)
+            ),
+            "baseline: nested PCIT count secondary must be populated"
+        );
+
+        // Indexed -> empty indexed is the classifier's safe subset; the
+        // post-apply pass must reclaim the whole old namespace family.
+        db.apply_batch(
+            vec![QualifiedGroveDbOp::insert_or_replace_op(
+                vec![TEST_LEAF.to_vec()],
+                b"cidx".to_vec(),
+                Element::empty_provable_count_indexed_tree(),
+            )],
+            Some(BatchApplyOptions {
+                validate_insertion_does_not_override: false,
+                validate_insertion_does_not_override_tree: false,
+                ..Default::default()
+            }),
+            None,
+            gv,
+        )
+        .unwrap()
+        .expect("indexed -> empty indexed overwrite");
+
+        assert_all_axis_namespaces_empty(&db, &nested_path, "batch cidx overwrite (nested)");
+        // The replaced primary's own secondaries stay covered too.
+        assert_all_axis_namespaces_empty(
+            &db,
+            &[TEST_LEAF, b"cidx"],
+            "batch cidx overwrite (top level)",
+        );
+        assert_verify_clean(&db, gv);
+    }
+
+    // -----------------------------------------------------------------
+    // Dedicated indexed-child overwrite cleanup
+    // -----------------------------------------------------------------
+
+    /// `insert_into_count_indexed_tree` overwriting a tree-typed child must
+    /// clear the secondaries of an indexed primary nested inside the
+    /// replaced child's subtree.
+    #[test]
+    fn dedicated_indexed_overwrite_clears_nested_indexed_secondaries() {
+        let gv = GroveVersion::latest();
+        let db = make_test_grovedb(gv);
+
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"cidx",
+            Element::empty_provable_count_indexed_tree(),
+            None,
+            None,
+            gv,
+        )
+        .unwrap()
+        .expect("insert PCIT");
+        db.insert_into_count_indexed_tree(
+            [TEST_LEAF, b"cidx"].as_ref(),
+            b"row",
+            Element::empty_tree(),
+            None,
+            gv,
+        )
+        .unwrap()
+        .expect("insert plain-tree row into PCIT");
+        db.insert(
+            [TEST_LEAF, b"cidx", b"row"].as_ref(),
+            b"nested_pcit",
+            Element::empty_provable_count_indexed_tree(),
+            None,
+            None,
+            gv,
+        )
+        .unwrap()
+        .expect("insert nested PCIT under the row subtree");
+        db.insert_into_count_indexed_tree(
+            [TEST_LEAF, b"cidx", b"row", b"nested_pcit"].as_ref(),
+            b"e",
+            Element::new_item(b"v".to_vec()),
+            None,
+            gv,
+        )
+        .unwrap()
+        .expect("populate nested PCIT");
+
+        let nested_path: [&[u8]; 4] = [TEST_LEAF, b"cidx", b"row", b"nested_pcit"];
+        assert!(
+            namespace_non_empty(
+                &db,
+                secondary_prefix_for_path(&nested_path, IndexAxis::Count)
+            ),
+            "baseline: nested PCIT count secondary must be populated"
+        );
+
+        // Dedicated-path overwrite of the tree-typed child.
+        db.insert_into_count_indexed_tree(
+            [TEST_LEAF, b"cidx"].as_ref(),
+            b"row",
+            Element::empty_tree(),
+            None,
+            gv,
+        )
+        .unwrap()
+        .expect("dedicated overwrite of the row subtree");
+
+        assert_all_axis_namespaces_empty(&db, &nested_path, "dedicated indexed overwrite");
+        assert_verify_clean(&db, gv);
+    }
+
+    // -----------------------------------------------------------------
+    // Direct delete (regression guard for the shared-helper refactor)
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn direct_delete_still_clears_nested_indexed_secondaries() {
+        let gv = GroveVersion::latest();
+        let db = make_test_grovedb(gv);
+        make_outer_tree_with_nested_pcit(&db, gv);
+
+        db.delete(
+            [TEST_LEAF].as_ref(),
+            b"outer",
+            Some(DeleteOptions {
+                allow_deleting_non_empty_trees: true,
+                deleting_non_empty_trees_returns_error: false,
+                ..Default::default()
+            }),
+            None,
+            gv,
+        )
+        .unwrap()
+        .expect("direct delete outer tree");
+
+        assert_all_axis_namespaces_empty(
+            &db,
+            &[TEST_LEAF, b"outer", b"nested_pcit"],
+            "direct delete",
+        );
+        assert_verify_clean(&db, gv);
+    }
+
+    // -----------------------------------------------------------------
+    // Path reuse after cleanup
+    // -----------------------------------------------------------------
+
+    /// After the batch cleanup, recreating the SAME deterministic path must
+    /// produce an index that reflects only the fresh rows — the failure
+    /// mode of #888 was stale secondary rows resurfacing here.
+    #[test]
+    fn path_reuse_after_batch_delete_sees_only_fresh_rows() {
+        let gv = GroveVersion::latest();
+        let db = make_test_grovedb(gv);
+        make_outer_tree_with_nested_pcit(&db, gv);
+
+        db.apply_batch(
+            vec![QualifiedGroveDbOp::delete_tree_op(
+                vec![TEST_LEAF.to_vec()],
+                b"outer".to_vec(),
+                TreeType::NormalTree,
+                SubelementsDeletionBehavior::DeleteChildren,
+            )],
+            None,
+            None,
+            gv,
+        )
+        .unwrap()
+        .expect("batch delete outer tree");
+
+        // Recreate the exact same path and repopulate with ONE fresh row.
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"outer",
+            Element::empty_tree(),
+            None,
+            None,
+            gv,
+        )
+        .unwrap()
+        .expect("recreate outer tree");
+        db.insert(
+            [TEST_LEAF, b"outer"].as_ref(),
+            b"nested_pcit",
+            Element::empty_provable_count_indexed_tree(),
+            None,
+            None,
+            gv,
+        )
+        .unwrap()
+        .expect("recreate nested PCIT");
+        db.insert_into_count_indexed_tree(
+            [TEST_LEAF, b"outer", b"nested_pcit"].as_ref(),
+            b"fresh",
+            Element::new_item(b"v".to_vec()),
+            None,
+            gv,
+        )
+        .unwrap()
+        .expect("populate recreated PCIT");
+
+        let rows = db
+            .indexed_count_top_k(
+                [TEST_LEAF, b"outer", b"nested_pcit"].as_ref(),
+                10,
+                true,
+                None,
+                gv,
+            )
+            .unwrap()
+            .expect("top_k on recreated PCIT");
+        assert_eq!(
+            rows.key_pairs(),
+            vec![(1u64, b"fresh".to_vec())],
+            "the recreated index must only contain the fresh row — stale rows from the \
+             deleted tree must not resurface"
+        );
+        assert_verify_clean(&db, gv);
+    }
+}


### PR DESCRIPTION
Fixes #888 ([audit][M005]).

## Problem

Recursive storage cleanup discovers nested subtrees via `find_subtrees` and clears their **primary** namespaces — but a nested indexed-tree primary (PCIT / PSIT / PCPSIT) also owns per-axis **secondary** namespaces at `Blake3(prefix ‖ axis_tag)`, which live outside the path-derived prefix space and are invisible to the walk. Four recursive cleanup routes cleared only what the walk could see and orphaned any nested primary's secondaries:

- full-batch `DeleteTree` cleanup (`apply_batch_with_element_flags_update`),
- partial-batch `DeleteTree` cleanup (`apply_partial_batch_with_element_flags_update`),
- the batch cidx safe-subset overwrite cleanup,
- the dedicated indexed-tree child overwrite (`cleanup_dedicated_indexed_child_storage`).

The direct delete (`delete_internal_on_transaction` v0/v1) already swept secondaries per descendant — issue #888's "expected control".

Because prefixes are path-derived, recreating the same deterministic path after such a cleanup resurrects the stale secondary rows inside the new tree: reads then name primary entries that no longer exist (`CorruptedData: primary entry named by a secondary row is missing`) and primary-secondary agreement is broken. Reproduced for all four routes (see tests — each failed before the fix).

## Fix

One recursive ownership-cleanup routine, per the issue's fix direction: `GroveDb::clear_subtree_storage_recursively` (in `operations/auxiliary.rs`, next to `find_subtrees`) clears, for **every** subtree discovered by the walk, its primary namespace **and** all three axis secondary namespaces. All recursive cleanup call sites now use it:

- the four gap routes above (fixed), and
- direct delete v0/v1 (behavior-preserving refactor: the helper replicates the inline loop's exact operation/cost sequence; v0 and v1 carried byte-identical copies of it).

The batch overwrite pass's separate top-level secondary sweep is folded in (the walk includes the root path itself); the `DontCheckWithNoCleanup` per-primary sweep is unchanged since no recursive clear runs there.

**Sweeping all three axes whenever secondary cleanup is enabled** (rather than decoding each subtree's element) matches the existing sweeps' rationale: clear on an empty namespace is a no-op, and it removes a class of missed-decoding bugs — cleanup of a corrupt element still clears every axis.

**Versioning:** Full and partial batch `DeleteTree` use the new `apply_batch.delete_tree_recursive_secondary_cleanup` feature slot: `0` on GROVE_V1–V3 preserves primary-only recursion and the existing top-level secondary pass; `1` on GROVE_V4 enables per-descendant secondary sweeps. Even empty sweeps charge seeks, boundary reads, and prefix hashes, so ordinary-tree deletion must retain its historical costs. Direct deletion keeps its existing recursive secondary sweep on every version. Indexed overwrite cleanup remains enabled.

## Tests

`grovedb/src/tests/nested_indexed_secondary_cleanup_tests.rs` — 10 tests covering namespace reclamation and versioned operation costs:

- full-batch `DeleteTree` with a nested populated PCIT (failed before fix),
- full-batch `DeleteTree` with a PCPSIT (count+sum+avg) two levels down (failed),
- partial-batch `DeleteTree` (failed),
- batch cidx overwrite (indexed → empty indexed) with a nested PCIT under a row subtree, asserting both nested and top-level namespaces (failed),
- dedicated `insert_into_count_indexed_tree` overwrite of a tree-typed child holding a nested PCIT (failed),
- direct delete regression guard for the helper refactor (passed before and after),
- path-reuse: recreate the same path after batch delete and assert the fresh index sees only fresh rows (failed before with `CorruptedData` on read),
- three cost-and-root regression tests for full batch, partial batch, and direct deletion across GROVE_V1–V4. The batch tests fail without the gate; direct deletion retains its existing costs.

`cargo test -p grovedb -p grovedb-version`: 3,421 GroveDB tests passed (8 ignored), 56 version tests passed, and 3 documentation tests passed. `cargo clippy -p grovedb -p grovedb-version --all-targets -- -D warnings` and `cargo fmt --all --check`: clean. The existing V3/V4 plain-batch cost test now separately checks classification-cost parity with the cleanup gate disabled and the extra cleanup cost enabled in V4.

Out of scope, per the issue: flat-drop (#849) has its own explicit reclamation contract; the v2 backward-references flow already fail-closes on specialized/indexed descendants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed cleanup of nested indexed trees during deletions and overwrites.
  - Removed stale secondary index data across all index dimensions, including namespaces outside the original path scope.
  - Prevented outdated index entries from reappearing when paths are reused.

- **Tests**
  - Added regression coverage for batch, partial-batch, overwrite, dedicated child-tree, and direct-delete cleanup scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->