### PR TITLE
ci: re-pin the shared review engine

### DIFF
--- a/.github/workflows/pr-review-policy.yml
+++ b/.github/workflows/pr-review-policy.yml
@@ -17,6 +17,6 @@ permissions:
   statuses: write
 jobs:
   policy:
-    uses: dashpay/stale_prs_are_bad/.github/workflows/pr-review-reusable.yml@25b9369077ef6394ffb5491be718a6f0740e6088
+    uses: dashpay/stale_prs_are_bad/.github/workflows/pr-review-reusable.yml@cc4d18484ceabf121886e47606b4b10628aafefa
     with:
-      engine_revision: 25b9369077ef6394ffb5491be718a6f0740e6088
+      engine_revision: cc4d18484ceabf121886e47606b4b10628aafefa


### PR DESCRIPTION
Follow-up to #954. The engine that #954 pinned rejected every caller in its preflight: `github.job_workflow_sha` is empty for a called workflow on `pull_request_target`, so its equality check could never pass. dashpay/stale_prs_are_bad#7 replaced it with a reachability check — the pinned engine must be a commit merged to the central default branch — and landed as `cc4d18484ceabf121886e47606b4b10628aafefa`. This re-pins to that commit.

Writes stay disabled: `PR_REVIEW_AUTOMATION_ENABLED` is not set, so the run only reports what it would do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pull request review workflow configuration to use a newer revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->