### PR TITLE
fix: preserve UTF-8 boundaries in path diagnostics

### DIFF
--- a/grovedb/src/tests/aggregate_count_query_tests.rs
+++ b/grovedb/src/tests/aggregate_count_query_tests.rs
@@ -1632,6 +1632,57 @@ mod tests {
     }
 
     #[test]
+    fn no_proof_missing_multibyte_index_prefix_returns_path_error() {
+        let v = GroveVersion::latest();
+        let db = make_test_grovedb(v);
+        db.insert(
+            [TEST_LEAF].as_ref(),
+            b"brand",
+            Element::empty_tree(),
+            None,
+            None,
+            v,
+        )
+        .unwrap()
+        .expect("insert index root");
+
+        // A compound [brand, color] index count query may select a brand
+        // with no stored subtree. Its UTF-8 value must remain safe to print
+        // when the missing color subtree produces a parent-path diagnostic.
+        for brand in ["é".repeat(17).into_bytes(), vec![0xff; 34], vec![b'x'; 34]] {
+            let path = vec![
+                TEST_LEAF.to_vec(),
+                b"brand".to_vec(),
+                brand,
+                b"color".to_vec(),
+            ];
+            let path_query = PathQuery::new_aggregate_count_on_range(
+                path.clone(),
+                QueryItem::RangeAfter(b"blue".to_vec()..),
+            );
+            let err = db
+                .grove_db
+                .query_aggregate_count(&path_query, None, v)
+                .unwrap()
+                .expect_err("a missing index branch must return an error");
+            assert!(matches!(err, crate::Error::InvalidParentLayerPath(_)));
+
+            let err = db
+                .grove_db
+                .get_raw(path.as_slice().into(), b"key", None, v)
+                .unwrap()
+                .expect_err("a missing lookup parent must return an error");
+            assert!(matches!(err, crate::Error::PathParentLayerNotFound(_)));
+            assert!(db
+                .grove_db
+                .get_raw_optional(path.as_slice().into(), b"key", None, v)
+                .unwrap()
+                .expect("a missing optional lookup remains absent")
+                .is_none());
+        }
+    }
+
+    #[test]
     fn no_proof_uses_provided_transaction() {
         // Exercise the TransactionArg = Some(&tx) path of query_aggregate_count
         // and verify the transactional read actually observes uncommitted

--- a/visualize/src/lib.rs
+++ b/visualize/src/lib.rs
@@ -148,11 +148,7 @@ impl Visualize for [u8] {
         if let Ok(str_repr) = str_repr {
             // Preserve the historical 33-byte preview, ending before any
             // character that would cross its byte boundary.
-            let mut end = str_repr.len().min(STR_LEN + 1);
-            while !str_repr.is_char_boundary(end) {
-                end -= 1;
-            }
-            let str_part = &str_repr[..end];
+            let str_part = &str_repr[..str_repr.floor_char_boundary(STR_LEN + 1)];
             drawer.write(format!(", str: {str_part}").as_bytes())?;
         }
         drawer.write(b"]")?;

--- a/visualize/src/lib.rs
+++ b/visualize/src/lib.rs
@@ -146,11 +146,13 @@ impl Visualize for [u8] {
         let str_repr = String::from_utf8(self.to_vec());
         drawer.write(format!("[hex: {hex_repr}").as_bytes())?;
         if let Ok(str_repr) = str_repr {
-            let str_part = if str_repr.len() > STR_LEN {
-                &str_repr[..=STR_LEN]
-            } else {
-                &str_repr
-            };
+            // Preserve the historical 33-byte preview, ending before any
+            // character that would cross its byte boundary.
+            let mut end = str_repr.len().min(STR_LEN + 1);
+            while !str_repr.is_char_boundary(end) {
+                end -= 1;
+            }
+            let str_part = &str_repr[..end];
             drawer.write(format!(", str: {str_part}").as_bytes())?;
         }
         drawer.write(b"]")?;
@@ -356,6 +358,36 @@ mod tests {
     fn bytes_visualize_non_utf8_omits_string_part() {
         let got = visualized(&[0xff, 0xfe, 0xfd][..]);
         assert_eq!(got, "[hex: fffefd]");
+    }
+
+    #[test]
+    fn bytes_visualize_preserves_complete_utf8_characters_at_preview_boundary() {
+        let cases = [
+            ("é".repeat(16), "é".repeat(16)),
+            ("x".repeat(33), "x".repeat(33)),
+            ("é".repeat(17), "é".repeat(16)),
+            (format!("{}é", "a".repeat(32)), "a".repeat(32)),
+            (format!("{}界", "a".repeat(31)), "a".repeat(31)),
+            (format!("{}🦀", "a".repeat(30)), "a".repeat(30)),
+            (format!("{}x", "界".repeat(11)), "界".repeat(11)),
+        ];
+        for (input, preview) in cases {
+            assert_eq!(
+                visualized(input.as_bytes()),
+                format!("[hex: {}, str: {preview}]", to_hex(input.as_bytes()))
+            );
+        }
+    }
+
+    #[test]
+    fn debug_wrappers_handle_multibyte_path_segments() {
+        let bytes = "é".repeat(17).into_bytes();
+        let expected = format!("[hex: {}, str: {}]", to_hex(&bytes), "é".repeat(16));
+        assert_eq!(format!("{:?}", DebugBytes(bytes.clone())), expected);
+        assert_eq!(
+            format!("{:?}", DebugByteVectors(vec![bytes, vec![0xff; 34]])),
+            format!("[ {expected}, [hex: ffffffff..ffffffff],  ]")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Issue being fixed or feature implemented
Fixes #905. A valid UTF-8 path segment crossing byte 33 panics while a missing-parent error is formatted. Platform's public no-proof COUNT route can construct this path from a string equality filter on a compound range-countable index; process-wide panic impact has not been established.

## What was done?
Keep the existing 33-byte diagnostic preview and move its endpoint backward to a UTF-8 boundary. The shared byte formatter covers path/key debug wrappers and missing-parent diagnostics. ASCII, safe Unicode boundaries and invalid UTF-8's hex-only output retain their existing behavior.

## How Has This Been Tested?
- Baseline: both new Unicode formatter regressions reproduced the byte-boundary panic; all 18 existing tests passed.
- `cargo test -p grovedb-visualize --offline`: 20 tests passed.
- `cargo test -p grovedb aggregate_count_query_tests --lib --offline`: 79 tests passed. The new compound-index regression checks multibyte, invalid UTF-8 and ASCII missing paths, including typed strict-read errors and optional-read absence.
- `cargo clippy -p grovedb-visualize --all-targets --offline --no-deps -- -D warnings`, formatting and diff checks passed.
- Independent read-only review found no concrete bypass or regression.

## Breaking Changes
None. This changes only previously panicking diagnostic previews; stored bytes, costs, hashes, version gates and proof formats are unchanged.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of missing paths when keys contain multibyte or binary data, returning consistent errors instead of incomplete results.
  - Fixed byte-string previews so truncation no longer splits UTF-8 characters, preserving readable text while maintaining the existing preview length.

- **Tests**
  - Added coverage for multibyte and binary keys, missing-path behavior, and character-safe debug output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->