### PR TITLE
fix!: skip non-Merk descendants during recursive discovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,3 +6,8 @@
 - Never propose modifying V0 proof generation or verification.
 - Do not report unchanged V0 behavior as a finding or blocker in current pull requests.
 - Review proof changes against V1 and later unless the user explicitly requests legacy analysis.
+
+## Versioned Implementations
+
+- Never conflate V0 and V1 implementations. If an operation has two versions, give each version its own function (for example, `operation_v0` and `operation_v1`) and select between them in a version dispatcher.
+- Keep version-specific behavior out of shared implementation bodies so changes to one version cannot alter the other version's historical behavior.

--- a/grovedb-version/src/version/grovedb_versions.rs
+++ b/grovedb-version/src/version/grovedb_versions.rs
@@ -257,6 +257,13 @@ pub struct GroveDBOperationsVersions {
 /// `DenseAppendOnlyFixedSizeTree`, `PrivateDocumentStore`).
 #[derive(Clone, Debug, Default)]
 pub struct GroveDBOperationsNonMerkTreeVersions {
+    /// Recursive discovery of non-Merk descendant namespaces (issue #890).
+    ///
+    /// - `0` (V1..V3): traverse every tree as Merk storage, preserving
+    ///   historical costs for empty namespaces and errors for populated ones.
+    /// - `1` (V4+): include non-Merk descendants in cleanup without decoding
+    ///   their records as Merk nodes. They cannot contain child subtrees.
+    pub subtree_discovery: FeatureVersion,
     /// How a typed write (a direct append, or the batch
     /// `ReplaceNonMerkTreeRoot` op every batch append preprocesses into)
     /// rebuilds the parent-Merk element that anchors the tree.

--- a/grovedb-version/src/version/v1.rs
+++ b/grovedb-version/src/version/v1.rs
@@ -242,6 +242,7 @@ pub const GROVE_V1: GroveVersion = GroveVersion {
             // GROVE_V4). Preserved for replay; GROVE_V4 restores the
             // wrapper for every family.
             non_merk_tree: GroveDBOperationsNonMerkTreeVersions {
+                subtree_discovery: 0,
                 parent_element_rewrap: 0,
             },
         },

--- a/grovedb-version/src/version/v2.rs
+++ b/grovedb-version/src/version/v2.rs
@@ -242,6 +242,7 @@ pub const GROVE_V2: GroveVersion = GroveVersion {
             // GROVE_V4). Preserved for replay; GROVE_V4 restores the
             // wrapper for every family.
             non_merk_tree: GroveDBOperationsNonMerkTreeVersions {
+                subtree_discovery: 0,
                 parent_element_rewrap: 0,
             },
         },

--- a/grovedb-version/src/version/v3.rs
+++ b/grovedb-version/src/version/v3.rs
@@ -246,6 +246,7 @@ pub const GROVE_V3: GroveVersion = GroveVersion {
             // GROVE_V4). Preserved for replay; GROVE_V4 restores the
             // wrapper for every family.
             non_merk_tree: GroveDBOperationsNonMerkTreeVersions {
+                subtree_discovery: 0,
                 parent_element_rewrap: 0,
             },
         },

--- a/grovedb-version/src/version/v4.rs
+++ b/grovedb-version/src/version/v4.rs
@@ -265,6 +265,11 @@
 //!   of the index as the whole index. Gated because (i) moves a committed
 //!   root and (ii)/(iii)/(iv) flip an accepted/rejected outcome.
 //!
+//! - `operations.non_merk_tree.subtree_discovery: 1` — recursive discovery
+//!   includes non-Merk descendants for cleanup without traversing their data
+//!   as Merk nodes (issue #890). V1..V3 preserve the historical traversal,
+//!   including its costs for empty namespaces and failures for populated ones.
+//!
 //! - `operations.non_merk_tree.parent_element_rewrap: 1` — a typed append to
 //!   a `NonCounted`-wrapped non-Merk data tree (`CommitmentTree`, `MmrTree`,
 //!   `BulkAppendTree`, `DenseAppendOnlyFixedSizeTree`) restores the wrapper
@@ -583,6 +588,7 @@ pub const GROVE_V4: GroveVersion = GroveVersion {
             // V1..V3 keep the released wrapper drop (PrivateDocumentStore
             // excepted) to preserve committed root hashes.
             non_merk_tree: GroveDBOperationsNonMerkTreeVersions {
+                subtree_discovery: 1,
                 parent_element_rewrap: 1,
             },
         },

--- a/grovedb/src/operations/auxiliary.rs
+++ b/grovedb/src/operations/auxiliary.rs
@@ -28,6 +28,8 @@
 
 //! Auxiliary operations
 
+mod find_subtrees;
+
 use grovedb_costs::{
     cost_return_on_error, storage_cost::key_value_cost::KeyValueStorageCost, CostResult, CostsExt,
     OperationCost,
@@ -35,12 +37,9 @@ use grovedb_costs::{
 use grovedb_element::indexed::IndexAxis;
 use grovedb_path::SubtreePath;
 use grovedb_storage::{rocksdb_storage::RocksDbStorage, Storage, StorageBatch, StorageContext};
-use grovedb_version::{check_grovedb_v0_or_v1_with_cost, version::GroveVersion};
+use grovedb_version::version::GroveVersion;
 
-use crate::{
-    element::elements_iterator::ElementIteratorExtensions, util::TxRef, Element, Error, GroveDb,
-    Transaction, TransactionArg,
-};
+use crate::{util::TxRef, Error, GroveDb, Transaction, TransactionArg};
 
 impl GroveDb {
     /// Put op for aux storage
@@ -128,87 +127,6 @@ impl GroveDb {
             .get_aux(key.as_ref())
             .map_err(|e| e.into())
             .add_cost(cost)
-    }
-
-    // TODO: dumb traversal should not be tolerated
-    /// Finds subtree namespaces recursively, including the starting Merk
-    /// namespace at `path`. Returned paths are absolute.
-    ///
-    /// On V4+, non-Merk descendants are included for cleanup but are not
-    /// traversed: their data records are not Merk nodes and they cannot
-    /// contain child subtrees. V1..V3 retain the historical traversal and
-    /// its costs and errors for replay compatibility.
-    ///
-    /// # Storage batch visibility
-    ///
-    /// This method reads directly from the transaction (passing `None` for
-    /// the storage batch parameter), so it only sees data that has been
-    /// **committed** to the transaction. Any writes staged in a pending
-    /// `StorageBatch` (e.g., from `apply_body` during batch processing)
-    /// are invisible.
-    ///
-    /// In practice this is safe because the batch consistency check
-    /// ([`crate::batch::QualifiedGroveDbOp::verify_consistency_of_operations`])
-    /// rejects batches that insert subtrees under paths being deleted.
-    /// The stale-state window only matters if the consistency check is
-    /// bypassed via
-    /// [`BatchApplyOptions::disable_operation_consistency_check`](crate::batch::BatchApplyOptions::disable_operation_consistency_check).
-    pub fn find_subtrees<B: AsRef<[u8]>>(
-        &self,
-        path: &SubtreePath<B>,
-        transaction: TransactionArg,
-        grove_version: &GroveVersion,
-    ) -> CostResult<Vec<Vec<Vec<u8>>>, Error> {
-        let discovery_version = grove_version
-            .grovedb_versions
-            .operations
-            .non_merk_tree
-            .subtree_discovery;
-        check_grovedb_v0_or_v1_with_cost!("find_subtrees", discovery_version);
-        let mut cost = OperationCost::default();
-
-        // TODO: remove conversion to vec;
-        // However, it's not easy for a reason:
-        // new keys to enqueue are taken from raw iterator which returns Vec<u8>;
-        // changing that to slice is hard as cursor should be moved for next iteration
-        // which requires exclusive (&mut) reference, also there is no guarantee that
-        // slice which points into storage internals will remain valid if raw
-        // iterator got altered so why that reference should be exclusive;
-        //
-        // Update: there are pinned views into RocksDB to return slices of data, perhaps
-        // there is something for iterators
-
-        let mut queue: Vec<Vec<Vec<u8>>> = vec![path.to_vec()];
-        let mut result: Vec<Vec<Vec<u8>>> = queue.clone();
-
-        let tx = TxRef::new(&self.db, transaction);
-
-        while let Some(q) = queue.pop() {
-            let subtree_path: SubtreePath<Vec<u8>> = q.as_slice().into();
-            // Get the correct subtree with q_ref as path
-            let storage = self
-                .db
-                .get_transactional_storage_context(subtree_path, None, tx.as_ref())
-                .unwrap_add_cost(&mut cost);
-            let mut raw_iter = Element::iterator(storage.raw_iter()).unwrap_add_cost(&mut cost);
-            while let Some((key, value)) =
-                cost_return_on_error!(&mut cost, raw_iter.next_element(grove_version))
-            {
-                if value.is_any_tree() {
-                    let mut sub_path = q.clone();
-                    sub_path.push(key.to_vec());
-                    // Only Merk namespaces can contain more subtrees. Use
-                    // the element already decoded from the parent to classify
-                    // storage, including through element wrappers, without
-                    // adding a read or dropping the namespace from cleanup.
-                    if discovery_version == 0 || !value.uses_non_merk_data_storage() {
-                        queue.push(sub_path.clone());
-                    }
-                    result.push(sub_path);
-                }
-            }
-        }
-        Ok(result).wrap_with_cost(cost)
     }
 
     /// Recursively clear storage owned by the subtree at `path`: the

--- a/grovedb/src/operations/auxiliary.rs
+++ b/grovedb/src/operations/auxiliary.rs
@@ -35,7 +35,7 @@ use grovedb_costs::{
 use grovedb_element::indexed::IndexAxis;
 use grovedb_path::SubtreePath;
 use grovedb_storage::{rocksdb_storage::RocksDbStorage, Storage, StorageBatch, StorageContext};
-use grovedb_version::version::GroveVersion;
+use grovedb_version::{check_grovedb_v0_or_v1_with_cost, version::GroveVersion};
 
 use crate::{
     element::elements_iterator::ElementIteratorExtensions, util::TxRef, Element, Error, GroveDb,
@@ -131,9 +131,13 @@ impl GroveDb {
     }
 
     // TODO: dumb traversal should not be tolerated
-    /// Finds keys which are trees for a given subtree recursively.
-    /// One element means a key of a `merk`, n > 1 elements mean relative path
-    /// for a deeply nested subtree.
+    /// Finds subtree namespaces recursively, including the starting Merk
+    /// namespace at `path`. Returned paths are absolute.
+    ///
+    /// On V4+, non-Merk descendants are included for cleanup but are not
+    /// traversed: their data records are not Merk nodes and they cannot
+    /// contain child subtrees. V1..V3 retain the historical traversal and
+    /// its costs and errors for replay compatibility.
     ///
     /// # Storage batch visibility
     ///
@@ -155,6 +159,12 @@ impl GroveDb {
         transaction: TransactionArg,
         grove_version: &GroveVersion,
     ) -> CostResult<Vec<Vec<Vec<u8>>>, Error> {
+        let discovery_version = grove_version
+            .grovedb_versions
+            .operations
+            .non_merk_tree
+            .subtree_discovery;
+        check_grovedb_v0_or_v1_with_cost!("find_subtrees", discovery_version);
         let mut cost = OperationCost::default();
 
         // TODO: remove conversion to vec;
@@ -187,7 +197,13 @@ impl GroveDb {
                 if value.is_any_tree() {
                     let mut sub_path = q.clone();
                     sub_path.push(key.to_vec());
-                    queue.push(sub_path.clone());
+                    // Only Merk namespaces can contain more subtrees. Use
+                    // the element already decoded from the parent to classify
+                    // storage, including through element wrappers, without
+                    // adding a read or dropping the namespace from cleanup.
+                    if discovery_version == 0 || !value.uses_non_merk_data_storage() {
+                        queue.push(sub_path.clone());
+                    }
                     result.push(sub_path);
                 }
             }

--- a/grovedb/src/operations/auxiliary/find_subtrees/mod.rs
+++ b/grovedb/src/operations/auxiliary/find_subtrees/mod.rs
@@ -1,0 +1,64 @@
+//! Version dispatch for recursive subtree discovery.
+//!
+//! V0 preserves historical traversal for Grove V1..V3. V1 recognizes
+//! non-Merk descendants for Grove V4+. Keep their implementations separate
+//! so changes to current discovery cannot alter historical replay.
+
+mod v0;
+mod v1;
+
+use grovedb_costs::{CostResult, CostsExt, OperationCost};
+use grovedb_path::SubtreePath;
+use grovedb_version::version::GroveVersion;
+
+use crate::{Error, GroveDb, TransactionArg};
+
+impl GroveDb {
+    /// Finds subtree namespaces recursively, including the starting Merk
+    /// namespace at `path`. Returned paths are absolute.
+    ///
+    /// On V4+, non-Merk descendants are included for cleanup but are not
+    /// traversed: their data records are not Merk nodes and they cannot
+    /// contain child subtrees. V1..V3 retain the historical traversal and
+    /// its costs and errors for replay compatibility.
+    ///
+    /// # Storage batch visibility
+    ///
+    /// This method reads directly from the transaction (passing `None` for
+    /// the storage batch parameter), so it only sees data that has been
+    /// **committed** to the transaction. Any writes staged in a pending
+    /// `StorageBatch` (e.g., from `apply_body` during batch processing)
+    /// are invisible.
+    ///
+    /// In practice this is safe because the batch consistency check
+    /// ([`crate::batch::QualifiedGroveDbOp::verify_consistency_of_operations`])
+    /// rejects batches that insert subtrees under paths being deleted.
+    /// The stale-state window only matters if the consistency check is
+    /// bypassed via
+    /// [`BatchApplyOptions::disable_operation_consistency_check`](crate::batch::BatchApplyOptions::disable_operation_consistency_check).
+    pub fn find_subtrees<B: AsRef<[u8]>>(
+        &self,
+        path: &SubtreePath<B>,
+        transaction: TransactionArg,
+        grove_version: &GroveVersion,
+    ) -> CostResult<Vec<Vec<Vec<u8>>>, Error> {
+        match grove_version
+            .grovedb_versions
+            .operations
+            .non_merk_tree
+            .subtree_discovery
+        {
+            0 => self.find_subtrees_v0(path, transaction, grove_version),
+            1 => self.find_subtrees_v1(path, transaction, grove_version),
+            version => Err(
+                grovedb_version::error::GroveVersionError::UnknownVersionMismatch {
+                    method: "find_subtrees".to_string(),
+                    known_versions: vec![0, 1],
+                    received: version,
+                }
+                .into(),
+            )
+            .wrap_with_cost(OperationCost::default()),
+        }
+    }
+}

--- a/grovedb/src/operations/auxiliary/find_subtrees/v0.rs
+++ b/grovedb/src/operations/auxiliary/find_subtrees/v0.rs
@@ -1,0 +1,62 @@
+//! Legacy recursive discovery for Grove V1..V3.
+//!
+//! Every descendant is traversed as Merk storage. Preserve the historical
+//! traversal, costs, and non-Merk decoding errors for replay compatibility.
+
+use grovedb_costs::{cost_return_on_error, CostResult, CostsExt, OperationCost};
+use grovedb_path::SubtreePath;
+use grovedb_storage::{Storage, StorageContext};
+use grovedb_version::version::GroveVersion;
+
+use crate::{
+    element::elements_iterator::ElementIteratorExtensions, util::TxRef, Element, Error, GroveDb,
+    TransactionArg,
+};
+
+impl GroveDb {
+    pub(super) fn find_subtrees_v0<B: AsRef<[u8]>>(
+        &self,
+        path: &SubtreePath<B>,
+        transaction: TransactionArg,
+        grove_version: &GroveVersion,
+    ) -> CostResult<Vec<Vec<Vec<u8>>>, Error> {
+        let mut cost = OperationCost::default();
+
+        // TODO: remove conversion to vec;
+        // However, it's not easy for a reason:
+        // new keys to enqueue are taken from raw iterator which returns Vec<u8>;
+        // changing that to slice is hard as cursor should be moved for next iteration
+        // which requires exclusive (&mut) reference, also there is no guarantee that
+        // slice which points into storage internals will remain valid if raw
+        // iterator got altered so why that reference should be exclusive;
+        //
+        // Update: there are pinned views into RocksDB to return slices of data, perhaps
+        // there is something for iterators
+
+        let mut queue: Vec<Vec<Vec<u8>>> = vec![path.to_vec()];
+        let mut result: Vec<Vec<Vec<u8>>> = queue.clone();
+
+        let tx = TxRef::new(&self.db, transaction);
+
+        while let Some(q) = queue.pop() {
+            let subtree_path: SubtreePath<Vec<u8>> = q.as_slice().into();
+            // Get the correct subtree with q_ref as path
+            let storage = self
+                .db
+                .get_transactional_storage_context(subtree_path, None, tx.as_ref())
+                .unwrap_add_cost(&mut cost);
+            let mut raw_iter = Element::iterator(storage.raw_iter()).unwrap_add_cost(&mut cost);
+            while let Some((key, value)) =
+                cost_return_on_error!(&mut cost, raw_iter.next_element(grove_version))
+            {
+                if value.is_any_tree() {
+                    let mut sub_path = q.clone();
+                    sub_path.push(key.to_vec());
+                    queue.push(sub_path.clone());
+                    result.push(sub_path);
+                }
+            }
+        }
+        Ok(result).wrap_with_cost(cost)
+    }
+}

--- a/grovedb/src/operations/auxiliary/find_subtrees/v1.rs
+++ b/grovedb/src/operations/auxiliary/find_subtrees/v1.rs
@@ -1,0 +1,68 @@
+//! Recursive discovery for Grove V4+.
+//!
+//! Non-Merk descendants remain in the cleanup result but are never traversed:
+//! their data records are not Merk nodes and cannot contain child subtrees.
+
+use grovedb_costs::{cost_return_on_error, CostResult, CostsExt, OperationCost};
+use grovedb_path::SubtreePath;
+use grovedb_storage::{Storage, StorageContext};
+use grovedb_version::version::GroveVersion;
+
+use crate::{
+    element::elements_iterator::ElementIteratorExtensions, util::TxRef, Element, Error, GroveDb,
+    TransactionArg,
+};
+
+impl GroveDb {
+    pub(super) fn find_subtrees_v1<B: AsRef<[u8]>>(
+        &self,
+        path: &SubtreePath<B>,
+        transaction: TransactionArg,
+        grove_version: &GroveVersion,
+    ) -> CostResult<Vec<Vec<Vec<u8>>>, Error> {
+        let mut cost = OperationCost::default();
+
+        // TODO: remove conversion to vec;
+        // However, it's not easy for a reason:
+        // new keys to enqueue are taken from raw iterator which returns Vec<u8>;
+        // changing that to slice is hard as cursor should be moved for next iteration
+        // which requires exclusive (&mut) reference, also there is no guarantee that
+        // slice which points into storage internals will remain valid if raw
+        // iterator got altered so why that reference should be exclusive;
+        //
+        // Update: there are pinned views into RocksDB to return slices of data, perhaps
+        // there is something for iterators
+
+        let mut queue: Vec<Vec<Vec<u8>>> = vec![path.to_vec()];
+        let mut result: Vec<Vec<Vec<u8>>> = queue.clone();
+
+        let tx = TxRef::new(&self.db, transaction);
+
+        while let Some(q) = queue.pop() {
+            let subtree_path: SubtreePath<Vec<u8>> = q.as_slice().into();
+            // Get the correct subtree with q_ref as path
+            let storage = self
+                .db
+                .get_transactional_storage_context(subtree_path, None, tx.as_ref())
+                .unwrap_add_cost(&mut cost);
+            let mut raw_iter = Element::iterator(storage.raw_iter()).unwrap_add_cost(&mut cost);
+            while let Some((key, value)) =
+                cost_return_on_error!(&mut cost, raw_iter.next_element(grove_version))
+            {
+                if value.is_any_tree() {
+                    let mut sub_path = q.clone();
+                    sub_path.push(key.to_vec());
+                    // Only Merk namespaces can contain more subtrees. Use
+                    // the element already decoded from the parent to classify
+                    // storage, including through element wrappers, without
+                    // adding a read or dropping the namespace from cleanup.
+                    if !value.uses_non_merk_data_storage() {
+                        queue.push(sub_path.clone());
+                    }
+                    result.push(sub_path);
+                }
+            }
+        }
+        Ok(result).wrap_with_cost(cost)
+    }
+}

--- a/grovedb/src/tests/mod.rs
+++ b/grovedb/src/tests/mod.rs
@@ -35,6 +35,7 @@ mod commitment_tree_cost_bound_tests;
 mod commitment_tree_tests;
 mod coverage_round7_tests;
 mod non_merk_completeness_budget_tests;
+mod non_merk_subtree_discovery_tests;
 // Tampers with raw storage via `GroveDb::raw_storage`, which is only
 // compiled under the `unsafe-dump-load` feature.
 #[cfg(feature = "unsafe-dump-load")]

--- a/grovedb/src/tests/non_merk_subtree_discovery_tests.rs
+++ b/grovedb/src/tests/non_merk_subtree_discovery_tests.rs
@@ -1,0 +1,372 @@
+//! Issue #890: recursive discovery must include non-Merk descendants for
+//! cleanup without interpreting their records as Merk nodes.
+
+use grovedb_element::indexed::IndexAxis;
+use grovedb_merk::tree_type::TreeType;
+use grovedb_path::SubtreePath;
+use grovedb_storage::{rocksdb_storage::RocksDbStorage, RawIterator, Storage, StorageContext};
+use grovedb_version::version::{GroveVersion, GROVE_VERSIONS};
+
+use crate::{
+    batch::{QualifiedGroveDbOp, SubelementsDeletionBehavior},
+    operations::delete::DeleteOptions,
+    tests::{common::EMPTY_PATH, make_empty_grovedb, TempGroveDb},
+    Element, Error, TransactionArg,
+};
+
+#[derive(Clone, Copy, Debug)]
+enum Family {
+    Mmr,
+    Bulk,
+    Dense,
+    Commitment,
+    PrivateDocumentStore,
+}
+
+impl Family {
+    fn empty_element(self) -> Element {
+        match self {
+            Self::Mmr => Element::empty_mmr_tree(),
+            Self::Bulk => Element::empty_bulk_append_tree(2).expect("valid chunk power"),
+            Self::Dense => Element::empty_dense_tree(3),
+            Self::Commitment => Element::empty_commitment_tree(2).expect("valid chunk power"),
+            Self::PrivateDocumentStore => {
+                Element::empty_private_document_store(48, 2).expect("valid configuration")
+            }
+        }
+    }
+
+    fn populate(self, db: &TempGroveDb, gv: &GroveVersion) {
+        // Five entries exercise an MMR merge, a full dense/bulk chunk and
+        // a partially filled buffer, as well as commitment-tree metadata.
+        for i in 0..5u8 {
+            let path = &[b"outer".as_slice(), b"mid".as_slice()];
+            match self {
+                Self::Mmr => {
+                    db.mmr_tree_append(path, b"payload", vec![i], None, gv)
+                        .unwrap()
+                        .expect("MMR append");
+                }
+                Self::Bulk => {
+                    db.bulk_append(path, b"payload", vec![i], None, gv)
+                        .unwrap()
+                        .expect("bulk append");
+                }
+                Self::Dense => {
+                    db.dense_tree_insert(path, b"payload", vec![i], None, gv)
+                        .unwrap()
+                        .expect("dense insert");
+                }
+                Self::Commitment => {
+                    use grovedb_commitment_tree::{
+                        DashMemo, NoteBytesData, TransmittedNoteCiphertext,
+                    };
+                    let mut cmx = [0; 32];
+                    cmx[0] = i;
+                    let ciphertext = TransmittedNoteCiphertext::<DashMemo>::from_parts(
+                        [i; 32],
+                        NoteBytesData([i; 104]),
+                        [i; 80],
+                    );
+                    db.commitment_tree_insert(
+                        path, b"payload", cmx, [i; 32], [i; 32], ciphertext, None, gv,
+                    )
+                    .unwrap()
+                    .expect("commitment insert");
+                }
+                Self::PrivateDocumentStore => {
+                    db.private_document_store_insert(path, b"payload", vec![i; 48], None, gv)
+                        .unwrap()
+                        .expect("private document insert");
+                }
+            }
+        }
+    }
+}
+
+fn namespace_non_empty(db: &TempGroveDb, prefix: [u8; 32], tx: TransactionArg) -> bool {
+    let local_tx = db.start_transaction();
+    let storage = db
+        .db
+        .get_transactional_storage_context_by_subtree_prefix(prefix, None, tx.unwrap_or(&local_tx))
+        .unwrap();
+    let mut iter = storage.raw_iter();
+    iter.seek_to_first().unwrap();
+    iter.valid().unwrap()
+}
+
+fn prefix(path: &[&[u8]]) -> [u8; 32] {
+    RocksDbStorage::build_prefix(SubtreePath::from(path)).unwrap()
+}
+
+#[derive(Clone, Copy, Debug)]
+enum DeleteRoute {
+    Direct,
+    FullBatch,
+    PartialBatch,
+}
+
+fn assert_discovery_and_cleanup(family: Family, wrapped: bool) {
+    let gv = GroveVersion::latest();
+    for populated in [false, true] {
+        for route in [
+            DeleteRoute::Direct,
+            DeleteRoute::FullBatch,
+            DeleteRoute::PartialBatch,
+        ] {
+            let db = make_empty_grovedb();
+            db.insert(
+                EMPTY_PATH,
+                b"survivor",
+                Element::empty_tree(),
+                None,
+                None,
+                gv,
+            )
+            .unwrap()
+            .expect("insert sibling outside deleted subtree");
+            db.insert(
+                &[b"survivor".as_slice()],
+                b"item",
+                Element::new_item(vec![42]),
+                None,
+                None,
+                gv,
+            )
+            .unwrap()
+            .expect("populate survivor");
+            let expected_root = db.root_hash(None, gv).unwrap().expect("survivor root");
+
+            let mut axes: Vec<_> = [IndexAxis::Count, IndexAxis::Sum, IndexAxis::Avg]
+                .into_iter()
+                .map(|axis| (axis.tag(), None))
+                .collect();
+            axes.sort_by_key(|(tag, _)| *tag);
+            for (path, key, element) in [
+                (&[] as &[&[u8]], b"outer".as_slice(), Element::empty_tree()),
+                (
+                    &[b"outer".as_slice()],
+                    b"mid".as_slice(),
+                    Element::empty_count_tree(),
+                ),
+                (
+                    &[b"outer".as_slice()],
+                    b"ordinary".as_slice(),
+                    Element::empty_tree(),
+                ),
+                (
+                    &[b"outer".as_slice()],
+                    b"indexed".as_slice(),
+                    Element::empty_provable_count_provable_sum_indexed_tree(axes)
+                        .expect("valid axes"),
+                ),
+            ] {
+                db.insert(path, key, element, None, None, gv)
+                    .unwrap()
+                    .expect("insert Merk tree");
+            }
+            let element = family.empty_element();
+            let element = if wrapped {
+                Element::new_non_counted(element).expect("valid wrapper")
+            } else {
+                element
+            };
+            db.insert(
+                &[b"outer".as_slice(), b"mid".as_slice()],
+                b"payload",
+                element,
+                None,
+                None,
+                gv,
+            )
+            .unwrap()
+            .expect("insert non-Merk tree");
+            db.insert(
+                &[b"outer".as_slice(), b"ordinary".as_slice()],
+                b"item",
+                Element::new_item(vec![7]),
+                None,
+                None,
+                gv,
+            )
+            .unwrap()
+            .expect("populate ordinary sibling");
+            db.insert_into_provable_count_provable_sum_indexed_tree(
+                &[b"outer".as_slice(), b"indexed".as_slice()],
+                b"item",
+                Element::new_item_with_sum_item(vec![8], 8),
+                None,
+                gv,
+            )
+            .unwrap()
+            .expect("populate all indexed axes");
+            if populated {
+                family.populate(&db, gv);
+            }
+
+            let paths: Vec<Vec<Vec<u8>>> = [
+                vec![b"outer".as_slice()],
+                vec![b"outer", b"indexed"],
+                vec![b"outer", b"mid"],
+                vec![b"outer", b"mid", b"payload"],
+                vec![b"outer", b"ordinary"],
+            ]
+            .into_iter()
+            .map(|path| path.into_iter().map(<[u8]>::to_vec).collect())
+            .collect();
+            let mut discovered = db
+                .find_subtrees(&[b"outer".as_slice()].as_slice().into(), None, gv)
+                .unwrap()
+                .expect("discover mixed storage families");
+            discovered.sort();
+            assert_eq!(discovered, paths, "{family:?}, populated={populated}");
+
+            let primary_prefixes: Vec<_> = paths
+                .iter()
+                .map(|path| {
+                    RocksDbStorage::build_prefix(SubtreePath::from(path.as_slice())).unwrap()
+                })
+                .collect();
+            let payload_prefix = prefix(&[b"outer", b"mid", b"payload"]);
+            assert_eq!(namespace_non_empty(&db, payload_prefix, None), populated);
+            let indexed_prefix = prefix(&[b"outer", b"indexed"]);
+            let secondary_prefixes: Vec<_> = [IndexAxis::Count, IndexAxis::Sum, IndexAxis::Avg]
+                .into_iter()
+                .map(|axis| {
+                    RocksDbStorage::secondary_prefix_for(&indexed_prefix, axis.tag()).unwrap()
+                })
+                .collect();
+            for &secondary in &secondary_prefixes {
+                assert!(
+                    namespace_non_empty(&db, secondary, None),
+                    "axis must be populated before cleanup"
+                );
+            }
+
+            let tx = db.start_transaction();
+            let ops = vec![QualifiedGroveDbOp::delete_tree_op(
+                vec![],
+                b"outer".to_vec(),
+                TreeType::NormalTree,
+                SubelementsDeletionBehavior::DeleteChildren,
+            )];
+            match route {
+                DeleteRoute::Direct => db.delete(
+                    EMPTY_PATH,
+                    b"outer",
+                    Some(DeleteOptions {
+                        allow_deleting_non_empty_trees: true,
+                        deleting_non_empty_trees_returns_error: false,
+                        ..Default::default()
+                    }),
+                    Some(&tx),
+                    gv,
+                ),
+                DeleteRoute::FullBatch => db.apply_batch(ops, None, Some(&tx), gv),
+                DeleteRoute::PartialBatch => {
+                    db.apply_partial_batch(ops, None, |_, _| Ok(vec![]), Some(&tx), gv)
+                }
+            }
+            .unwrap()
+            .expect("delete ancestor of non-Merk tree");
+
+            for &owned_prefix in primary_prefixes.iter().chain(&secondary_prefixes) {
+                assert!(
+                    !namespace_non_empty(&db, owned_prefix, Some(&tx)),
+                    "{family:?} {route:?}: owned namespace survived"
+                );
+            }
+            assert!(
+                namespace_non_empty(&db, prefix(&[b"outer"]), None),
+                "deletion must remain transaction-local"
+            );
+            db.commit_transaction(tx).unwrap().expect("commit deletion");
+            for &owned_prefix in primary_prefixes.iter().chain(&secondary_prefixes) {
+                assert!(
+                    !namespace_non_empty(&db, owned_prefix, None),
+                    "committed cleanup must persist"
+                );
+            }
+            assert_eq!(
+                db.root_hash(None, gv).unwrap().expect("root after delete"),
+                expected_root
+            );
+            assert_eq!(
+                db.get(&[b"survivor".as_slice()], b"item", None, gv)
+                    .unwrap()
+                    .expect("retained item"),
+                Element::new_item(vec![42])
+            );
+        }
+    }
+}
+
+#[test]
+fn discovers_and_deletes_nested_mmr() {
+    assert_discovery_and_cleanup(Family::Mmr, false);
+}
+
+#[test]
+fn discovers_and_deletes_nested_bulk() {
+    assert_discovery_and_cleanup(Family::Bulk, false);
+}
+
+#[test]
+fn discovers_and_deletes_nested_dense() {
+    assert_discovery_and_cleanup(Family::Dense, false);
+}
+
+#[test]
+fn discovers_and_deletes_nested_commitment() {
+    assert_discovery_and_cleanup(Family::Commitment, false);
+}
+
+#[test]
+fn discovers_and_deletes_nested_private_document_store() {
+    assert_discovery_and_cleanup(Family::PrivateDocumentStore, false);
+}
+
+#[test]
+fn discovers_and_deletes_wrapped_non_merk_descendant() {
+    assert_discovery_and_cleanup(Family::Mmr, true);
+}
+
+#[test]
+fn legacy_versions_preserve_populated_mmr_discovery_failure() {
+    for gv in GROVE_VERSIONS.iter().filter(|gv| gv.protocol_version <= 3) {
+        let db = make_empty_grovedb();
+        db.insert(EMPTY_PATH, b"outer", Element::empty_tree(), None, None, gv)
+            .unwrap()
+            .expect("insert outer");
+        db.insert(
+            &[b"outer".as_slice()],
+            b"mmr",
+            Element::empty_mmr_tree(),
+            None,
+            None,
+            gv,
+        )
+        .unwrap()
+        .expect("insert MMR");
+        db.mmr_tree_append(&[b"outer".as_slice()], b"mmr", vec![1], None, gv)
+            .unwrap()
+            .expect("append MMR");
+        assert!(db
+            .find_subtrees(&[b"outer".as_slice()].as_slice().into(), None, gv)
+            .unwrap()
+            .is_err());
+    }
+}
+
+#[test]
+fn unknown_discovery_version_fails_closed() {
+    let db = make_empty_grovedb();
+    let mut gv = GroveVersion::latest().clone();
+    gv.grovedb_versions
+        .operations
+        .non_merk_tree
+        .subtree_discovery = 2;
+    let result = db.find_subtrees(&EMPTY_PATH, None, &gv);
+    assert!(matches!(result.value, Err(Error::VersionError(_))));
+    assert_eq!(result.cost, Default::default());
+}


### PR DESCRIPTION
## Issue being fixed or feature implemented

Closes #890. Recursive discovery tries to decode populated non-Merk descendants as Merk nodes, preventing discovery and deletion of an otherwise healthy ancestor tree. Reproduced independently for MMR, bulk append, dense, commitment, and private document storage, plus a wrapped MMR.

## What was done?

Use separate `find_subtrees_v0` and `find_subtrees_v1` functions in version-specific modules, selected by a dispatcher. V0 preserves the original implementation. V1 classifies descendants using their already-decoded elements, keeping every tree namespace in the cleanup result but only enqueueing Merk-backed descendants for traversal. The shared cleanup still clears non-Merk payloads and all indexed-axis namespaces.

Enable the fix through `operations.non_merk_tree.subtree_discovery` on Grove V4. V1–V3 retain historical traversal, costs, and failures. No additional storage reads are needed.

## How Has This Been Tested?

- Confirmed six regression tests fail on the unmodified implementation with Merk decoding errors.
- New tests cover all five families, empty and populated descendants, a `NonCounted` wrapper, direct/full-batch/partial-batch deletion, transaction visibility, persisted namespace cleanup, all three indexed axes, retained sibling data, and legacy/unknown version behavior.
- Initial fix: `cargo test -p grovedb -p grovedb-version --lib --offline`: 3,506 passed, eight existing ignored tests. Includes existing versioned deletion-cost regressions.
- After extracting separate V0/V1 functions: 95 subtree tests and 10 indexed-secondary cleanup tests passed. Source comparisons confirm the V0 body matches the original implementation and the V1 body retains the fix without the shared version branch.
- `cargo fmt -p grovedb -p grovedb-version --check` and `git diff --check` passed.
- `cargo clippy -p grovedb -p grovedb-version --lib --tests --no-deps --offline -- -D warnings` passed.

## Breaking Changes

Adds `subtree_discovery` to the public `GroveDBOperationsNonMerkTreeVersions` struct. Custom struct literals must initialize the new version slot. Grove V1–V3 behavior remains unchanged.

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Recursive subtree discovery now recognizes non-Merk descendants in protocol version 4 and later.
  - Cleanup operations remove namespaces associated with MMR, bulk, dense, commitment, and private document store trees while preserving surviving data.

- **Bug Fixes**
  - Deleting ancestors no longer misinterprets non-Merk records as Merk nodes.
  - Discovery remains compatible with legacy protocol versions and fails safely for unsupported version configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->