### PR TITLE
fix(commitment-tree): make client append atomic and align checkpoint ordering across backends (#882)

### DIFF
--- a/grovedb-commitment-tree/src/client/client_memory_commitment_tree.rs
+++ b/grovedb-commitment-tree/src/client/client_memory_commitment_tree.rs
@@ -3,7 +3,10 @@ use orchard::{
     tree::{MerkleHashOrchard, MerklePath},
     Anchor, NOTE_COMMITMENT_TREE_DEPTH,
 };
-use shardtree::{store::memory::MemoryShardStore, ShardTree};
+use shardtree::{
+    store::{memory::MemoryShardStore, ShardStore},
+    ShardTree,
+};
 
 use super::SHARD_HEIGHT;
 use crate::commitment_frontier::{merkle_hash_from_bytes, CommitmentTreeError};
@@ -44,12 +47,37 @@ impl ClientMemoryCommitmentTree {
     /// `cmx` is the 32-byte extracted note commitment. `retention` controls
     /// whether the leaf is marked for witness generation, checkpointed, or
     /// ephemeral.
+    ///
+    /// Checkpoint ids must be strictly increasing: appending with
+    /// `Retention::Checkpoint { id, .. }` where `id` is not greater than the
+    /// current maximum checkpoint id fails with
+    /// [`CommitmentTreeError::CheckpointOutOfOrder`] before anything is
+    /// modified. This matches
+    /// [`ClientPersistentCommitmentTree`](crate::ClientPersistentCommitmentTree)
+    /// (and `ShardTree::append`); the in-memory store would otherwise
+    /// silently replace the existing checkpoint.
     pub fn append(
         &mut self,
         cmx: [u8; 32],
         retention: Retention<u32>,
     ) -> Result<(), CommitmentTreeError> {
         let leaf = merkle_hash_from_bytes(&cmx).ok_or(CommitmentTreeError::InvalidFieldElement)?;
+        // `ShardTree::batch_insert` (unlike `ShardTree::append`) does not
+        // check checkpoint-id ordering, and `MemoryShardStore` silently
+        // replaces a checkpoint with a duplicate id. Refuse before mutating,
+        // keeping memory and SQLite backends on the same contract.
+        if let Retention::Checkpoint { id, .. } = &retention {
+            let max =
+                self.inner.store().max_checkpoint_id().map_err(|e| {
+                    CommitmentTreeError::InvalidData(format!("max_checkpoint_id: {e}"))
+                })?;
+            if max.as_ref() >= Some(id) {
+                return Err(CommitmentTreeError::CheckpointOutOfOrder {
+                    provided: *id,
+                    max: max.expect("comparison above requires max to be Some"),
+                });
+            }
+        }
         self.inner
             .batch_insert(self.next_position()?, std::iter::once((leaf, retention)))
             .map_err(|e| CommitmentTreeError::InvalidData(format!("append failed: {e}")))?;

--- a/grovedb-commitment-tree/src/client/client_persistent_commitment_tree.rs
+++ b/grovedb-commitment-tree/src/client/client_persistent_commitment_tree.rs
@@ -229,31 +229,43 @@ impl ClientPersistentCommitmentTree {
         &mut self,
         f: impl FnOnce(&mut Self) -> Result<T, CommitmentTreeError>,
     ) -> Result<T, CommitmentTreeError> {
-        self.inner
+        let owns_transaction = self
+            .inner
             .store()
-            .with_conn(|conn| conn.execute_batch("SAVEPOINT commitment_tree_client_op"))
+            .with_conn(|conn| {
+                let owns_transaction = conn.is_autocommit();
+                conn.execute_batch("SAVEPOINT commitment_tree_client_op")
+                    .map(|()| owns_transaction)
+            })
             .map_err(|e| CommitmentTreeError::InvalidData(format!("savepoint failed: {e}")))?;
-        match f(self) {
-            Ok(value) => {
-                self.inner
-                    .store()
-                    .with_conn(|conn| {
-                        conn.execute_batch("RELEASE SAVEPOINT commitment_tree_client_op")
-                    })
-                    .map_err(|e| {
-                        CommitmentTreeError::InvalidData(format!("savepoint release failed: {e}"))
-                    })?;
-                Ok(value)
-            }
+        // Releasing the outermost savepoint commits the transaction and can
+        // itself fail (for example, SQLITE_BUSY). Treat that like an error
+        // from the operation, so no pending writes escape cleanup.
+        let result = f(self).and_then(|value| {
+            self.inner
+                .store()
+                .with_conn(|conn| conn.execute_batch("RELEASE SAVEPOINT commitment_tree_client_op"))
+                .map_err(|e| {
+                    CommitmentTreeError::InvalidData(format!("savepoint release failed: {e}"))
+                })?;
+            Ok(value)
+        });
+        match result {
+            Ok(value) => Ok(value),
             Err(e) => {
-                // ROLLBACK TO undoes the writes but keeps the savepoint on
-                // the stack; RELEASE pops it, restoring the caller's
-                // transaction state.
+                // If we own the transaction, end it with ROLLBACK: RELEASE
+                // can remain blocked by a reader even after ROLLBACK TO.
+                // Otherwise undo only our savepoint, preserving the wallet's
+                // transaction and any writes it made before this operation.
                 if let Err(rollback_err) = self.inner.store().with_conn(|conn| {
-                    conn.execute_batch(
-                        "ROLLBACK TO SAVEPOINT commitment_tree_client_op; RELEASE SAVEPOINT \
-                         commitment_tree_client_op",
-                    )
+                    if owns_transaction {
+                        conn.execute_batch("ROLLBACK")
+                    } else {
+                        conn.execute_batch(
+                            "ROLLBACK TO SAVEPOINT commitment_tree_client_op; RELEASE SAVEPOINT \
+                             commitment_tree_client_op",
+                        )
+                    }
                 }) {
                     return Err(CommitmentTreeError::InvalidData(format!(
                         "rollback failed after error ({e}): {rollback_err}"

--- a/grovedb-commitment-tree/src/client/client_persistent_commitment_tree.rs
+++ b/grovedb-commitment-tree/src/client/client_persistent_commitment_tree.rs
@@ -32,7 +32,7 @@ use orchard::{
     NOTE_COMMITMENT_TREE_DEPTH,
 };
 use rusqlite::Connection;
-use shardtree::ShardTree;
+use shardtree::{store::ShardStore, ShardTree};
 
 use super::{
     sqlite_store::{SqliteShardStore, SqliteShardStoreError},
@@ -68,6 +68,16 @@ impl ClientPersistentCommitmentTree {
     /// (e.g., a wallet database). The commitment tree tables are created if
     /// missing, and the mutex is locked only for the duration of each SQL
     /// operation.
+    ///
+    /// Mutating tree operations ([`append`](Self::append),
+    /// [`checkpoint`](Self::checkpoint)) wrap their statements in a SQLite
+    /// savepoint. Savepoints nest, so calling them while the wallet holds an
+    /// open transaction on this connection is supported — the wallet then
+    /// owns the final commit or rollback. Because the mutex is released
+    /// between individual statements, other threads must not write through
+    /// the same connection while a mutating tree operation is in flight: if
+    /// the operation fails, its rollback would revert those interleaved
+    /// writes as well.
     pub fn open_on_shared_connection(
         conn: Arc<Mutex<Connection>>,
         max_checkpoints: usize,
@@ -95,26 +105,71 @@ impl ClientPersistentCommitmentTree {
     /// `cmx` is the 32-byte extracted note commitment. `retention` controls
     /// whether the leaf is marked for witness generation, checkpointed, or
     /// ephemeral.
+    ///
+    /// Checkpoint ids must be strictly increasing: appending with
+    /// `Retention::Checkpoint { id, .. }` where `id` is not greater than the
+    /// current maximum checkpoint id fails with
+    /// [`CommitmentTreeError::CheckpointOutOfOrder`] before anything is
+    /// written.
+    ///
+    /// # Atomicity
+    ///
+    /// The whole operation (shard write, checkpoint row, checkpoint pruning)
+    /// runs inside a SQLite savepoint. On `Err` the savepoint has been rolled
+    /// back and the persisted tree state is unchanged, so the append can be
+    /// safely retried.
     pub fn append(
         &mut self,
         cmx: [u8; 32],
         retention: Retention<u32>,
     ) -> Result<(), CommitmentTreeError> {
         let leaf = merkle_hash_from_bytes(&cmx).ok_or(CommitmentTreeError::InvalidFieldElement)?;
-        self.inner
-            .batch_insert(self.next_position()?, std::iter::once((leaf, retention)))
-            .map_err(|e| CommitmentTreeError::InvalidData(format!("append failed: {e}")))?;
-        Ok(())
+        // `ShardTree::batch_insert` (unlike `ShardTree::append`) does not
+        // check checkpoint-id ordering before writing, and the SQLite store
+        // would only reject the duplicate id after the shard row is already
+        // persisted. Refuse here, before any mutation, with the same
+        // strictly-increasing contract as `ShardTree::append`.
+        if let Retention::Checkpoint { id, .. } = &retention {
+            let max =
+                self.inner.store().max_checkpoint_id().map_err(|e| {
+                    CommitmentTreeError::InvalidData(format!("max_checkpoint_id: {e}"))
+                })?;
+            if max.as_ref() >= Some(id) {
+                return Err(CommitmentTreeError::CheckpointOutOfOrder {
+                    provided: *id,
+                    max: max.expect("comparison above requires max to be Some"),
+                });
+            }
+        }
+        let start = self.next_position()?;
+        self.atomically(|tree| {
+            tree.inner
+                .batch_insert(start, std::iter::once((leaf, retention)))
+                .map_err(|e| CommitmentTreeError::InvalidData(format!("append failed: {e}")))?;
+            Ok(())
+        })
     }
 
     /// Create a checkpoint at the current tree state.
     ///
     /// Checkpoints allow `witness_at_checkpoint_depth` to produce witnesses
     /// relative to historical anchors.
+    ///
+    /// Returns `Ok(false)` without modifying anything if `checkpoint_id` is
+    /// not greater than the current maximum checkpoint id.
+    ///
+    /// # Atomicity
+    ///
+    /// The whole operation (shard retention update, checkpoint row,
+    /// checkpoint pruning) runs inside a SQLite savepoint. On `Err` the
+    /// savepoint has been rolled back and the persisted tree state is
+    /// unchanged.
     pub fn checkpoint(&mut self, checkpoint_id: u32) -> Result<bool, CommitmentTreeError> {
-        self.inner
-            .checkpoint(checkpoint_id)
-            .map_err(|e| CommitmentTreeError::InvalidData(format!("checkpoint failed: {e}")))
+        self.atomically(|tree| {
+            tree.inner
+                .checkpoint(checkpoint_id)
+                .map_err(|e| CommitmentTreeError::InvalidData(format!("checkpoint failed: {e}")))
+        })
     }
 
     /// Get the position of the most recently appended leaf.
@@ -153,6 +208,59 @@ impl ClientPersistentCommitmentTree {
         {
             Some(root) => Ok(Anchor::from(root)),
             None => Ok(Anchor::empty_tree()),
+        }
+    }
+
+    /// Run a mutating multi-statement tree operation inside a SQLite
+    /// savepoint so it commits or rolls back as a unit.
+    ///
+    /// `ShardTree` operations issue several store calls (shard writes,
+    /// checkpoint inserts, pruning); without this, a storage error partway
+    /// through would leave the earlier writes committed while the operation
+    /// reports failure. Savepoints nest, so this also composes with a
+    /// caller-owned wallet transaction on a shared connection — the wallet
+    /// then owns the final commit.
+    ///
+    /// On a shared connection the mutex is only held per SQL statement, so
+    /// other threads must not write through the same connection while a
+    /// mutating tree operation is in flight: a rollback here would revert
+    /// their interleaved writes as well.
+    fn atomically<T>(
+        &mut self,
+        f: impl FnOnce(&mut Self) -> Result<T, CommitmentTreeError>,
+    ) -> Result<T, CommitmentTreeError> {
+        self.inner
+            .store()
+            .with_conn(|conn| conn.execute_batch("SAVEPOINT commitment_tree_client_op"))
+            .map_err(|e| CommitmentTreeError::InvalidData(format!("savepoint failed: {e}")))?;
+        match f(self) {
+            Ok(value) => {
+                self.inner
+                    .store()
+                    .with_conn(|conn| {
+                        conn.execute_batch("RELEASE SAVEPOINT commitment_tree_client_op")
+                    })
+                    .map_err(|e| {
+                        CommitmentTreeError::InvalidData(format!("savepoint release failed: {e}"))
+                    })?;
+                Ok(value)
+            }
+            Err(e) => {
+                // ROLLBACK TO undoes the writes but keeps the savepoint on
+                // the stack; RELEASE pops it, restoring the caller's
+                // transaction state.
+                if let Err(rollback_err) = self.inner.store().with_conn(|conn| {
+                    conn.execute_batch(
+                        "ROLLBACK TO SAVEPOINT commitment_tree_client_op; RELEASE SAVEPOINT \
+                         commitment_tree_client_op",
+                    )
+                }) {
+                    return Err(CommitmentTreeError::InvalidData(format!(
+                        "rollback failed after error ({e}): {rollback_err}"
+                    )));
+                }
+                Err(e)
+            }
         }
     }
 

--- a/grovedb-commitment-tree/src/client/sqlite_client_tests.rs
+++ b/grovedb-commitment-tree/src/client/sqlite_client_tests.rs
@@ -514,4 +514,197 @@ mod tests {
             .expect("direct query");
         assert!(count > 0, "shards should have been written");
     }
+
+    /// Commit failures must undo the leaf, checkpoints, and pruning while
+    /// releasing the transaction even before the blocking reader finishes.
+    #[test]
+    fn test_append_commit_failure_rolls_back_and_allows_retry() {
+        for retention in [Retention::Marked, checkpoint_retention(2)] {
+            let dir = tempfile::tempdir().unwrap();
+            let db_path = dir.path().join("commit_busy.db");
+            let conn = Connection::open(&db_path).unwrap();
+            conn.execute_batch("PRAGMA journal_mode=DELETE").unwrap();
+            conn.busy_timeout(std::time::Duration::ZERO).unwrap();
+            let arc = Arc::new(Mutex::new(conn));
+            // Retaining one checkpoint makes the checkpointed append prune
+            // the old checkpoint, which must also be restored on failure.
+            let mut tree =
+                ClientPersistentCommitmentTree::open_on_shared_connection(arc.clone(), 1).unwrap();
+            tree.append(test_leaf(0), checkpoint_retention(1)).unwrap();
+            let before_anchor = tree.anchor().unwrap();
+
+            let reader = Connection::open(&db_path).unwrap();
+            reader.execute_batch("BEGIN").unwrap();
+            let _: i64 = reader
+                .query_row("SELECT COUNT(*) FROM commitment_tree_shards", [], |r| {
+                    r.get(0)
+                })
+                .unwrap();
+            let err = tree
+                .append(test_leaf(1), retention.clone())
+                .expect_err("reader must block commit");
+            assert!(
+                err.to_string().contains("savepoint release failed"),
+                "{err}"
+            );
+            assert!(
+                arc.lock().unwrap().is_autocommit(),
+                "failed append left a transaction open"
+            );
+            assert_eq!(tree.max_leaf_position().unwrap(), Some(Position::from(0)));
+            assert_eq!(tree.anchor().unwrap(), before_anchor);
+            let checkpoints: (u32, u32, u32) = arc.lock().unwrap().query_row(
+                "SELECT MIN(checkpoint_id), MAX(checkpoint_id), COUNT(*) FROM commitment_tree_checkpoints",
+                [], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            ).unwrap();
+            assert_eq!(
+                checkpoints,
+                (1, 1, 1),
+                "failed commit changed historical checkpoints"
+            );
+
+            reader.execute_batch("ROLLBACK").unwrap();
+            tree.append(test_leaf(1), retention)
+                .expect("retry after reader releases lock");
+            assert_eq!(tree.max_leaf_position().unwrap(), Some(Position::from(1)));
+            assert!(arc.lock().unwrap().is_autocommit());
+            let after_anchor = tree.anchor().unwrap();
+            drop(tree);
+            drop(arc);
+            let reopened = ClientPersistentCommitmentTree::open_path(&db_path, 1).unwrap();
+            assert_eq!(
+                reopened.max_leaf_position().unwrap(),
+                Some(Position::from(1))
+            );
+            assert_eq!(
+                reopened.anchor().unwrap(),
+                after_anchor,
+                "successful retry was not durable"
+            );
+        }
+    }
+
+    /// A failed checkpoint commit must restore the checkpoint it pruned.
+    #[test]
+    fn test_checkpoint_commit_failure_rolls_back_and_allows_retry() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("checkpoint_busy.db");
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute_batch("PRAGMA journal_mode=DELETE").unwrap();
+        conn.busy_timeout(std::time::Duration::ZERO).unwrap();
+        let arc = Arc::new(Mutex::new(conn));
+        let mut tree =
+            ClientPersistentCommitmentTree::open_on_shared_connection(arc.clone(), 1).unwrap();
+        tree.append(test_leaf(0), checkpoint_retention(1)).unwrap();
+        let before_anchor = tree.anchor().unwrap();
+        let reader = Connection::open(&db_path).unwrap();
+        reader.execute_batch("BEGIN").unwrap();
+        let _: i64 = reader
+            .query_row(
+                "SELECT COUNT(*) FROM commitment_tree_checkpoints",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let err = tree
+            .checkpoint(2)
+            .expect_err("reader must block checkpoint commit");
+        assert!(
+            err.to_string().contains("savepoint release failed"),
+            "{err}"
+        );
+        assert!(arc.lock().unwrap().is_autocommit());
+        assert_eq!(tree.anchor().unwrap(), before_anchor);
+        let ids: (u32, u32) = arc
+            .lock()
+            .unwrap()
+            .query_row(
+                "SELECT MIN(checkpoint_id), MAX(checkpoint_id) FROM commitment_tree_checkpoints",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(ids, (1, 1));
+        reader.execute_batch("ROLLBACK").unwrap();
+        assert!(
+            tree.checkpoint(2).unwrap(),
+            "failed checkpoint must not consume its id"
+        );
+        assert!(arc.lock().unwrap().is_autocommit());
+        drop(tree);
+        drop(arc);
+        let reopened_conn = Connection::open(&db_path).unwrap();
+        let ids: (u32, u32) = reopened_conn
+            .query_row(
+                "SELECT MIN(checkpoint_id), MAX(checkpoint_id) FROM commitment_tree_checkpoints",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(
+            ids,
+            (2, 2),
+            "retry must commit the new checkpoint and prune the old one"
+        );
+    }
+
+    /// Operation cleanup must preserve writes owned by an outer wallet
+    /// transaction and permit a retry within that same transaction.
+    #[test]
+    fn test_append_failure_preserves_wallet_transaction() {
+        let conn = Connection::open_in_memory().unwrap();
+        let arc = Arc::new(Mutex::new(conn));
+        let mut tree =
+            ClientPersistentCommitmentTree::open_on_shared_connection(arc.clone(), 1).unwrap();
+        tree.append(test_leaf(0), checkpoint_retention(1)).unwrap();
+        let before_anchor = tree.anchor().unwrap();
+        arc.lock()
+            .unwrap()
+            .execute_batch(
+                "CREATE TABLE wallet_data (value INTEGER);
+             CREATE TRIGGER fail_checkpoint BEFORE INSERT ON commitment_tree_checkpoints
+             BEGIN SELECT RAISE(ABORT, 'injected checkpoint failure'); END;
+             BEGIN;
+             INSERT INTO wallet_data VALUES (42);",
+            )
+            .unwrap();
+        let err = tree
+            .append(test_leaf(1), checkpoint_retention(2))
+            .expect_err("injected failure");
+        assert!(
+            err.to_string().contains("injected checkpoint failure"),
+            "{err}"
+        );
+        assert_eq!(tree.max_leaf_position().unwrap(), Some(Position::from(0)));
+        assert_eq!(tree.anchor().unwrap(), before_anchor);
+        {
+            let guard = arc.lock().unwrap();
+            assert!(
+                !guard.is_autocommit(),
+                "tree cleanup must not end the wallet transaction"
+            );
+            let value: i64 = guard
+                .query_row("SELECT value FROM wallet_data", [], |r| r.get(0))
+                .unwrap();
+            assert_eq!(
+                value, 42,
+                "tree cleanup must not roll back the wallet's writes"
+            );
+            guard.execute_batch("DROP TRIGGER fail_checkpoint").unwrap();
+        }
+        tree.append(test_leaf(1), checkpoint_retention(2))
+            .expect("retry in wallet transaction");
+        assert!(!arc.lock().unwrap().is_autocommit());
+        arc.lock()
+            .unwrap()
+            .execute_batch("COMMIT")
+            .expect("wallet still owns final commit");
+        assert_eq!(tree.max_leaf_position().unwrap(), Some(Position::from(1)));
+        let value: i64 = arc
+            .lock()
+            .unwrap()
+            .query_row("SELECT value FROM wallet_data", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(value, 42);
+    }
 }

--- a/grovedb-commitment-tree/src/client/sqlite_client_tests.rs
+++ b/grovedb-commitment-tree/src/client/sqlite_client_tests.rs
@@ -2,13 +2,21 @@
 mod tests {
     use std::sync::{Arc, Mutex};
 
-    use incrementalmerkletree::{Position, Retention};
+    use incrementalmerkletree::{Marking, Position, Retention};
     use orchard::tree::Anchor;
     use rusqlite::Connection;
 
     use crate::{
         test_utils::test_leaf, ClientMemoryCommitmentTree, ClientPersistentCommitmentTree,
+        CommitmentTreeError,
     };
+
+    fn checkpoint_retention(id: u32) -> Retention<u32> {
+        Retention::Checkpoint {
+            id,
+            marking: Marking::None,
+        }
+    }
 
     fn memory_tree() -> ClientPersistentCommitmentTree {
         let conn = Connection::open_in_memory().expect("open in-memory sqlite");
@@ -243,6 +251,242 @@ mod tests {
             sqlite_witness.auth_path(),
             memory_witness.auth_path(),
             "witness auth paths should match after pruning"
+        );
+    }
+
+    #[test]
+    fn test_append_duplicate_checkpoint_id_refused_before_mutation() {
+        // Regression test for issue #882: appending with a duplicate
+        // checkpoint id used to persist the leaf (shard write committed)
+        // and then fail on the checkpoint insert, returning an error while
+        // the database had already changed. The ordering must now be
+        // validated before any write.
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let db_path = dir.path().join("test_dup_checkpoint.db");
+
+        let anchor_before;
+        {
+            let mut tree =
+                ClientPersistentCommitmentTree::open_path(&db_path, 100).expect("open tree");
+            tree.append(test_leaf(0), checkpoint_retention(1))
+                .expect("first checkpointed append");
+            anchor_before = tree.anchor().expect("anchor");
+
+            let err = tree
+                .append(test_leaf(1), checkpoint_retention(1))
+                .expect_err("duplicate checkpoint id must be refused");
+            assert!(
+                matches!(
+                    err,
+                    CommitmentTreeError::CheckpointOutOfOrder {
+                        provided: 1,
+                        max: 1
+                    }
+                ),
+                "unexpected error: {err}"
+            );
+
+            // Nothing may have been persisted by the refused append.
+            assert_eq!(
+                tree.max_leaf_position().expect("pos"),
+                Some(Position::from(0)),
+                "refused append must not persist the leaf"
+            );
+            assert_eq!(
+                tree.anchor().expect("anchor"),
+                anchor_before,
+                "refused append must not change the anchor"
+            );
+
+            // A lower id is refused the same way.
+            let err = tree
+                .append(test_leaf(1), checkpoint_retention(0))
+                .expect_err("lower checkpoint id must be refused");
+            assert!(matches!(
+                err,
+                CommitmentTreeError::CheckpointOutOfOrder {
+                    provided: 0,
+                    max: 1
+                }
+            ));
+        }
+
+        // Reopen: on-disk state is coherent, and the append can be retried
+        // with the next checkpoint id.
+        let mut tree =
+            ClientPersistentCommitmentTree::open_path(&db_path, 100).expect("reopen tree");
+        assert_eq!(
+            tree.max_leaf_position().expect("pos"),
+            Some(Position::from(0))
+        );
+        assert_eq!(tree.anchor().expect("anchor"), anchor_before);
+        tree.append(test_leaf(1), checkpoint_retention(2))
+            .expect("retry with next checkpoint id");
+        assert_eq!(
+            tree.max_leaf_position().expect("pos"),
+            Some(Position::from(1))
+        );
+    }
+
+    #[test]
+    fn test_memory_and_persistent_agree_on_duplicate_checkpoint_id() {
+        // Regression test for issue #882: the memory backend used to
+        // silently replace an existing checkpoint on a duplicate id while
+        // the SQLite backend errored (after persisting the leaf). Both
+        // backends must refuse identically, before mutating.
+        let conn = Connection::open_in_memory().expect("open sqlite");
+        let mut sqlite_tree =
+            ClientPersistentCommitmentTree::open(conn, 100).expect("open sqlite tree");
+        let mut memory_tree = ClientMemoryCommitmentTree::new(100);
+
+        sqlite_tree
+            .append(test_leaf(0), checkpoint_retention(1))
+            .expect("sqlite append");
+        memory_tree
+            .append(test_leaf(0), checkpoint_retention(1))
+            .expect("memory append");
+
+        let sqlite_err = sqlite_tree
+            .append(test_leaf(1), checkpoint_retention(1))
+            .expect_err("sqlite duplicate checkpoint id must be refused");
+        let memory_err = memory_tree
+            .append(test_leaf(1), checkpoint_retention(1))
+            .expect_err("memory duplicate checkpoint id must be refused");
+        assert_eq!(
+            sqlite_err.to_string(),
+            memory_err.to_string(),
+            "backends must report the same error"
+        );
+
+        assert_eq!(
+            sqlite_tree.max_leaf_position().expect("sqlite pos"),
+            memory_tree.max_leaf_position().expect("memory pos"),
+            "backends must agree on position after a refused append"
+        );
+        assert_eq!(
+            sqlite_tree.anchor().expect("sqlite anchor"),
+            memory_tree.anchor().expect("memory anchor"),
+            "backends must agree on anchor after a refused append"
+        );
+    }
+
+    #[test]
+    fn test_append_storage_error_rolls_back_shard_write() {
+        // Regression test for issue #882: a storage error partway through an
+        // append (after the shard write, during the checkpoint insert) used
+        // to leave the leaf committed while `append` returned an error.
+        // Inject a failure on the checkpoint insert with a SQL trigger and
+        // verify the operation-level savepoint rolls the shard write back.
+        let conn = Connection::open_in_memory().expect("open sqlite");
+        let arc = Arc::new(Mutex::new(conn));
+        let mut tree = ClientPersistentCommitmentTree::open_on_shared_connection(arc.clone(), 100)
+            .expect("open shared tree");
+
+        tree.append(test_leaf(0), checkpoint_retention(1))
+            .expect("first append");
+        let anchor_before = tree.anchor().expect("anchor");
+
+        {
+            let guard = arc.lock().expect("lock");
+            guard
+                .execute_batch(
+                    "CREATE TABLE test_fail_checkpoint (flag INTEGER);
+                     CREATE TRIGGER test_fail_checkpoint_insert
+                     BEFORE INSERT ON commitment_tree_checkpoints
+                     WHEN EXISTS (SELECT 1 FROM test_fail_checkpoint)
+                     BEGIN SELECT RAISE(ABORT, 'injected checkpoint failure'); END;
+                     INSERT INTO test_fail_checkpoint VALUES (1);",
+                )
+                .expect("install failure trigger");
+        }
+
+        let err = tree
+            .append(test_leaf(1), checkpoint_retention(2))
+            .expect_err("append must fail while the trigger is armed");
+        assert!(
+            err.to_string().contains("injected checkpoint failure"),
+            "unexpected error: {err}"
+        );
+
+        // The failed append must have been rolled back completely.
+        assert_eq!(
+            tree.max_leaf_position().expect("pos"),
+            Some(Position::from(0)),
+            "failed append must not persist the leaf"
+        );
+        assert_eq!(
+            tree.anchor().expect("anchor"),
+            anchor_before,
+            "failed append must not change the anchor"
+        );
+        {
+            let guard = arc.lock().expect("lock");
+            let checkpoints: i64 = guard
+                .query_row(
+                    "SELECT COUNT(*) FROM commitment_tree_checkpoints",
+                    [],
+                    |row| row.get(0),
+                )
+                .expect("count checkpoints");
+            assert_eq!(checkpoints, 1, "failed append must not add a checkpoint");
+            guard
+                .execute("DELETE FROM test_fail_checkpoint", [])
+                .expect("disarm trigger");
+        }
+
+        // Error recovery: the same append succeeds once the fault clears,
+        // without double-inserting the leaf.
+        tree.append(test_leaf(1), checkpoint_retention(2))
+            .expect("retry after transient failure");
+        assert_eq!(
+            tree.max_leaf_position().expect("pos"),
+            Some(Position::from(1))
+        );
+    }
+
+    #[test]
+    fn test_mutations_compose_with_wallet_transaction() {
+        // The store's multi-statement helpers use savepoints (not BEGIN), so
+        // tree mutations nest inside a wallet-owned transaction on a shared
+        // connection; the wallet owns the final commit or rollback.
+        let conn = Connection::open_in_memory().expect("open sqlite");
+        let arc = Arc::new(Mutex::new(conn));
+        let mut tree = ClientPersistentCommitmentTree::open_on_shared_connection(arc.clone(), 100)
+            .expect("open shared tree");
+
+        // Wallet rolls back: the appends and checkpoint vanish with it.
+        arc.lock()
+            .expect("lock")
+            .execute_batch("BEGIN IMMEDIATE")
+            .expect("wallet begin");
+        tree.append(test_leaf(0), checkpoint_retention(1))
+            .expect("append inside wallet transaction");
+        assert!(tree.checkpoint(2).expect("checkpoint inside wallet tx"));
+        arc.lock()
+            .expect("lock")
+            .execute_batch("ROLLBACK")
+            .expect("wallet rollback");
+        assert_eq!(
+            tree.max_leaf_position().expect("pos"),
+            None,
+            "wallet rollback must undo tree mutations"
+        );
+        assert_eq!(tree.anchor().expect("anchor"), Anchor::empty_tree());
+
+        // Wallet commits: the mutations persist.
+        arc.lock()
+            .expect("lock")
+            .execute_batch("BEGIN IMMEDIATE")
+            .expect("wallet begin");
+        tree.append(test_leaf(0), checkpoint_retention(1))
+            .expect("append inside wallet transaction");
+        arc.lock()
+            .expect("lock")
+            .execute_batch("COMMIT")
+            .expect("wallet commit");
+        assert_eq!(
+            tree.max_leaf_position().expect("pos"),
+            Some(Position::from(0))
         );
     }
 

--- a/grovedb-commitment-tree/src/client/sqlite_store/sql_helpers.rs
+++ b/grovedb-commitment-tree/src/client/sqlite_store/sql_helpers.rs
@@ -35,7 +35,9 @@ fn u64_to_i64(value_name: &str, value: u64) -> Result<i64, SqliteShardStoreError
 }
 
 /// Run `f` inside a SQLite savepoint named `name`, releasing it on success
-/// and rolling back (then releasing) on error.
+/// and rolling back on operation or release errors. A transaction opened
+/// by this helper is fully rolled back; a nested savepoint is rolled back
+/// and released without ending the caller's transaction.
 ///
 /// Savepoints nest — unlike `BEGIN`, which fails inside an open transaction —
 /// so multi-statement helpers wrapped in this compose both with an enclosing
@@ -46,19 +48,27 @@ pub(crate) fn with_savepoint<T>(
     name: &str,
     f: impl FnOnce(&Connection) -> Result<T, SqliteShardStoreError>,
 ) -> Result<T, SqliteShardStoreError> {
+    let owns_transaction = conn.is_autocommit();
     conn.execute_batch(&format!("SAVEPOINT {name}"))?;
-    match f(conn) {
-        Ok(value) => {
-            conn.execute_batch(&format!("RELEASE SAVEPOINT {name}"))?;
-            Ok(value)
-        }
+    // The release is also fallible: an outermost savepoint commits here.
+    let result = f(conn).and_then(|value| {
+        conn.execute_batch(&format!("RELEASE SAVEPOINT {name}"))?;
+        Ok(value)
+    });
+    match result {
+        Ok(value) => Ok(value),
         Err(e) => {
-            // ROLLBACK TO undoes the writes but leaves the savepoint on the
-            // stack; RELEASE pops it so the caller's transaction state is
-            // exactly as before this call.
-            if let Err(rollback_err) = conn.execute_batch(&format!(
-                "ROLLBACK TO SAVEPOINT {name}; RELEASE SAVEPOINT {name}"
-            )) {
+            // RELEASE can still need an exclusive lock after ROLLBACK TO.
+            // End an owned transaction outright, but preserve a caller's
+            // enclosing transaction when this savepoint is nested.
+            let rollback_result = if owns_transaction {
+                conn.execute_batch("ROLLBACK")
+            } else {
+                conn.execute_batch(&format!(
+                    "ROLLBACK TO SAVEPOINT {name}; RELEASE SAVEPOINT {name}"
+                ))
+            };
+            if let Err(rollback_err) = rollback_result {
                 return Err(SqliteShardStoreError::Serialization(format!(
                     "failed to roll back savepoint {name} after error ({e}): {rollback_err}"
                 )));

--- a/grovedb-commitment-tree/src/client/sqlite_store/sql_helpers.rs
+++ b/grovedb-commitment-tree/src/client/sqlite_store/sql_helpers.rs
@@ -34,6 +34,40 @@ fn u64_to_i64(value_name: &str, value: u64) -> Result<i64, SqliteShardStoreError
     })
 }
 
+/// Run `f` inside a SQLite savepoint named `name`, releasing it on success
+/// and rolling back (then releasing) on error.
+///
+/// Savepoints nest — unlike `BEGIN`, which fails inside an open transaction —
+/// so multi-statement helpers wrapped in this compose both with an enclosing
+/// operation-level savepoint (see `ClientPersistentCommitmentTree`) and with
+/// a caller-owned wallet transaction on a shared connection.
+pub(crate) fn with_savepoint<T>(
+    conn: &Connection,
+    name: &str,
+    f: impl FnOnce(&Connection) -> Result<T, SqliteShardStoreError>,
+) -> Result<T, SqliteShardStoreError> {
+    conn.execute_batch(&format!("SAVEPOINT {name}"))?;
+    match f(conn) {
+        Ok(value) => {
+            conn.execute_batch(&format!("RELEASE SAVEPOINT {name}"))?;
+            Ok(value)
+        }
+        Err(e) => {
+            // ROLLBACK TO undoes the writes but leaves the savepoint on the
+            // stack; RELEASE pops it so the caller's transaction state is
+            // exactly as before this call.
+            if let Err(rollback_err) = conn.execute_batch(&format!(
+                "ROLLBACK TO SAVEPOINT {name}; RELEASE SAVEPOINT {name}"
+            )) {
+                return Err(SqliteShardStoreError::Serialization(format!(
+                    "failed to roll back savepoint {name} after error ({e}): {rollback_err}"
+                )));
+            }
+            Err(e)
+        }
+    }
+}
+
 pub(crate) fn create_tables(conn: &Connection) -> Result<(), SqliteShardStoreError> {
     conn.execute_batch(
         "CREATE TABLE IF NOT EXISTS commitment_tree_shards (
@@ -226,21 +260,21 @@ pub(crate) fn sql_add_checkpoint(
         .map(|mark_pos| u64_to_i64("mark position", u64::from(*mark_pos)))
         .collect::<Result<_, _>>()?;
 
-    let tx = conn.unchecked_transaction()?;
-    tx.execute(
-        "INSERT INTO commitment_tree_checkpoints (checkpoint_id, position) VALUES (?1, ?2)",
-        params![checkpoint_id, position],
-    )?;
-
-    for mark_pos in mark_positions {
-        tx.execute(
-            "INSERT INTO commitment_tree_checkpoint_marks_removed (checkpoint_id, position) \
-             VALUES (?1, ?2)",
-            params![checkpoint_id, mark_pos],
+    with_savepoint(conn, "commitment_tree_add_checkpoint", |conn| {
+        conn.execute(
+            "INSERT INTO commitment_tree_checkpoints (checkpoint_id, position) VALUES (?1, ?2)",
+            params![checkpoint_id, position],
         )?;
-    }
-    tx.commit()?;
-    Ok(())
+
+        for mark_pos in mark_positions {
+            conn.execute(
+                "INSERT INTO commitment_tree_checkpoint_marks_removed (checkpoint_id, position) \
+                 VALUES (?1, ?2)",
+                params![checkpoint_id, mark_pos],
+            )?;
+        }
+        Ok(())
+    })
 }
 
 pub(crate) fn sql_checkpoint_count(conn: &Connection) -> Result<usize, SqliteShardStoreError> {
@@ -347,24 +381,26 @@ where
                 .map(|mark_pos| u64_to_i64("mark position", u64::from(*mark_pos)))
                 .collect::<Result<_, _>>()?;
 
-            let tx = conn.unchecked_transaction()?;
-            tx.execute(
-                "DELETE FROM commitment_tree_checkpoint_marks_removed WHERE checkpoint_id = ?1",
-                params![checkpoint_id],
-            )?;
-            tx.execute(
-                "UPDATE commitment_tree_checkpoints SET position = ?1 WHERE checkpoint_id = ?2",
-                params![position, checkpoint_id],
-            )?;
-            for mark_pos in mark_positions {
-                tx.execute(
-                    "INSERT INTO commitment_tree_checkpoint_marks_removed (checkpoint_id, \
-                     position) VALUES (?1, ?2)",
-                    params![checkpoint_id, mark_pos],
+            with_savepoint(conn, "commitment_tree_update_checkpoint", |conn| {
+                conn.execute(
+                    "DELETE FROM commitment_tree_checkpoint_marks_removed WHERE checkpoint_id = \
+                     ?1",
+                    params![checkpoint_id],
                 )?;
-            }
-            tx.commit()?;
-            Ok(true)
+                conn.execute(
+                    "UPDATE commitment_tree_checkpoints SET position = ?1 WHERE checkpoint_id = \
+                     ?2",
+                    params![position, checkpoint_id],
+                )?;
+                for mark_pos in mark_positions {
+                    conn.execute(
+                        "INSERT INTO commitment_tree_checkpoint_marks_removed (checkpoint_id, \
+                         position) VALUES (?1, ?2)",
+                        params![checkpoint_id, mark_pos],
+                    )?;
+                }
+                Ok(true)
+            })
         }
     }
 }
@@ -373,38 +409,38 @@ pub(crate) fn sql_remove_checkpoint(
     conn: &Connection,
     checkpoint_id: u32,
 ) -> Result<(), SqliteShardStoreError> {
-    let tx = conn.unchecked_transaction()?;
-    tx.execute(
-        "DELETE FROM commitment_tree_checkpoint_marks_removed WHERE checkpoint_id = ?1",
-        params![checkpoint_id],
-    )?;
-    tx.execute(
-        "DELETE FROM commitment_tree_checkpoints WHERE checkpoint_id = ?1",
-        params![checkpoint_id],
-    )?;
-    tx.commit()?;
-    Ok(())
+    with_savepoint(conn, "commitment_tree_remove_checkpoint", |conn| {
+        conn.execute(
+            "DELETE FROM commitment_tree_checkpoint_marks_removed WHERE checkpoint_id = ?1",
+            params![checkpoint_id],
+        )?;
+        conn.execute(
+            "DELETE FROM commitment_tree_checkpoints WHERE checkpoint_id = ?1",
+            params![checkpoint_id],
+        )?;
+        Ok(())
+    })
 }
 
 pub(crate) fn sql_truncate_checkpoints_retaining(
     conn: &Connection,
     checkpoint_id: u32,
 ) -> Result<(), SqliteShardStoreError> {
-    let tx = conn.unchecked_transaction()?;
-    tx.execute(
-        "DELETE FROM commitment_tree_checkpoint_marks_removed WHERE checkpoint_id > ?1",
-        params![checkpoint_id],
-    )?;
-    tx.execute(
-        "DELETE FROM commitment_tree_checkpoints WHERE checkpoint_id > ?1",
-        params![checkpoint_id],
-    )?;
-    tx.execute(
-        "DELETE FROM commitment_tree_checkpoint_marks_removed WHERE checkpoint_id = ?1",
-        params![checkpoint_id],
-    )?;
-    tx.commit()?;
-    Ok(())
+    with_savepoint(conn, "commitment_tree_truncate_checkpoints", |conn| {
+        conn.execute(
+            "DELETE FROM commitment_tree_checkpoint_marks_removed WHERE checkpoint_id > ?1",
+            params![checkpoint_id],
+        )?;
+        conn.execute(
+            "DELETE FROM commitment_tree_checkpoints WHERE checkpoint_id > ?1",
+            params![checkpoint_id],
+        )?;
+        conn.execute(
+            "DELETE FROM commitment_tree_checkpoint_marks_removed WHERE checkpoint_id = ?1",
+            params![checkpoint_id],
+        )?;
+        Ok(())
+    })
 }
 
 /// Load a full Checkpoint (including marks_removed).

--- a/grovedb-commitment-tree/src/client/sqlite_store_tests.rs
+++ b/grovedb-commitment-tree/src/client/sqlite_store_tests.rs
@@ -802,4 +802,50 @@ mod tests {
         assert!(loaded.marks_removed().contains(&Position::from(42)));
         assert!(loaded.marks_removed().contains(&Position::from(99)));
     }
+
+    /// The store helper also owns its transaction when called directly,
+    /// outside a ClientPersistentCommitmentTree operation savepoint.
+    #[test]
+    fn test_store_commit_failure_rolls_back_and_allows_retry() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("store_busy.db");
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute_batch("PRAGMA journal_mode=DELETE").unwrap();
+        conn.busy_timeout(std::time::Duration::ZERO).unwrap();
+        let arc = Arc::new(Mutex::new(conn));
+        let mut store = SqliteShardStore::new_shared(arc.clone()).unwrap();
+        store.add_checkpoint(1, Checkpoint::tree_empty()).unwrap();
+        let reader = Connection::open(&db_path).unwrap();
+        reader.execute_batch("BEGIN").unwrap();
+        let _: i64 = reader
+            .query_row(
+                "SELECT COUNT(*) FROM commitment_tree_checkpoints",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let err = store
+            .add_checkpoint(2, Checkpoint::tree_empty())
+            .expect_err("reader must block commit");
+        assert!(
+            matches!(err, SqliteShardStoreError::Sqlite(rusqlite::Error::SqliteFailure(ref e, _)) if e.code == rusqlite::ErrorCode::DatabaseBusy),
+            "{err}"
+        );
+        assert!(
+            arc.lock().unwrap().is_autocommit(),
+            "failed helper commit left a transaction open"
+        );
+        assert_eq!(store.checkpoint_count().unwrap(), 1);
+        assert!(store.get_checkpoint(&2).unwrap().is_none());
+        reader.execute_batch("ROLLBACK").unwrap();
+        store
+            .add_checkpoint(2, Checkpoint::tree_empty())
+            .expect("retry after lock clears");
+        assert!(arc.lock().unwrap().is_autocommit());
+        drop(store);
+        drop(arc);
+        let reopened = SqliteShardStore::new(Connection::open(&db_path).unwrap()).unwrap();
+        assert_eq!(reopened.checkpoint_count().unwrap(), 2);
+        assert!(reopened.get_checkpoint(&2).unwrap().is_some());
+    }
 }

--- a/grovedb-commitment-tree/src/client/tests.rs
+++ b/grovedb-commitment-tree/src/client/tests.rs
@@ -257,3 +257,66 @@ fn test_witness_anchors_match_across_syncs() {
     // (MerklePath doesn't implement PartialEq so we just verify both are
     // Some)
 }
+
+#[test]
+fn test_append_duplicate_checkpoint_id_refused() {
+    // Regression test for issue #882: the in-memory store used to silently
+    // replace an existing checkpoint when a leaf was appended with a
+    // duplicate checkpoint id, diverging from the persistent backend (and
+    // from `ShardTree::append`, which refuses out-of-order checkpoint ids).
+    use incrementalmerkletree::Marking;
+
+    use crate::CommitmentTreeError;
+
+    let mut tree = ClientMemoryCommitmentTree::new(10);
+    tree.append(
+        test_leaf(0),
+        Retention::Checkpoint {
+            id: 1,
+            marking: Marking::None,
+        },
+    )
+    .expect("first checkpointed append");
+    let anchor_before = tree.anchor().expect("anchor");
+
+    let err = tree
+        .append(
+            test_leaf(1),
+            Retention::Checkpoint {
+                id: 1,
+                marking: Marking::None,
+            },
+        )
+        .expect_err("duplicate checkpoint id must be refused");
+    assert!(
+        matches!(
+            err,
+            CommitmentTreeError::CheckpointOutOfOrder {
+                provided: 1,
+                max: 1
+            }
+        ),
+        "unexpected error: {err}"
+    );
+
+    // The refused append must not have modified anything.
+    assert_eq!(
+        tree.max_leaf_position().expect("pos"),
+        Some(Position::from(0))
+    );
+    assert_eq!(tree.anchor().expect("anchor"), anchor_before);
+
+    // The next id is accepted.
+    tree.append(
+        test_leaf(1),
+        Retention::Checkpoint {
+            id: 2,
+            marking: Marking::None,
+        },
+    )
+    .expect("append with next checkpoint id");
+    assert_eq!(
+        tree.max_leaf_position().expect("pos"),
+        Some(Position::from(1))
+    );
+}

--- a/grovedb-commitment-tree/src/error.rs
+++ b/grovedb-commitment-tree/src/error.rs
@@ -13,6 +13,18 @@ pub enum CommitmentTreeError {
     /// A 32-byte value is not a valid Pallas field element.
     #[error("invalid Pallas field element")]
     InvalidFieldElement,
+    /// A checkpoint id was not greater than the current maximum checkpoint
+    /// id. Checkpoint ids must be strictly increasing; the operation was
+    /// refused before any state was modified.
+    #[error(
+        "checkpoint id {provided} is not greater than the current maximum checkpoint id {max}"
+    )]
+    CheckpointOutOfOrder {
+        /// The checkpoint id supplied by the caller.
+        provided: u32,
+        /// The current maximum checkpoint id in the tree.
+        max: u32,
+    },
 
     /// An unknown grove version was supplied for a versioned accounting
     /// decision.


### PR DESCRIPTION
## Issue being fixed or feature implemented

Fixes #882 (audit S09, `csf_a14031d8edd670297fd21fd0`).

**Verified live on develop** before fixing, with a runtime reproduction:

- **Persistent (SQLite)**: both client wrappers append via `ShardTree::batch_insert`, which — unlike `ShardTree::append` — has no checkpoint-id ordering precheck and writes the shard before adding checkpoints. Appending a leaf with a duplicate checkpoint id committed the shard row (autocommit), then failed on the checkpoint `INSERT` with a UNIQUE violation: `append` returned `Err` while `max_leaf_position` had advanced and the anchor had changed, on disk, surviving reopen. A caller retrying after the error double-inserts the note commitment.
- **Memory**: the identical sequence returned `Ok` and silently *replaced* the existing checkpoint (moving its anchor to a different position) — divergent from both the SQLite backend and `ShardTree::append`'s `CheckpointOutOfOrder` contract.
- More generally, any storage error between the shard write and the checkpoint/pruning writes left partially committed state, and the store's multi-statement helpers used `unchecked_transaction` (`BEGIN`), which cannot nest inside a caller-owned wallet transaction on a shared connection.

## What was done?

- **Pre-mutation ordering validation, both backends**: `append` with `Retention::Checkpoint { id, .. }` where `id` is not greater than the current max checkpoint id now fails with a new typed `CommitmentTreeError::CheckpointOutOfOrder { provided, max }` *before anything is written* — the same strictly-increasing contract as `ShardTree::append`, now identical across memory and persistent backends.
- **Operation-level atomicity (SQLite)**: `append` and `checkpoint` run inside a SQLite savepoint (`atomically`). Both operation errors and final savepoint-release errors trigger cleanup. If the savepoint opened the transaction, cleanup uses a full `ROLLBACK`: `RELEASE` can remain blocked by a reader even after `ROLLBACK TO`. Nested operations roll back and release only their own savepoint, preserving the wallet transaction. The store helper follows the same ownership rule. Failed operations leave position, root, and historical checkpoints unchanged, and a retry persists after reopen.
- **Wallet-transaction composability**: the store's four multi-statement helpers (`add_checkpoint`, `update_checkpoint_with`, `remove_checkpoint`, `truncate_checkpoints_retaining`) now use nestable savepoints instead of `BEGIN`. Tree mutations therefore compose with an open wallet transaction on a shared connection, and commit ownership is explicit: the wallet's `COMMIT`/`ROLLBACK` decides. Documented on `open_on_shared_connection`, along with the constraint that other threads must not write through the shared connection while a mutating tree call is in flight.

### Issue's "validation to complete" checklist

- ✅ Ordinary checkpoint sequences produce matching memory and persistent behavior (parity test asserts identical errors, positions, and anchors).
- ✅ A rejected append leaves position, root and historical checkpoints coherent, including after reopen (tests cover both the refused-duplicate path and a trigger-injected mid-append storage failure that must roll back the shard write).
- ✅ Operation-level transaction handling composes with documented wallet transaction/connection usage and pruning (test drives append + checkpoint inside a wallet `BEGIN`, verifying both `ROLLBACK` and `COMMIT` ownership; pruning runs inside the operation savepoint).

## How Has This Been Tested?

Nine new tests in `grovedb-commitment-tree`:

- `test_append_duplicate_checkpoint_id_refused_before_mutation` — refusal is pre-mutation; on-disk state coherent after reopen; retry with the next id succeeds.
- `test_memory_and_persistent_agree_on_duplicate_checkpoint_id` — backend parity on error, position, and anchor.
- `test_append_storage_error_rolls_back_shard_write` — a SQL trigger injects a failure on the checkpoint insert mid-append; the shard write is rolled back and the same append succeeds once the fault clears (no double insert).
- `test_mutations_compose_with_wallet_transaction` — mutations inside a wallet-owned `BEGIN` vanish on wallet `ROLLBACK` and persist on wallet `COMMIT` (fails on the old `unchecked_transaction` helpers with *cannot start a transaction within a transaction*).
- `test_append_duplicate_checkpoint_id_refused` (memory-only, runs under the `client` feature without `sqlite`).

- `test_append_commit_failure_rolls_back_and_allows_retry` — a reader on another connection blocks commit in rollback-journal mode; marked and checkpointed appends roll back completely, including checkpoint pruning, release their transaction while the reader is still active, and permit a durable retry.
- `test_checkpoint_commit_failure_rolls_back_and_allows_retry` — failed checkpoint commits restore the pruned checkpoint and permit reuse of the new id after the lock clears.
- `test_store_commit_failure_rolls_back_and_allows_retry` — direct store-helper calls also clean up failed commits and persist a successful retry.
- `test_append_failure_preserves_wallet_transaction` — an injected failure rolls back only the tree operation; prior wallet writes survive and the same wallet transaction can retry and commit.

After the commit-failure fix, `cargo test -p grovedb-commitment-tree --features sqlite` passes 77 tests and `--features server,sqlite` passes 141 tests (one ignored). Workspace clippy with all features and warnings denied, plus `cargo fmt --all --check`, pass. The three commit-failure regression tests fail on the previous PR head and pass with the fix.

## Breaking Changes

None to the wire or server behavior. Two client-library behavior changes, both intentional per the audit finding:

- `ClientMemoryCommitmentTree::append` with a duplicate/lower checkpoint id now errors instead of silently replacing the checkpoint.
- `CommitmentTreeError` gains the `CheckpointOutOfOrder` variant.

No GroveVersion gate: this is the client-side wallet library (`client`/`sqlite` features, no GroveVersion in these APIs); server-side CommitmentTree state transitions, costs, and proofs are untouched.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)