### PR TITLE
ci: pin the shared review engine to its merge commit

### DIFF
--- a/.github/workflows/pr-review-policy.yml
+++ b/.github/workflows/pr-review-policy.yml
@@ -17,6 +17,6 @@ permissions:
   statuses: write
 jobs:
   policy:
-    uses: dashpay/stale_prs_are_bad/.github/workflows/pr-review-reusable.yml@5ee27dc4a7d8c18de1a9d1723cc9b7b641cee90a
+    uses: dashpay/stale_prs_are_bad/.github/workflows/pr-review-reusable.yml@25b9369077ef6394ffb5491be718a6f0740e6088
     with:
-      engine_revision: 5ee27dc4a7d8c18de1a9d1723cc9b7b641cee90a
+      engine_revision: 25b9369077ef6394ffb5491be718a6f0740e6088


### PR DESCRIPTION
Follow-up to #952. The caller was pinned to the engine PR head (`5ee27dc`), which is no longer reachable from any branch after the stack was squash-merged, so every scheduled run fails with "workflow file issue" (the reusable workflow cannot be resolved). This re-pins both the reusable workflow reference and `engine_revision` to the merge commit of dashpay/stale_prs_are_bad#5, `25b9369077ef6394ffb5491be718a6f0740e6088`.

The engine at that commit also requires `engine_revision` to equal its own commit, and refuses to read policies unless `master` of the central repository is governed by the required ruleset (it is, as of today). Writes stay disabled: `PR_REVIEW_AUTOMATION_ENABLED` is not set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pull request review policy workflow to use a newer revision of its shared review process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->