### PR TITLE
chore(release): bump GroveDB to 6.0.0 and bincode fork to 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Updated proof verification logic to handle parent tree inclusion
 
 ### Changed
+- Bumped the GroveDB workspace crates and their internal dependency requirements
+  to **6.0.0** for the public API changes since 5.0.1. This package version is
+  independent of the existing `GroveVersion` runtime compatibility versions.
+- Bumped `grovedb-bincode` and `grovedb-bincode-derive` together to **2.1.0**.
+  Their new opt-in untrusted decoding traits, derives, and entry points are
+  backward-compatible API additions to the fork's upstream 2.0.1 baseline.
 - Updated delete function to include grove_version parameter (#377)
 - Adjusted batch size type for better performance (#377)
 - Renamed `prove_internal` to `prove_query_non_serialized` for clarity (#373)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ thiserror = "2.0"
 hex = "0.4.3"
 integer-encoding = "4.1.0"
 blake3 = "1.8"
-bincode = { package = "grovedb-bincode", version = "=2.0.2", path = "grovedb-bincode" }
-bincode_derive = { package = "grovedb-bincode-derive", version = "=2.0.2", path = "grovedb-bincode-derive" }
+bincode = { package = "grovedb-bincode", version = "=2.1.0", path = "grovedb-bincode" }
+bincode_derive = { package = "grovedb-bincode-derive", version = "=2.1.0", path = "grovedb-bincode-derive" }
 indexmap = "2.13.0"
 serde = { version = "1.0", features = ["derive"] }
 byteorder = "1.5.0"

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ A high-performance, cryptographically verifiable database that organizes data as
 
 ```toml
 [dependencies]
-grovedb = "3.0"
+grovedb = "6.0"
 ```
 
 ```rust

--- a/costs/Cargo.toml
+++ b/costs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grovedb-costs"
-version = "5.0.1"
+version = "6.0.0"
 edition = "2024"
 license = "MIT"
 description = "Costs extension crate for GroveDB"

--- a/grovedb-bincode-derive/Cargo.toml
+++ b/grovedb-bincode-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grovedb-bincode-derive"
-version = "2.0.2"
+version = "2.1.0"
 authors = [
     "Zoey Riordan <zoey@dos.cafe>",
     "Victor Koenders <bincode@trangar.com>",

--- a/grovedb-bincode-derive/GROVEDB.md
+++ b/grovedb-bincode-derive/GROVEDB.md
@@ -2,7 +2,7 @@
 
 This package imports the derive macros from the published `bincode_derive`
 **2.0.1** release as `grovedb-bincode-derive`. It accompanies
-`grovedb-bincode`. Version **2.0.2** adds `DecodeUntrusted` and
+`grovedb-bincode`. Version **2.1.0** adds `DecodeUntrusted` and
 `BorrowDecodeUntrusted`. Ordinary derives and default generated `::bincode` paths
 retain their upstream behavior.
 

--- a/grovedb-bincode/Cargo.toml
+++ b/grovedb-bincode/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grovedb-bincode"
-version = "2.0.2"
+version = "2.1.0"
 authors = [
     "Ty Overby <ty@pre-alpha.com>",
     "Zoey Riordan <zoey@dos.cafe>",
@@ -27,7 +27,7 @@ alloc = ["serde?/alloc"]
 derive = ["bincode_derive"]
 
 [dependencies]
-bincode_derive = { package = "grovedb-bincode-derive", path = "../grovedb-bincode-derive", version = "=2.0.2", optional = true }
+bincode_derive = { package = "grovedb-bincode-derive", path = "../grovedb-bincode-derive", version = "=2.1.0", optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
 unty = "0.0.4"
 

--- a/grovedb-bincode/GROVEDB.md
+++ b/grovedb-bincode/GROVEDB.md
@@ -4,8 +4,8 @@ This workspace package started from the published `bincode` **2.0.1** release as
 `grovedb-bincode`, together with `bincode_derive` **2.0.1** as
 `grovedb-bincode-derive`. The initial import preserved the upstream encoder, decoder,
 derive macros, wire format, features, tests, benchmarks, specification, and MIT
-license. Runtime version **2.0.2** adds explicit untrusted decoding APIs below;
-the derive package is also **2.0.2** with explicit untrusted derives.
+license. Runtime version **2.1.0** adds explicit untrusted decoding APIs below;
+the derive package is also **2.1.0** with explicit untrusted derives.
 
 The original documentation remains in [readme.md](readme.md) and [docs](docs/).
 The original copyright and license remain in [LICENSE.md](LICENSE.md).
@@ -35,14 +35,14 @@ paths continue to work:
 
 ```toml
 [dependencies]
-bincode = { package = "grovedb-bincode", version = "=2.0.2" }
+bincode = { package = "grovedb-bincode", version = "=2.1.0" }
 ```
 
 The default `derive` feature uses the matching local derive package. Code that
 depends on the macros separately can use:
 
 ```toml
-bincode_derive = { package = "grovedb-bincode-derive", version = "=2.0.2" }
+bincode_derive = { package = "grovedb-bincode-derive", version = "=2.1.0" }
 ```
 
 Although the bytes are unchanged, these are new Cargo packages with distinct
@@ -52,7 +52,7 @@ alias does not make implementations interchangeable with upstream bincode.
 Publish the derive package, then the runtime package, before publishing GroveDB
 packages that depend on them. Their versions are independent of GroveDB's version.
 
-## Opt-in untrusted decoding in 2.0.2
+## Opt-in untrusted decoding in 2.1.0
 
 Ordinary `decode_*` / `borrow_decode_*` functions and decoder constructors retain
 upstream 2.0.1 behavior, including eager allocation, Serde size hints, and reader

--- a/grovedb-bulk-append-tree/Cargo.toml
+++ b/grovedb-bulk-append-tree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grovedb-bulk-append-tree"
-version = "5.0.1"
+version = "6.0.0"
 authors = ["Samuel Westrich <sam@dash.org>"]
 edition = "2024"
 license = "MIT"
@@ -23,12 +23,12 @@ mem_store = ["grovedb-merkle-mountain-range/mem_store"]
 test-utils = ["storage"]
 
 [dependencies]
-grovedb-merkle-mountain-range = { version = "5.0.1", path = "../grovedb-merkle-mountain-range", default-features = false }
-grovedb-dense-fixed-sized-merkle-tree = { version = "5.0.1", path = "../grovedb-dense-fixed-sized-merkle-tree", default-features = false }
-grovedb-query = { version = "5.0.1", path = "../grovedb-query" }
-grovedb-costs = { version = "5.0.1", path = "../costs" }
-grovedb-version = { version = "5.0.1", path = "../grovedb-version" }
-grovedb-storage = { version = "5.0.1", path = "../storage", optional = true }
+grovedb-merkle-mountain-range = { version = "6.0.0", path = "../grovedb-merkle-mountain-range", default-features = false }
+grovedb-dense-fixed-sized-merkle-tree = { version = "6.0.0", path = "../grovedb-dense-fixed-sized-merkle-tree", default-features = false }
+grovedb-query = { version = "6.0.0", path = "../grovedb-query" }
+grovedb-costs = { version = "6.0.0", path = "../costs" }
+grovedb-version = { version = "6.0.0", path = "../grovedb-version" }
+grovedb-storage = { version = "6.0.0", path = "../storage", optional = true }
 blake3 = { workspace = true }
 integer-encoding = { workspace = true }
 bincode = { workspace = true, features = ["derive"] }

--- a/grovedb-commitment-tree/Cargo.toml
+++ b/grovedb-commitment-tree/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "grovedb-commitment-tree"
 description = "Orchard-style commitment tree integration for GroveDB"
-version = "5.0.1"
+version = "6.0.0"
 authors = ["Samuel Westrich <sam@dash.org>"]
 edition = "2024"
 license = "MIT"
@@ -21,10 +21,10 @@ orchard = { git = "https://github.com/dashpay/orchard.git", tag = "dashified-0.1
 incrementalmerkletree = "0.8"
 shardtree = { version = "0.6", optional = true }
 rusqlite = { version = "0.38", features = ["bundled"], optional = true }
-grovedb-costs = { version = "5.0.1", path = "../costs" }
-grovedb-version = { version = "5.0.1", path = "../grovedb-version" }
-grovedb-storage = { version = "5.0.1", path = "../storage", optional = true }
-grovedb-bulk-append-tree = { version = "5.0.1", path = "../grovedb-bulk-append-tree", default-features = false }
+grovedb-costs = { version = "6.0.0", path = "../costs" }
+grovedb-version = { version = "6.0.0", path = "../grovedb-version" }
+grovedb-storage = { version = "6.0.0", path = "../storage", optional = true }
+grovedb-bulk-append-tree = { version = "6.0.0", path = "../grovedb-bulk-append-tree", default-features = false }
 blake3 = { workspace = true }
 thiserror = { workspace = true }
 
@@ -34,8 +34,8 @@ criterion = { workspace = true }
 rand = { workspace = true }
 rand_core = "0.6"
 # For the `seeding` benchmark: a real RocksDB-backed storage context.
-grovedb-storage = { version = "5.0.1", path = "../storage", features = ["rocksdb_storage"] }
-grovedb-path = { version = "5.0.1", path = "../path" }
+grovedb-storage = { version = "6.0.0", path = "../storage", features = ["rocksdb_storage"] }
+grovedb-path = { version = "6.0.0", path = "../path" }
 
 [[bench]]
 name = "verification"

--- a/grovedb-dense-fixed-sized-merkle-tree/Cargo.toml
+++ b/grovedb-dense-fixed-sized-merkle-tree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grovedb-dense-fixed-sized-merkle-tree"
-version = "5.0.1"
+version = "6.0.0"
 authors = ["Samuel Westrich <sam@dash.org>"]
 edition = "2024"
 license = "MIT"
@@ -16,7 +16,7 @@ storage = ["grovedb-storage"]
 blake3 = { workspace = true }
 bincode = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
-grovedb-costs = { version = "5.0.1", path = "../costs" }
-grovedb-query = { version = "5.0.1", path = "../grovedb-query" }
-grovedb-version = { version = "5.0.1", path = "../grovedb-version" }
-grovedb-storage = { version = "5.0.1", path = "../storage", optional = true }
+grovedb-costs = { version = "6.0.0", path = "../costs" }
+grovedb-query = { version = "6.0.0", path = "../grovedb-query" }
+grovedb-version = { version = "6.0.0", path = "../grovedb-version" }
+grovedb-storage = { version = "6.0.0", path = "../storage", optional = true }

--- a/grovedb-element/Cargo.toml
+++ b/grovedb-element/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "grovedb-element"
 description = "The storage element crate for grovedb"
-version = "5.0.1"
+version = "6.0.0"
 authors = ["Samuel Westrich <sam@dash.org>"]
 edition = "2024"
 license = "MIT"
@@ -17,10 +17,10 @@ serde = { workspace = true, optional = true }
 hex = { workspace = true }
 integer-encoding = { workspace = true }
 thiserror = { workspace = true }
-grovedb-version = { version = "5.0.1", path = "../grovedb-version" }
-grovedb-visualize = { version = "5.0.1", path = "../visualize", optional = true }
-grovedb-path = { version = "5.0.1", path = "../path" }
-grovedb-query = { version = "5.0.1", path = "../grovedb-query" }
+grovedb-version = { version = "6.0.0", path = "../grovedb-version" }
+grovedb-visualize = { version = "6.0.0", path = "../visualize", optional = true }
+grovedb-path = { version = "6.0.0", path = "../path" }
+grovedb-query = { version = "6.0.0", path = "../grovedb-query" }
 
 [features]
 default = ["verify", "constructor"]

--- a/grovedb-epoch-based-storage-flags/Cargo.toml
+++ b/grovedb-epoch-based-storage-flags/Cargo.toml
@@ -2,13 +2,13 @@
 name = "grovedb-epoch-based-storage-flags"
 authors = ["Samuel Westrich <sam@dash.org>"]
 description = "Epoch based storage flags for GroveDB"
-version = "5.0.1"
+version = "6.0.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/dashpay/grovedb"
 
 [dependencies]
-grovedb-costs = { version = "5.0.1", path = "../costs" }
+grovedb-costs = { version = "6.0.0", path = "../costs" }
 
 hex = { workspace = true }
 integer-encoding = { workspace = true }

--- a/grovedb-merkle-mountain-range/Cargo.toml
+++ b/grovedb-merkle-mountain-range/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grovedb-merkle-mountain-range"
-version = "5.0.1"
+version = "6.0.0"
 authors = [
     "Samuel Westrich <sam@dash.org>",
     "Nervos Core Dev <dev@nervos.org>",
@@ -20,9 +20,9 @@ mem_store = []
 [dependencies]
 blake3 = { workspace = true }
 bincode = { workspace = true, features = ["derive"] }
-grovedb-costs = { version = "5.0.1", path = "../costs" }
-grovedb-storage = { version = "5.0.1", path = "../storage", optional = true }
-grovedb-version = { version = "5.0.1", path = "../grovedb-version" }
+grovedb-costs = { version = "6.0.0", path = "../costs" }
+grovedb-storage = { version = "6.0.0", path = "../storage", optional = true }
+grovedb-version = { version = "6.0.0", path = "../grovedb-version" }
 integer-encoding = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/grovedb-private-document-store/Cargo.toml
+++ b/grovedb-private-document-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grovedb-private-document-store"
-version = "5.0.1"
+version = "6.0.0"
 authors = ["Samuel Westrich <sam@dash.org>"]
 edition = "2024"
 license = "MIT"
@@ -15,14 +15,14 @@ default = ["storage"]
 storage = ["grovedb-storage", "grovedb-bulk-append-tree/storage"]
 
 [dependencies]
-grovedb-bulk-append-tree = { version = "5.0.1", path = "../grovedb-bulk-append-tree", default-features = false }
-grovedb-costs = { version = "5.0.1", path = "../costs" }
-grovedb-version = { version = "5.0.1", path = "../grovedb-version" }
-grovedb-storage = { version = "5.0.1", path = "../storage", optional = true }
+grovedb-bulk-append-tree = { version = "6.0.0", path = "../grovedb-bulk-append-tree", default-features = false }
+grovedb-costs = { version = "6.0.0", path = "../costs" }
+grovedb-version = { version = "6.0.0", path = "../grovedb-version" }
+grovedb-storage = { version = "6.0.0", path = "../storage", optional = true }
 blake3 = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
 # Reuses the in-memory StorageContext harness rather than copying it; see the
 # `test-utils` feature on grovedb-bulk-append-tree.
-grovedb-bulk-append-tree = { version = "5.0.1", path = "../grovedb-bulk-append-tree", features = ["test-utils"] }
+grovedb-bulk-append-tree = { version = "6.0.0", path = "../grovedb-bulk-append-tree", features = ["test-utils"] }

--- a/grovedb-query/Cargo.toml
+++ b/grovedb-query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grovedb-query"
-version = "5.0.1"
+version = "6.0.0"
 edition = "2024"
 license = "MIT"
 description = "Query primitives for GroveDB"
@@ -19,8 +19,8 @@ byteorder = { workspace = true }
 integer-encoding = { workspace = true }
 
 # Feature-gated deps for merk integration
-grovedb-costs = { version = "5.0.1", path = "../costs", optional = true }
-grovedb-storage = { version = "5.0.1", path = "../storage", optional = true }
+grovedb-costs = { version = "6.0.0", path = "../costs", optional = true }
+grovedb-storage = { version = "6.0.0", path = "../storage", optional = true }
 
 
 

--- a/grovedb-version/Cargo.toml
+++ b/grovedb-version/Cargo.toml
@@ -2,7 +2,7 @@
 name = "grovedb-version"
 authors = ["Samuel Westrich <sam@dash.org>"]
 description = "Versioning library for Platform"
-version = "5.0.1"
+version = "6.0.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/dashpay/grovedb"

--- a/grovedb/Cargo.toml
+++ b/grovedb/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "grovedb"
 description = "Fully featured database using balanced hierarchical authenticated data structures"
-version = "5.0.1"
+version = "6.0.0"
 authors = [
     "Samuel Westrich <sam@dash.org>",
     "Wisdom Ogwu <wisdom@dash.org>",
@@ -15,20 +15,20 @@ readme = "../README.md"
 documentation = "https://docs.rs/grovedb"
 
 [dependencies]
-grovedb-costs = { version = "5.0.1", path = "../costs", optional = true }
-grovedbg-types = { version = "5.0.1", path = "../grovedbg-types", optional = true }
-grovedb-merk = { version = "5.0.1", path = "../merk", optional = true, default-features = false }
-grovedb-path = { version = "5.0.1", path = "../path" }
-grovedb-storage = { version = "5.0.1", path = "../storage", optional = true }
-grovedb-version = { version = "5.0.1", path = "../grovedb-version" }
-grovedb-visualize = { version = "5.0.1", path = "../visualize", optional = true }
-grovedb-element = { version = "5.0.1", path = "../grovedb-element" }
-grovedb-commitment-tree = { version = "5.0.1", path = "../grovedb-commitment-tree", optional = true }
-grovedb-merkle-mountain-range = { version = "5.0.1", path = "../grovedb-merkle-mountain-range", optional = true, default-features = false }
-grovedb-bulk-append-tree = { version = "5.0.1", path = "../grovedb-bulk-append-tree", optional = true, default-features = false }
-grovedb-private-document-store = { version = "5.0.1", path = "../grovedb-private-document-store", optional = true, default-features = false }
-grovedb-dense-fixed-sized-merkle-tree = { version = "5.0.1", path = "../grovedb-dense-fixed-sized-merkle-tree", optional = true, default-features = false }
-grovedb-query = { version = "5.0.1", path = "../grovedb-query" }
+grovedb-costs = { version = "6.0.0", path = "../costs", optional = true }
+grovedbg-types = { version = "6.0.0", path = "../grovedbg-types", optional = true }
+grovedb-merk = { version = "6.0.0", path = "../merk", optional = true, default-features = false }
+grovedb-path = { version = "6.0.0", path = "../path" }
+grovedb-storage = { version = "6.0.0", path = "../storage", optional = true }
+grovedb-version = { version = "6.0.0", path = "../grovedb-version" }
+grovedb-visualize = { version = "6.0.0", path = "../visualize", optional = true }
+grovedb-element = { version = "6.0.0", path = "../grovedb-element" }
+grovedb-commitment-tree = { version = "6.0.0", path = "../grovedb-commitment-tree", optional = true }
+grovedb-merkle-mountain-range = { version = "6.0.0", path = "../grovedb-merkle-mountain-range", optional = true, default-features = false }
+grovedb-bulk-append-tree = { version = "6.0.0", path = "../grovedb-bulk-append-tree", optional = true, default-features = false }
+grovedb-private-document-store = { version = "6.0.0", path = "../grovedb-private-document-store", optional = true, default-features = false }
+grovedb-dense-fixed-sized-merkle-tree = { version = "6.0.0", path = "../grovedb-dense-fixed-sized-merkle-tree", optional = true, default-features = false }
+grovedb-query = { version = "6.0.0", path = "../grovedb-query" }
 
 axum = { workspace = true, optional = true }
 bincode = { workspace = true }
@@ -51,7 +51,7 @@ zip-extensions = { version = "0.13.0", optional = true }
 serde = { workspace = true, optional = true }
 
 [dev-dependencies]
-grovedb-epoch-based-storage-flags = { version = "5.0.1", path = "../grovedb-epoch-based-storage-flags" }
+grovedb-epoch-based-storage-flags = { version = "6.0.0", path = "../grovedb-epoch-based-storage-flags" }
 
 criterion = { workspace = true }
 hex = { workspace = true }

--- a/grovedbg-types/Cargo.toml
+++ b/grovedbg-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grovedbg-types"
-version = "5.0.1"
+version = "6.0.0"
 edition = "2024"
 description = "Common type definitions for data exchange over GroveDBG protocol"
 authors = ["Evgeny Fomin <evgeny.fomin@dash.org>"]

--- a/merk/Cargo.toml
+++ b/merk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "grovedb-merk"
 description = "Merkle key/value store adapted for GroveDB"
-version = "5.0.1"
+version = "6.0.0"
 authors = [
         "Samuel Westrich <sam@dash.org>",
         "Wisdom Ogwu <wisdom@dash.org>",
@@ -16,13 +16,13 @@ readme = "README.md"
 documentation = "https://docs.rs/grovedb-merk"
 
 [dependencies]
-grovedb-costs = { version = "5.0.1", path = "../costs" }
-grovedb-path = { version = "5.0.1", path = "../path" }
-grovedb-storage = { version = "5.0.1", path = "../storage", optional = true }
-grovedb-version = { version = "5.0.1", path = "../grovedb-version" }
-grovedb-visualize = { version = "5.0.1", path = "../visualize" }
-grovedb-element = { version = "5.0.1", path = "../grovedb-element" }
-grovedb-query = { version = "5.0.1", path = "../grovedb-query" }
+grovedb-costs = { version = "6.0.0", path = "../costs" }
+grovedb-path = { version = "6.0.0", path = "../path" }
+grovedb-storage = { version = "6.0.0", path = "../storage", optional = true }
+grovedb-version = { version = "6.0.0", path = "../grovedb-version" }
+grovedb-visualize = { version = "6.0.0", path = "../visualize" }
+grovedb-element = { version = "6.0.0", path = "../grovedb-element" }
+grovedb-query = { version = "6.0.0", path = "../grovedb-query" }
 
 bincode = { workspace = true }
 bincode_derive = { workspace = true }

--- a/path/Cargo.toml
+++ b/path/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grovedb-path"
-version = "5.0.1"
+version = "6.0.0"
 edition = "2024"
 license = "MIT"
 description = "Path extension crate for GroveDB"

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grovedb-storage"
-version = "5.0.1"
+version = "6.0.0"
 edition = "2024"
 license = "MIT"
 description = "Storage extension crate for GroveDB"
@@ -9,9 +9,9 @@ documentation = "https://docs.rs/grovedb-storage"
 repository = "https://github.com/dashpay/grovedb"
 
 [dependencies]
-grovedb-costs = { version = "5.0.1", path = "../costs" }
-grovedb-path = { version = "5.0.1", path = "../path" }
-grovedb-visualize = { version = "5.0.1", path = "../visualize" }
+grovedb-costs = { version = "6.0.0", path = "../costs" }
+grovedb-path = { version = "6.0.0", path = "../path" }
+grovedb-visualize = { version = "6.0.0", path = "../visualize" }
 
 blake3 = { workspace = true, optional = true }
 hex = { workspace = true }

--- a/visualize/Cargo.toml
+++ b/visualize/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grovedb-visualize"
-version = "5.0.1"
+version = "6.0.0"
 edition = "2024"
 license = "MIT"
 description = "Debug prints extension crate for GroveDB"


### PR DESCRIPTION
## Issue being fixed or feature implemented

Prepare GroveDB 6.0.0 for the public API changes merged since 5.0.1. Give the bincode fork's new public untrusted decoding APIs a minor release, 2.1.0.

## What was done?

- Bump all 16 GroveDB workspace crates from 5.0.1 to 6.0.0 and update their internal dependency requirements.
- Bump grovedb-bincode and grovedb-bincode-derive from 2.0.2 to 2.1.0, including workspace aliases and the runtime's exact derive dependency.
- Update the README dependency example, both fork integration guides, and the changelog. Retain upstream bincode 2.0.1 provenance and compatibility-test dependencies.

## How Has This Been Tested?

- `cargo metadata --all-features --format-version 1` resolves the full workspace.
- Compared metadata before and after: all 18 package versions and 69 versioned internal dependency declarations match the intended release versions; external requirements, features, and build targets are unchanged.
- `cargo check -p grovedb-bincode -p grovedb-bincode-derive --all-features --offline` passed.
- Repository commit hooks, including TOML validation and typo checks, passed; `git diff --check` passed.

Cargo.lock remains ignored under repository policy. Runtime tests were not rerun locally because this PR changes only manifests and documentation.

## Breaking Changes

The 6.0.0 package version marks the already-merged GroveDB API changes. This PR adds no runtime behavior changes and does not alter GroveVersion compatibility settings or serialized formats. The bincode fork keeps its independent 2.1.0 version.

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

Code comments and new runtime tests are not applicable to this version-only change.

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
