### PR TITLE
ci(release): publish every workspace crate in dependency order, idempotently

### DIFF
--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -12,6 +12,11 @@ concurrency:
   group: release-crates
   cancel-in-progress: false
 
+# Publishing uses the crates.io token, not GITHUB_TOKEN; the job only reads
+# the checkout.
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -28,9 +33,14 @@ jobs:
 
       - name: Check that the release tag matches the workspace version
         if: github.event_name == 'release'
+        # The tag reaches the shell through the environment, never through
+        # template expansion into the script, so a crafted tag cannot inject
+        # commands into the release job.
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           set -euo pipefail
-          tag="${{ github.event.release.tag_name }}"
+          tag="$RELEASE_TAG"
           version="$(cargo metadata --format-version 1 --no-deps \
             | jq -r '.packages[] | select(.name == "grovedb") | .version')"
           if [ "$tag" != "v$version" ]; then

--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -6,6 +6,15 @@ on:
     types:
       - published
 
+# Publishing is not re-entrant: two runs racing on the same versions would
+# both try to upload. Queue instead.
+concurrency:
+  group: release-crates
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+
 jobs:
   publish:
     name: Publish to crates.io
@@ -17,18 +26,98 @@ jobs:
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Login to crates.io
-        run: cargo login ${{ secrets.CARGO_GROVE_TOKEN }}
+      - name: Check that the release tag matches the workspace version
+        if: github.event_name == 'release'
+        run: |
+          set -euo pipefail
+          tag="${{ github.event.release.tag_name }}"
+          version="$(cargo metadata --format-version 1 --no-deps \
+            | jq -r '.packages[] | select(.name == "grovedb") | .version')"
+          if [ "$tag" != "v$version" ]; then
+            echo "::error::release tag $tag does not match the grovedb crate version $version"
+            exit 1
+          fi
+          echo "release $tag matches grovedb $version"
 
       - name: Publish crates
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_GROVE_TOKEN }}
         run: |
-          # Publish all workspace crates
-          cargo publish -p grovedb-version
-          cargo publish -p grovedb-costs
-          cargo publish -p grovedb-visualize
-          cargo publish -p grovedb-path
-          cargo publish -p grovedb-storage
-          cargo publish -p grovedb-epoch-based-storage-flags
-          cargo publish -p grovedbg-types
-          cargo publish -p grovedb-merk
-          cargo publish -p grovedb
+          set -euo pipefail
+
+          # Every crate is listed after the workspace crates it depends on
+          # (see `cargo metadata`). cargo waits for each upload to reach the
+          # index before the next publish resolves it, so no sleeps are needed.
+          #
+          # A version that is already on crates.io is skipped, which makes a
+          # re-run after a partial failure pick up where the last run stopped.
+          crates=(
+            grovedb-costs
+            grovedb-path
+            grovedb-visualize
+            grovedb-version
+            grovedbg-types
+            grovedb-bincode-derive
+            grovedb-bincode
+            grovedb-storage
+            grovedb-epoch-based-storage-flags
+            grovedb-query
+            grovedb-element
+            grovedb-merkle-mountain-range
+            grovedb-dense-fixed-sized-merkle-tree
+            grovedb-bulk-append-tree
+            grovedb-private-document-store
+            grovedb-merk
+            # grovedb-commitment-tree depends on the dashpay orchard fork by
+            # git tag with no version, which crates.io rejects, and grovedb
+            # depends on grovedb-commitment-tree. Both stay last so everything
+            # else publishes; they succeed once orchard is a registry crate.
+            grovedb-commitment-tree
+            grovedb
+          )
+
+          metadata="$(cargo metadata --format-version 1 --no-deps)"
+          published=()
+          skipped=()
+
+          for i in "${!crates[@]}"; do
+            crate="${crates[$i]}"
+            version="$(jq -r --arg name "$crate" \
+              '.packages[] | select(.name == $name) | .version' <<<"$metadata")"
+            if [ -z "$version" ]; then
+              echo "::error::$crate is not a workspace member"
+              exit 1
+            fi
+
+            http_status="$(curl -sS -o /dev/null -w '%{http_code}' \
+              -A 'grovedb release workflow (https://github.com/dashpay/grovedb)' \
+              "https://crates.io/api/v1/crates/$crate/$version")"
+            case "$http_status" in
+              200)
+                echo "skip $crate $version: already on crates.io"
+                skipped+=("$crate@$version")
+                continue
+                ;;
+              404) ;;
+              *)
+                echo "::error::crates.io returned HTTP $http_status for $crate $version"
+                exit 1
+                ;;
+            esac
+
+            echo "::group::publish $crate $version"
+            if ! cargo publish -p "$crate"; then
+              echo "::endgroup::"
+              remaining=("${crates[@]:$((i + 1))}")
+              echo "::error::publishing $crate $version failed"
+              echo "published this run: ${published[*]:-none}"
+              echo "already on crates.io: ${skipped[*]:-none}"
+              echo "not attempted: ${remaining[*]:-none}"
+              exit 1
+            fi
+            echo "::endgroup::"
+            published+=("$crate@$version")
+          done
+
+          echo "published this run: ${published[*]:-none}"
+          echo "already on crates.io: ${skipped[*]:-none}"


