### PR TITLE
fix: stop malformed proof decoding after the first error

### DIFF
--- a/grovedb-query/src/proofs/encoding.rs
+++ b/grovedb-query/src/proofs/encoding.rs
@@ -2002,10 +2002,14 @@ pub fn encode_into<'a, T: Iterator<Item = &'a Op>>(ops: T, output: &mut Vec<u8>)
     }
 }
 
-/// Decoder iterates over proof bytes, yielding Op values
+/// Decoder iterates over proof bytes, yielding Op values.
+///
+/// A decoding error is yielded once, then iteration terminates. The invalid
+/// bytes remain unconsumed and are included in [`Self::remaining_bytes`].
 pub struct Decoder<'a> {
     offset: usize,
     bytes: &'a [u8],
+    failed: bool,
 }
 
 impl<'a> Decoder<'a> {
@@ -2014,6 +2018,7 @@ impl<'a> Decoder<'a> {
         Decoder {
             offset: 0,
             bytes: proof_bytes,
+            failed: false,
         }
     }
 
@@ -2027,18 +2032,20 @@ impl Iterator for Decoder<'_> {
     type Item = Result<Op, Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.offset >= self.bytes.len() {
+        if self.failed || self.offset >= self.bytes.len() {
             return None;
         }
 
-        Some((|| {
-            let bytes = &self.bytes[self.offset..];
-            let op = Op::decode(bytes)?;
-            self.offset += op.encoding_length();
-            Ok(op)
-        })())
+        let result = Op::decode(&self.bytes[self.offset..]);
+        match &result {
+            Ok(op) => self.offset += op.encoding_length(),
+            Err(_) => self.failed = true,
+        }
+        Some(result)
     }
 }
