### PR TITLE
chore: update rocksdb to 0.25.0

### DIFF
--- a/grovedb/Cargo.toml
+++ b/grovedb/Cargo.toml
@@ -69,9 +69,9 @@ rand_distr = "0.6"
 assert_matches = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "time", "sync"] }
 # For the `unsafe-dump-load` dump+ingest roundtrip test: writing the SST and
-# ingesting it both need direct rocksdb types. Pinned to the same revision
-# used by `grovedb-storage`'s optional dep.
-rocksdb = { git = "https://github.com/QuantumExplorer/rust-rocksdb.git", rev = "52772eea7bcd214d1d07d80aa538b1d24e5015b7" }
+# ingesting it both need direct rocksdb types. Use the same version
+# as `grovedb-storage`'s optional dep.
+rocksdb = "0.25.0"
 
 [[bench]]
 name = "insertion_benchmark"

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -18,8 +18,7 @@ hex = { workspace = true }
 integer-encoding = { workspace = true, optional = true }
 lazy_static = { version = "1.5.0", optional = true }
 num_cpus = { workspace = true, optional = true }
-# TODO: Switch back to crates.io once https://github.com/rust-rocksdb/rust-rocksdb/pull/1055 is merged and released
-rocksdb = { git = "https://github.com/QuantumExplorer/rust-rocksdb.git", rev = "52772eea7bcd214d1d07d80aa538b1d24e5015b7", optional = true }
+rocksdb = { version = "0.25.0", optional = true }
 strum = { version = "0.28.0", features = ["derive"] }
 tempfile = { workspace = true, optional = true }
 thiserror = { workspace = true }


### PR DESCRIPTION
## Issue being fixed or feature implemented

GroveDB still uses a Rust RocksDB fork for `create_checkpoint_with_log_size`. That feature was merged in [rust-rocksdb/rust-rocksdb#1055](https://github.com/rust-rocksdb/rust-rocksdb/pull/1055) and is included in [v0.25.0](https://github.com/rust-rocksdb/rust-rocksdb/releases/tag/v0.25.0), so the fork is no longer needed.

## What was done?

- Switch the optional storage dependency and GroveDB's dump/restore test dependency to crates.io `rocksdb = "0.25.0"`.
- Remove the completed upstream-release TODO and update the matching-version comment.
- Preserve the existing checkpoint API and `u64::MAX` flush setting.

The resolved dependency graph contains `rocksdb 0.25.0` and `librocksdb-sys 0.19.0+11.8.1`, with no Rust RocksDB fork dependency. The repository ignores `Cargo.lock`, so it is not included.

## How Has This Been Tested?

On macOS Apple Silicon with Rust 1.97.1:

- `cargo test -p grovedb-storage --features rocksdb_storage` — 49 passed.
- `cargo test -p grovedb --features unsafe-dump-load --lib` — 3,446 passed, 8 ignored. Includes checkpoint independence, WAL recovery, and subtree dump/restore preserving the root hash.
- `cargo clippy --workspace --all-features -- -D warnings` — passed.
- `cargo check --workspace --all-features --all-targets` — passed.
- `cargo build --no-default-features --features verify -p grovedb` — passed, with unused-import/dead-code warnings in the verification-only configuration.
- `cargo fmt --all --check` and commit hooks — passed.

The existing ignored checkpoint-threshold test remains ignored. The separate C++ fix [facebook/rocksdb#14193](https://github.com/facebook/rocksdb/pull/14193) was not part of the pinned Rust fork; this update does not depend on it.

## Breaking Changes

No GroveDB API changes. The dependency now requires Rust 1.88 or newer and upgrades the bundled RocksDB engine from 10.7.5 to 11.8.1.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

Existing regression tests cover this dependency-only update; no new tests or user documentation were needed.

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