### PR DESCRIPTION
## Issue being fixed or feature implemented
The `Release Crates` workflow has failed on every release since v4.0.0. Its publish list predates the workspace split: it never included `grovedb-bincode`, `grovedb-bincode-derive`, `grovedb-query`, `grovedb-element`, or the append-family crates, and it is not ordered by dependencies. The v6.0.0 run published seven crates and then failed at `grovedb-merk` with `no matching package named grovedb-bincode found`. Earlier runs died sooner on the rocksdb git pin in `grovedb-storage`, which #939 removed.

The four crates that blocked merk were published by hand from the v6.0.0 tree today, so crates.io currently holds eleven of the eighteen workspace crates at their 6.0.0 / 2.1.0 versions.

## What was done?
- List all eighteen workspace crates in `cargo metadata` dependency order. cargo waits for each upload to reach the index before the next publish resolves it, so no sleeps are needed.
- Skip any `crate@version` that crates.io already serves (checked through the crates.io API), so a re-run resumes after a partial failure instead of failing on the first already-published crate. Against live crates.io today this skips the eleven published crates and attempts the remaining seven.
- On a failed publish, print what this run published, what was already present, and what was not attempted, then fail.
- Pass the token through `CARGO_REGISTRY_TOKEN` instead of `cargo login`, so it is never written to disk on the runner.
- Queue concurrent runs with a `concurrency` group rather than racing two uploads.
- For `release` events, refuse to publish when the tag does not equal `v` plus the `grovedb` crate version.
- Keep `grovedb-commitment-tree` and `grovedb` last with a comment explaining why they still fail: commitment-tree depends on the dashpay `orchard` fork by git tag with no version, which crates.io rejects, and `grovedb` depends on commitment-tree. Everything before them now publishes; those two succeed once orchard is a registry dependency.

## How Has This Been Tested?
- The workflow parses as YAML and the publish script passes `bash -n`.
- The skip check was run locally under bash against live crates.io for all eighteen crates: the eleven published ones return 200, the seven unpublished return 404.
- `cargo publish --dry-run` at the v6.0.0 tree passes for `grovedb-merk`, `grovedb-merkle-mountain-range`, and `grovedb-dense-fixed-sized-merkle-tree`; `grovedb-bulk-append-tree` and `grovedb-private-document-store` fail only on their not-yet-published siblings, which the ordering resolves; `grovedb-commitment-tree` fails on the orchard dependency as described.
- Not exercised end to end: a real run requires `CARGO_GROVE_TOKEN`. Triggering `workflow_dispatch` on this branch after merge would publish the five remaining publishable crates and then stop at commitment-tree.

## Breaking Changes
None. Workflow only.

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release publishing reliability by preventing overlapping runs.
  * Added validation to ensure release tags match the workspace version.
  * Publishing now processes workspace crates in order, skips versions already available, and provides clearer progress and failure details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->