+
+impl std::iter::FusedIterator for Decoder<'_> {}
 
 #[cfg(test)]
 mod test {
@@ -2590,10 +2597,7 @@ mod test {
     #[test]
     fn decode_multiple_child() {
         let bytes = [0x11, 0x11, 0x11, 0x10];
-        let decoder = Decoder {
-            bytes: &bytes,
-            offset: 0,
-        };
+        let decoder = Decoder::new(&bytes);
 
         let mut vecop = vec![];
         for op in decoder {
@@ -2798,6 +2802,53 @@ mod test {
         let decoder = Decoder::new(&encoded);
         let decoded_ops: Result<Vec<Op>, _> = decoder.collect();
         assert_eq!(decoded_ops.expect("decode failed"), ops);
+    }
+
+    #[test]
+    fn decoder_stops_after_first_error_without_consuming_invalid_bytes() {
+        for invalid in [
+            vec![0xFF, 0x10], // Unknown opcode followed by a valid Parent.
+            vec![0x01, 0x02], // Truncated Hash payload.
+        ] {
+            for prefix in [vec![], vec![Op::Parent, Op::ChildInverted]] {
+                let mut encoded = vec![];
+                super::encode_into(prefix.iter(), &mut encoded);
+                encoded.extend_from_slice(&invalid);
+                let mut decoder = Decoder::new(&encoded);
+
+                for op in &prefix {
+                    assert_eq!(decoder.next().unwrap().unwrap(), *op);
+                }
+                assert_eq!(decoder.remaining_bytes(), invalid.len());
+                assert_eq!(
+                    decoder.next().unwrap().unwrap_err().to_string(),
+                    Op::decode(&invalid).unwrap_err().to_string()
+                );
+                // Keep this probe bounded: the unfixed decoder repeats the
+                // error forever, so collecting it would hang the test.
+                for _ in 0..3 {
+                    assert!(decoder.next().is_none());
+                    assert_eq!(decoder.remaining_bytes(), invalid.len());
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn decoder_stays_exhausted_after_valid_input() {
+        for ops in [vec![], vec![Op::Parent, Op::Child, Op::ParentInverted]] {
+            let mut encoded = vec![];
+            super::encode_into(ops.iter(), &mut encoded);
+            let mut decoder = Decoder::new(&encoded);
+            assert_eq!(
+                decoder.by_ref().collect::<Result<Vec<_>, _>>().unwrap(),
+                ops
+            );
+            for _ in 0..3 {
+                assert!(decoder.next().is_none());
+                assert_eq!(decoder.remaining_bytes(), 0);
+            }
+        }
     }
 
     #[test]

--- a/grovedb/src/operations/proof/mod.rs
+++ b/grovedb/src/operations/proof/mod.rs
@@ -1103,6 +1103,7 @@ fn decode_merk_proof(proof: &[u8]) -> Result<String, fmt::Error> {
             }
             Err(e) => {
                 result.push_str(&format!("\n    {}: Error decoding op: {}", i, e));
+                break;
             }
         }
     }

--- a/grovedb/tests/proof_formatting.rs
+++ b/grovedb/tests/proof_formatting.rs
@@ -1,0 +1,170 @@
+//! Regression coverage for formatting malformed inner Merk proofs.
+
+#![cfg(any(feature = "minimal", feature = "verify"))]
+
+use std::collections::BTreeMap;
+
+use grovedb::operations::proof::{
+    GroveDBProof, GroveDBProofV0, GroveDBProofV1, LayerProof, MerkOnlyLayerProof, ProofBytes,
+    ProveOptions,
+};
+use grovedb_merk::proofs::{Decoder, Node, Op};
+
+// Check progress before invoking Display so reverting the decoder fix fails
+// promptly instead of letting a regression test build an unbounded String.
+fn assert_error_is_terminal(bytes: &[u8]) {
+    let mut decoder = Decoder::new(bytes);
+    for _ in 0..=bytes.len() {
+        match decoder.next() {
+            Some(Ok(_)) => {}
+            Some(Err(_)) => {
+                assert!(decoder.next().is_none());
+                assert!(decoder.remaining_bytes() > 0);
+                return;
+            }
+            None => panic!("expected malformed proof bytes"),
+        }
+    }
+    panic!("decoder did not reach the malformed operation");
+}
+
+fn assert_malformed_display(proof: GroveDBProof) {
+    // Exercise the outer-envelope decode followed by Display, as diagnostic
+    // callers do. Formatting must not change the serialized proof.
+    let config = bincode::config::standard().with_big_endian();
+    let encoded = bincode::encode_to_vec(&proof, config).unwrap();
+    let (decoded, consumed): (GroveDBProof, _) =
+        bincode::decode_from_slice(&encoded, config).unwrap();
+    assert_eq!(consumed, encoded.len());
+    let display = decoded.to_string();
+    assert_eq!(display.matches("Error decoding op:").count(), 1);
+    assert!(display.contains("0: Parent"));
+    assert!(display.contains("1: Error decoding op:"));
+    assert!(!display.contains("2:"));
+    assert!(display.len() < 1024, "malformed diagnostic must terminate");
+    assert_eq!(bincode::encode_to_vec(&decoded, config).unwrap(), encoded);
+}
+
+#[test]
+fn malformed_inner_proofs_display_once_in_all_merk_envelopes() {
+    for invalid in [
+        vec![0x10, 0xFF, 0x10], // Parent, unknown opcode, then valid Parent.
+        vec![0x10, 0x01, 0x02], // Parent, then truncated Hash.
+    ] {
+        assert_error_is_terminal(&invalid);
+        for nested in [false, true] {
+            let mut root_layer = MerkOnlyLayerProof {
+                merk_proof: invalid.clone(),
+                lower_layers: BTreeMap::new(),
+            };
+            if nested {
+                root_layer = MerkOnlyLayerProof {
+                    merk_proof: vec![],
+                    lower_layers: BTreeMap::from([(b"child".to_vec(), root_layer)]),
+                };
+            }
+            assert_malformed_display(GroveDBProof::V0(GroveDBProofV0 {
+                root_layer,
+                prove_options: ProveOptions::default(),
+            }));
+
+            let mut indexed = vec![0; 32];
+            indexed.extend_from_slice(&invalid);
+            for merk_proof in [
+                ProofBytes::Merk(invalid.clone()),
+                ProofBytes::CountIndexedTree(indexed),
+            ] {
+                let mut root_layer = LayerProof {
+                    merk_proof,
+                    lower_layers: BTreeMap::new(),
+                };
+                if nested {
+                    root_layer = LayerProof {
+                        merk_proof: ProofBytes::Merk(vec![]),
+                        lower_layers: BTreeMap::from([(b"child".to_vec(), root_layer)]),
+                    };
+                }
+                assert_malformed_display(GroveDBProof::V1(GroveDBProofV1 { root_layer }));
+            }
+        }
+    }
+}
+
+#[test]
+fn valid_inner_proof_display_preserves_operations() {
+    assert_eq!(ProofBytes::Merk(vec![]).to_string(), "Merk()");
+    let ops = [
+        Op::Push(Node::Hash([0xAB; 32])),
+        Op::Parent,
+        Op::ChildInverted,
+    ];
+    let mut encoded = vec![];
+    grovedb_query::proofs::encode_into(ops.iter(), &mut encoded);
+    assert_eq!(
+        ProofBytes::Merk(encoded).to_string(),
+        format!(
+            "Merk(\n    0: Push(Hash(HASH[{}]))\n    1: Parent\n    2: ChildInverted)",
+            "ab".repeat(32)
+        )
+    );
+}
+
+#[test]
+fn invalid_element_display_still_returns_a_format_error() {
+    use std::fmt::Write;
+
+    let ops = [Op::Push(Node::KV(b"key".to_vec(), vec![0xFF]))];
+    let mut encoded = vec![];
+    grovedb_query::proofs::encode_into(ops.iter(), &mut encoded);
+    assert!(write!(&mut String::new(), "{}", ProofBytes::Merk(encoded)).is_err());
+}
+
+#[cfg(feature = "minimal")]
+#[test]
+fn formatting_preserves_generated_proof_bytes_roots_and_results() {
+    use grovedb::{Element, GroveDb, PathQuery, Query};
+    use grovedb_version::version::{v2::GROVE_V2, GroveVersion};
+
+    for grove_version in [&GROVE_V2, GroveVersion::latest()] {
+        let directory = tempfile::tempdir().unwrap();
+        let db = GroveDb::open(directory.path()).unwrap();
+        db.insert(
+            &[] as &[&[u8]],
+            b"key",
+            Element::new_item(b"value".to_vec()),
+            None,
+            None,
+            grove_version,
+        )
+        .unwrap()
+        .unwrap();
+        let mut query = Query::new();
+        query.insert_key(b"key".to_vec());
+        let query = PathQuery::new_unsized(vec![], query);
+        let encoded = db
+            .prove_query(&query, None, grove_version)
+            .unwrap()
+            .unwrap();
+        let verified = GroveDb::verify_query_raw(&encoded, &query, grove_version).unwrap();
+        assert_eq!(
+            verified.0,
+            db.root_hash(None, grove_version).unwrap().unwrap()
+        );
+        assert_eq!(verified.1.len(), 1);
+
+        let config = bincode::config::standard().with_big_endian();
+        let (proof, consumed): (GroveDBProof, _) =
+            bincode::decode_from_slice(&encoded, config).unwrap();
+        assert_eq!(consumed, encoded.len());
+        let display = proof.to_string();
+        assert!(display.contains("key"));
+        assert!(display.contains("value"));
+        assert!(!display.contains("Error"));
+        let after_display = bincode::encode_to_vec(&proof, config).unwrap();
+        assert_eq!(after_display, encoded);
+        assert_eq!(
+            GroveDb::verify_query_raw(&after_display, &query, grove_version).unwrap(),
+            verified
+        );
+    }
+}

--- a/merk/src/proofs/mod.rs
+++ b/merk/src/proofs/mod.rs
@@ -25,7 +25,9 @@ pub use tree::{execute, Tree};
 /// Decoder iterates over proof bytes, yielding Op values with merk Error type.
 ///
 /// This wraps grovedb-query's Decoder, converting its error type to merk's
-/// Error.
+/// Error. Like the wrapped decoder, it yields a decoding error once and then
+/// stays exhausted; the invalid bytes remain counted by
+/// [`Self::remaining_bytes`].
 #[cfg(any(feature = "minimal", feature = "verify"))]
 pub struct Decoder<'a> {
     inner: grovedb_query::proofs::Decoder<'a>,
@@ -55,10 +57,34 @@ impl Iterator for Decoder<'_> {
     }
 }
 
+// The wrapped decoder is fused (one error, then `None` forever), and `next`
+// only maps its items, so the wrapper upholds the same contract.
+#[cfg(any(feature = "minimal", feature = "verify"))]
+impl std::iter::FusedIterator for Decoder<'_> {}
+
 /// Re-export encoding module for backward compatibility
 #[cfg(any(feature = "minimal", feature = "verify"))]
 pub mod encoding {
     pub use grovedb_query::proofs::encode_into;
 
     pub use super::Decoder;
+}
+
+#[cfg(all(test, any(feature = "minimal", feature = "verify")))]
+mod tests {
+    use super::{Decoder, Op};
+
+    #[test]
+    fn decoder_yields_one_error_then_stays_exhausted() {
+        // A valid Parent op, then an unknown opcode followed by one more byte.
+        let bytes = [0x10, 0xFF, 0x10];
+        let mut decoder = Decoder::new(&bytes);
+        assert!(matches!(decoder.next(), Some(Ok(Op::Parent))));
+        assert_eq!(decoder.remaining_bytes(), 2);
+        assert!(matches!(decoder.next(), Some(Err(_))));
+        for _ in 0..3 {
+            assert!(decoder.next().is_none());
+            assert_eq!(decoder.remaining_bytes(), 2);
+        }
+    }
 }


### PR DESCRIPTION
## Issue being fixed or feature implemented
Fixes #860. Formatting a proof with malformed inner Merk bytes could repeatedly decode the same error and grow its diagnostic string indefinitely. Platform exposes this through the public SDK `prettify_proof` helper; an automatic runtime caller has not been established.

## What was done?
Make the shared Merk operation decoder yield an error once and remain exhausted, preserving the invalid bytes in `remaining_bytes()`. Also stop proof formatting after its first decoding error. Valid diagnostics, successful operation decoding and verification's first-error behavior stay unchanged.

## How Has This Been Tested?
- A bounded baseline regression reproduced repeated errors after malformed input; a valid decoder control passed.
- Full `grovedb-query` test suite: 433 tests passed.
- Clean rebuild of `cargo test -p grovedb --test proof_formatting --offline`: 4 tests passed, including malformed root/nested envelopes, CountIndexedTree, and generated V0/V1 proof byte/root/result preservation.
- The same integration under `--no-default-features --features verify`: 3 tests passed.
- Existing `grovedb_proof_display` and `decode_vec_ops` tests: 8 passed.
- `cargo clippy -p grovedb-query -p grovedb --lib --tests --offline --no-deps -- -D warnings`, formatting, diff checks and independent review passed.

## Breaking Changes
None for successful decoding or proof verification. Continued iteration after a decoding error now ends; the first error and unread-byte count are preserved. Diagnostic output is still proportional to valid proof contents; this patch does not introduce a global formatting-size limit.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone