### PR TITLE
build!: use published bincode 2.1.0 for Git consumers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,9 @@ thiserror = "2.0"
 hex = "0.4.3"
 integer-encoding = "4.1.0"
 blake3 = "1.8"
-bincode = { package = "grovedb-bincode", version = "=2.1.0", path = "grovedb-bincode" }
-bincode_derive = { package = "grovedb-bincode-derive", version = "=2.1.0", path = "grovedb-bincode-derive" }
+# Share codec traits with SDKs using the published crates, including Git consumers.
+bincode = { package = "grovedb-bincode", version = "=2.1.0" }
+bincode_derive = { package = "grovedb-bincode-derive", version = "=2.1.0" }
 indexmap = "2.13.0"
 serde = { version = "1.0", features = ["derive"] }
 byteorder = "1.5.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Platform and rust-dashcore are adopting the published `grovedb-bincode` and `grovedb-bincode-derive` 2.1.0 crates. GroveDB's workspace path dependencies still select repository-local copies for Git consumers, giving their types different bincode trait identities even at the same version.

Companion to [Platform #4625](https://github.com/dashpay/platform/pull/4625) and [rust-dashcore #1005](https://github.com/dashpay/rust-dashcore/pull/1005).

## What was done?
<!--- Describe your changes in detail -->

Remove the two workspace dependency `path` entries while retaining exact `=2.1.0` version requirements. Git consumers now resolve the registry codec shared with the SDKs, without requiring a downstream Cargo override. The local fork packages remain workspace members for their own development and testing.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- `cargo check --workspace --all-targets --all-features`
- `cargo test -p grovedb-element -p grovedb-query --lib --all-features`: 489 passed, one ignored.
- Confirmed the published codec's Rust source matches the previously used fork implementation. No codec or proof implementation changes.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->

Git consumers must use the registry `grovedb-bincode` 2.1.0 crate to share `Encode`/`Decode` traits with GroveDB types. Existing serialized bytes and ordinary decoding behavior are unchanged. Published GroveDB packages already resolve registry dependencies.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
